### PR TITLE
feat: crib prune command, remove confirmation, and test image cleanup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
           cache: true
       - uses: gotesttools/gotestfmt-action@v2
       - name: Unit tests
-        run: make test 2>&1 | gotestfmt
+        run: make test | gotestfmt
         env:
           GO_TEST_FLAGS: -json
       - name: Lint
@@ -49,12 +49,12 @@ jobs:
           podman system service -t 0 &
           sleep 2
       - name: Integration tests
-        run: make test-integration 2>&1 | gotestfmt
+        run: make test-integration | gotestfmt
         env:
           CRIB_RUNTIME: podman
           GO_TEST_FLAGS: -json
       - name: E2E tests
-        run: make test-e2e 2>&1 | gotestfmt
+        run: make test-e2e | gotestfmt
         env:
           CRIB_RUNTIME: podman
           GO_TEST_FLAGS: -json
@@ -74,12 +74,12 @@ jobs:
       - name: Verify Docker is available
         run: docker info
       - name: Integration tests
-        run: make test-integration 2>&1 | gotestfmt
+        run: make test-integration | gotestfmt
         env:
           CRIB_RUNTIME: docker
           GO_TEST_FLAGS: -json
       - name: E2E tests
-        run: make test-e2e 2>&1 | gotestfmt
+        run: make test-e2e | gotestfmt
         env:
           CRIB_RUNTIME: docker
           GO_TEST_FLAGS: -json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,13 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      - run: make test
-      - run: make lint
+      - uses: gotesttools/gotestfmt-action@v2
+      - name: Unit tests
+        run: make test 2>&1 | gotestfmt
+        env:
+          GO_TEST_FLAGS: -json
+      - name: Lint
+        run: make lint
       - name: Complexity gate (gocyclo -over 40)
         run: |
           out=$(go tool gocyclo -over 40 .)
@@ -38,14 +43,21 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+      - uses: gotesttools/gotestfmt-action@v2
       - name: Start podman daemon
         run: |
           podman system service -t 0 &
           sleep 2
-      - name: Run integration tests
-        run: CRIB_RUNTIME=podman make test-integration
-      - name: Run e2e tests
-        run: CRIB_RUNTIME=podman make test-e2e
+      - name: Integration tests
+        run: make test-integration 2>&1 | gotestfmt
+        env:
+          CRIB_RUNTIME: podman
+          GO_TEST_FLAGS: -json
+      - name: E2E tests
+        run: make test-e2e 2>&1 | gotestfmt
+        env:
+          CRIB_RUNTIME: podman
+          GO_TEST_FLAGS: -json
 
   e2e-docker:
     name: E2E tests (Docker)
@@ -58,9 +70,16 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+      - uses: gotesttools/gotestfmt-action@v2
       - name: Verify Docker is available
         run: docker info
-      - name: Run integration tests
-        run: CRIB_RUNTIME=docker make test-integration
-      - name: Run e2e tests
-        run: CRIB_RUNTIME=docker make test-e2e
+      - name: Integration tests
+        run: make test-integration 2>&1 | gotestfmt
+        env:
+          CRIB_RUNTIME: docker
+          GO_TEST_FLAGS: -json
+      - name: E2E tests
+        run: make test-e2e 2>&1 | gotestfmt
+        env:
+          CRIB_RUNTIME: docker
+          GO_TEST_FLAGS: -json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `crib prune` command removes stale and orphan workspace images. Shows a dry-run
+  preview with sizes before prompting for confirmation. `--all` includes orphan
+  images from workspaces that no longer exist. `--force` / `-f` skips the prompt.
+- `crib remove` now shows a preview of what will be deleted (container ID, images,
+  state directory) and prompts for confirmation. Use `--force` / `-f` to skip.
+- All crib-managed images are now labeled with `crib.workspace={wsID}`, enabling
+  label-based discovery without name-pattern heuristics. Applied via `--label` on
+  `docker build` and `--change "LABEL ..."` on `docker commit` (snapshots).
+- Build images are automatically removed when a new build replaces them (hash
+  change). The old image is deleted after the new one is successfully built.
+- `crib remove` now deletes all labeled images for the workspace in addition to
+  the container and workspace state.
+
+### Changed
+
+- **Breaking**: Workspace IDs now include a 7-character hash of the absolute
+  project path: `{slug}-{hash}` (e.g. `my-app-a1b2c3d`). Workspaces created
+  before this change will not be recognized. Run `crib up` in each project to
+  create a new workspace with the updated ID.
+
 ## [0.6.3] - 2026-03-09
 
 ### Security

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ install: build ## Install crib to ~/.local/bin
 	install -m 755 bin/crib ~/.local/bin/crib
 
 test: ## Run unit tests
-	go test ./internal/... -short -count=1
+	go test $(GO_TEST_FLAGS) ./internal/... -short -count=1
 
 lint: ## Run linters
 	go tool golangci-lint run
@@ -30,10 +30,10 @@ audit: ## Run complexity and dead-code analysis (informational)
 	@go tool deadcode ./... 2>&1 || true
 
 test-integration: ## Run integration tests (requires Docker or Podman)
-	go test ./internal/... -run Integration -count=1
+	go test $(GO_TEST_FLAGS) ./internal/... -run Integration -v -count=1
 
 test-e2e: ## Run end-to-end tests against the crib binary (requires Docker or Podman)
-	go test ./e2e/... -v -count=1 -timeout=10m
+	go test $(GO_TEST_FLAGS) ./e2e/... -v -count=1 -timeout=10m
 
 setup-hooks: ## Configure git hooks
 	@git config core.hooksPath .githooks

--- a/cmd/cache.go
+++ b/cmd/cache.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
 	"os"
@@ -143,18 +142,15 @@ var cacheCleanCmd = &cobra.Command{
 
 		// Prompt for confirmation when --all is used (affects other projects).
 		if cacheCleanAllFlag && !cacheCleanForceFlag {
-			if !stdinIsTerminal() {
-				return fmt.Errorf("--all requires confirmation; use --force to skip (stdin is not a terminal)")
-			}
 			fmt.Fprintf(os.Stderr, "This will remove %d cache volume(s) from ALL workspaces:\n", len(toRemove))
 			for _, name := range toRemove {
 				fmt.Fprintf(os.Stderr, "  %s\n", name)
 			}
-			fmt.Fprint(os.Stderr, "Continue? [y/N] ")
-			reader := bufio.NewReader(os.Stdin)
-			answer, _ := reader.ReadString('\n')
-			answer = strings.TrimSpace(strings.ToLower(answer))
-			if answer != "y" && answer != "yes" {
+			confirmed, err := confirmPrompt("--all requires confirmation")
+			if err != nil {
+				return err
+			}
+			if !confirmed {
 				u.Dim("Aborted")
 				return nil
 			}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"syscall"
 
 	"github.com/charmbracelet/x/term"
@@ -118,4 +120,17 @@ func init() {
 // reports /dev/null as a character device.
 func stdinIsTerminal() bool {
 	return term.IsTerminal(os.Stdin.Fd())
+}
+
+// confirmPrompt shows a y/N prompt and returns true if the user confirms.
+// Returns an error if stdin is not a terminal (non-interactive context).
+func confirmPrompt(nonInteractiveMsg string) (bool, error) {
+	if !stdinIsTerminal() {
+		return false, fmt.Errorf("%s; use --force to skip (stdin is not a terminal)", nonInteractiveMsg)
+	}
+	fmt.Fprint(os.Stderr, "Continue? [y/N] ")
+	reader := bufio.NewReader(os.Stdin)
+	answer, _ := reader.ReadString('\n')
+	answer = strings.TrimSpace(strings.ToLower(answer))
+	return answer == "y" || answer == "yes", nil
 }

--- a/cmd/prune.go
+++ b/cmd/prune.go
@@ -1,0 +1,119 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/fgrehm/crib/internal/engine"
+	"github.com/spf13/cobra"
+)
+
+var (
+	pruneAllFlag   bool
+	pruneForceFlag bool
+)
+
+var pruneCmd = &cobra.Command{
+	Use:   "prune",
+	Short: "Remove stale and orphan workspace images",
+	Long: `Remove stale and orphan crib-managed images.
+
+By default, prunes images for the current workspace only.
+Use --all to prune images across all workspaces (including orphans).`,
+	Args: noArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		u := newUI()
+
+		eng, _, _, err := newEngine()
+		if err != nil {
+			return err
+		}
+
+		opts := engine.PruneOptions{DryRun: true}
+		if !pruneAllFlag {
+			wsID, err := inferWorkspaceID()
+			if err != nil {
+				return err
+			}
+			opts.WorkspaceID = wsID
+		}
+
+		// Dry run to show what would be removed.
+		preview, err := eng.PruneImages(cmd.Context(), opts)
+		if err != nil {
+			return err
+		}
+
+		if len(preview.Removed) == 0 {
+			u.Dim("No stale images to remove")
+			return nil
+		}
+
+		var totalSize int64
+		for _, img := range preview.Removed {
+			label := "stale"
+			if img.Orphan {
+				label = "orphan"
+			}
+			fmt.Fprintf(os.Stderr, "  %s (%s, %s)\n", img.Reference, label, formatBytes(img.Size))
+			totalSize += img.Size
+		}
+		fmt.Fprintf(os.Stderr, "\n%d image(s), %s total\n", len(preview.Removed), formatBytes(totalSize))
+
+		if !pruneForceFlag {
+			if !stdinIsTerminal() {
+				return fmt.Errorf("pruning requires confirmation; use --force to skip (stdin is not a terminal)")
+			}
+			fmt.Fprint(os.Stderr, "Remove? [y/N] ")
+			reader := bufio.NewReader(os.Stdin)
+			answer, _ := reader.ReadString('\n')
+			answer = strings.TrimSpace(strings.ToLower(answer))
+			if answer != "y" && answer != "yes" {
+				u.Dim("Aborted")
+				return nil
+			}
+		}
+
+		// Actual removal.
+		opts.DryRun = false
+		result, err := eng.PruneImages(cmd.Context(), opts)
+		if err != nil {
+			return err
+		}
+
+		for _, img := range result.Removed {
+			u.Success("Removed " + img.Reference)
+		}
+		for _, e := range result.Errors {
+			u.Dim(fmt.Sprintf("  warning: %s: %v", e.Reference, e.Err))
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	pruneCmd.Flags().BoolVar(&pruneAllFlag, "all", false, "prune images across all workspaces")
+	pruneCmd.Flags().BoolVarP(&pruneForceFlag, "force", "f", false, "skip confirmation prompt")
+}
+
+// formatBytes returns a human-readable byte size (e.g., "1.2 GB").
+func formatBytes(b int64) string {
+	const (
+		kb = 1024
+		mb = kb * 1024
+		gb = mb * 1024
+	)
+	switch {
+	case b >= gb:
+		return fmt.Sprintf("%.1f GB", float64(b)/float64(gb))
+	case b >= mb:
+		return fmt.Sprintf("%.1f MB", float64(b)/float64(mb))
+	case b >= kb:
+		return fmt.Sprintf("%.1f KB", float64(b)/float64(kb))
+	default:
+		return fmt.Sprintf("%d B", b)
+	}
+}

--- a/cmd/prune.go
+++ b/cmd/prune.go
@@ -1,10 +1,8 @@
 package cmd
 
 import (
-	"bufio"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/fgrehm/crib/internal/engine"
 	"github.com/spf13/cobra"
@@ -63,14 +61,11 @@ Use --all to prune images across all workspaces (including orphans).`,
 		fmt.Fprintf(os.Stderr, "\n%d image(s), %s total\n", len(preview.Removed), formatBytes(totalSize))
 
 		if !pruneForceFlag {
-			if !stdinIsTerminal() {
-				return fmt.Errorf("pruning requires confirmation; use --force to skip (stdin is not a terminal)")
+			confirmed, err := confirmPrompt("pruning requires confirmation")
+			if err != nil {
+				return err
 			}
-			fmt.Fprint(os.Stderr, "Remove? [y/N] ")
-			reader := bufio.NewReader(os.Stdin)
-			answer, _ := reader.ReadString('\n')
-			answer = strings.TrimSpace(strings.ToLower(answer))
-			if answer != "y" && answer != "yes" {
+			if !confirmed {
 				u.Dim("Aborted")
 				return nil
 			}

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -43,7 +43,7 @@ var removeCmd = &cobra.Command{
 			for _, img := range preview.Images {
 				fmt.Fprintf(os.Stderr, "  image: %s\n", img)
 			}
-			fmt.Fprintf(os.Stderr, "  state: ~/.crib/workspaces/%s/\n", ws.ID)
+			fmt.Fprintf(os.Stderr, "  state: %s\n", store.WorkspaceDir(ws.ID))
 
 			confirmed, err := confirmPrompt("removal requires confirmation")
 			if err != nil {

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -1,10 +1,8 @@
 package cmd
 
 import (
-	"bufio"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -36,21 +34,22 @@ var removeCmd = &cobra.Command{
 
 			fmt.Fprintf(os.Stderr, "Will remove workspace %q:\n", ws.ID)
 			if preview.ContainerID != "" {
-				fmt.Fprintf(os.Stderr, "  container: %s\n", preview.ContainerID[:12])
+				cid := preview.ContainerID
+				if len(cid) > 12 {
+					cid = cid[:12]
+				}
+				fmt.Fprintf(os.Stderr, "  container: %s\n", cid)
 			}
 			for _, img := range preview.Images {
 				fmt.Fprintf(os.Stderr, "  image: %s\n", img)
 			}
 			fmt.Fprintf(os.Stderr, "  state: ~/.crib/workspaces/%s/\n", ws.ID)
 
-			if !stdinIsTerminal() {
-				return fmt.Errorf("removal requires confirmation; use --force to skip (stdin is not a terminal)")
+			confirmed, err := confirmPrompt("removal requires confirmation")
+			if err != nil {
+				return err
 			}
-			fmt.Fprint(os.Stderr, "Continue? [y/N] ")
-			reader := bufio.NewReader(os.Stdin)
-			answer, _ := reader.ReadString('\n')
-			answer = strings.TrimSpace(strings.ToLower(answer))
-			if answer != "y" && answer != "yes" {
+			if !confirmed {
 				u.Dim("Aborted")
 				return nil
 			}

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -1,13 +1,20 @@
 package cmd
 
 import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
 	"github.com/spf13/cobra"
 )
+
+var removeForceFlag bool
 
 var removeCmd = &cobra.Command{
 	Use:     "remove",
 	Aliases: []string{"rm", "delete"},
-	Short:   "Remove the current workspace container and state",
+	Short:   "Remove the current workspace container, images, and state",
 	Args:    noArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		u := newUI()
@@ -24,6 +31,31 @@ var removeCmd = &cobra.Command{
 
 		u.Dim(versionString())
 
+		if !removeForceFlag {
+			preview := eng.PreviewRemove(cmd.Context(), ws)
+
+			fmt.Fprintf(os.Stderr, "Will remove workspace %q:\n", ws.ID)
+			if preview.ContainerID != "" {
+				fmt.Fprintf(os.Stderr, "  container: %s\n", preview.ContainerID[:12])
+			}
+			for _, img := range preview.Images {
+				fmt.Fprintf(os.Stderr, "  image: %s\n", img)
+			}
+			fmt.Fprintf(os.Stderr, "  state: ~/.crib/workspaces/%s/\n", ws.ID)
+
+			if !stdinIsTerminal() {
+				return fmt.Errorf("removal requires confirmation; use --force to skip (stdin is not a terminal)")
+			}
+			fmt.Fprint(os.Stderr, "Continue? [y/N] ")
+			reader := bufio.NewReader(os.Stdin)
+			answer, _ := reader.ReadString('\n')
+			answer = strings.TrimSpace(strings.ToLower(answer))
+			if answer != "y" && answer != "yes" {
+				u.Dim("Aborted")
+				return nil
+			}
+		}
+
 		if err := eng.Remove(cmd.Context(), ws); err != nil {
 			return err
 		}
@@ -31,4 +63,8 @@ var removeCmd = &cobra.Command{
 		u.Success("Removed " + ws.ID)
 		return nil
 	},
+}
+
+func init() {
+	removeCmd.Flags().BoolVarP(&removeForceFlag, "force", "f", false, "skip confirmation prompt")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -122,6 +122,7 @@ func init() {
 	rootCmd.AddCommand(logsCmd)
 	rootCmd.AddCommand(doctorCmd)
 	rootCmd.AddCommand(cacheCmd)
+	rootCmd.AddCommand(pruneCmd)
 	rootCmd.AddCommand(versionCmd)
 }
 

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -300,6 +300,43 @@ or `exec.Command` with no stdin). Docker strictly validates the TTY and errors w
 
 - `cmd/exec.go` (`stdinIsTerminal`)
 
+### Image lifecycle management
+
+`crib` labels all images it builds or commits with `crib.workspace={wsID}` (the same
+label key used for containers). This enables discovery via `docker images --filter
+label=crib.workspace` without relying on name-pattern heuristics.
+
+| Image type | How the label is applied |
+|------------|------------------------|
+| Build image (`crib-{wsID}:{hash}`) | `--label` flag on `docker build` / `podman build` |
+| Snapshot image (`crib-{wsID}:snapshot`) | `--change "LABEL ..."` on `docker commit` / `podman commit` |
+| Compose feature image | `build.labels` in the generated compose override YAML |
+
+Images are cleaned up automatically at three points:
+
+1. **During build:** when the prebuild hash changes, the previous build image is removed
+   before saving the new result. Base images (those not prefixed `crib-`) are never touched.
+2. **On `crib remove`:** all labeled images for the workspace are swept via `ListImages`,
+   plus the active build image from `result.json`.
+3. **On `crib prune`:** stale images (labeled but not referenced by `result.json`) and
+   orphan images (workspace no longer exists in `~/.crib/workspaces/`) are removed.
+   Supports `--all` (global) and dry-run preview with sizes.
+
+All removals are best-effort: failures are logged and skipped so a single in-use image
+doesn't block cleanup of the rest.
+
+Existing unlabeled images from before this change are not discovered by label-based
+cleanup. Clean them up manually with `docker rmi $(docker images --filter
+reference='crib-*' -q)`.
+
+**Files**:
+
+- `internal/driver/oci/image.go` (`ListImages`, `BuildOptions.Labels`, `CommitContainer`)
+- `internal/engine/build.go` (`cleanupPreviousBuildImage`)
+- `internal/engine/engine.go` (`cleanupWorkspaceImages`, `PreviewRemove`)
+- `internal/engine/prune.go` (`PruneImages`)
+- `cmd/prune.go` (`crib prune`)
+
 ## Spec Compliance
 
 ### Fully Implemented

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -310,7 +310,10 @@ label=crib.workspace` without relying on name-pattern heuristics.
 |------------|------------------------|
 | Build image (`crib-{wsID}:{hash}`) | `--label` flag on `docker build` / `podman build` |
 | Snapshot image (`crib-{wsID}:snapshot`) | `--change "LABEL ..."` on `docker commit` / `podman commit` |
-| Compose feature image | `build.labels` in the generated compose override YAML |
+
+Compose-built images (those produced by `docker compose build`) are not labeled because
+adding a `build:` section to the compose override triggers a build attempt even for
+image-only services that have no Dockerfile.
 
 Images are cleaned up automatically at three points:
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -29,13 +29,13 @@ Currently plugin mounts land at ad-hoc paths (`~/.crib_history/`, `/tmp/ssh-agen
 
 Add `--json` or `--format json` flag to commands like `status`, `list` for scripting and tooling integration. The internal data structures already support this.
 
-### Fully qualified workspace paths
+### ~~Fully qualified workspace paths~~
 
-Workspace IDs are currently derived from the project directory name (e.g. `ruby-project`), which can collide when different orgs or parent directories have projects with the same name. Use a hash or full path to guarantee uniqueness. This is a breaking change (existing workspaces would need migration), so it should land before v1.0.
+~~Workspace IDs are currently derived from the project directory name (e.g. `ruby-project`), which can collide when different orgs or parent directories have projects with the same name. Use a hash or full path to guarantee uniqueness. This is a breaking change (existing workspaces would need migration), so it should land before v1.0.~~ Done. Workspace IDs now use `{slug}-{7-char-sha256}` of the absolute project path.
 
-### `--force` flag for destructive commands
+### ~~`--force` flag for destructive commands~~
 
-Add a `--force` / `-f` flag to commands like `remove`, `rebuild`, and `restart` to skip confirmation prompts. Useful for scripting and CI.
+~~Add a `--force` / `-f` flag to commands like `remove`, `rebuild`, and `restart` to skip confirmation prompts. Useful for scripting and CI.~~ Done. `crib remove` and `crib prune` have `--force` / `-f`.
 
 ### Colored log output
 
@@ -53,9 +53,13 @@ Show a spinner or progress bar during `docker commit` and other long-running ope
 
 Accept an explicit workspace name argument so these commands work outside the project directory. Also useful for managing multiple workspaces from a central location.
 
-### `crib nuke` / `crib prune`
+### ~~`crib prune`~~
 
-Clean all crib state, containers, volumes, and images in one shot. Useful for full reset or uninstall.
+~~Clean all crib state, containers, volumes, and images in one shot. Useful for full reset or uninstall.~~ Done. `crib prune` removes stale and orphan workspace images, with dry-run preview and `--all` for global scope.
+
+### Compose-built image cleanup
+
+`crib remove` and `crib prune` don't clean up images produced by `docker compose build` for services that have a `build:` section but no DevContainer Features. These images are unnamed by crib (compose names them `{project}-{service}` on Docker, `{project}_{service}` on Podman) and carry no `crib.workspace` label. Cleaning them up requires either tracking the compose image name in `result.json` at build time, or deriving it from the stored config at remove time (accounting for runtime differences and explicit `image:` overrides in the compose file).
 
 ### Enhanced `crib list`
 

--- a/e2e/aliases_test.go
+++ b/e2e/aliases_test.go
@@ -15,7 +15,7 @@ func TestE2EAliases(t *testing.T) {
 	cribHome := t.TempDir()
 
 	t.Cleanup(func() {
-		cmd := cribCmd(projectDir, cribHome, "rm")
+		cmd := cribCmd(projectDir, cribHome, "rm", "--force")
 		_ = cmd.Run()
 	})
 

--- a/e2e/aliases_test.go
+++ b/e2e/aliases_test.go
@@ -42,7 +42,7 @@ func TestE2EAliases(t *testing.T) {
 	}
 
 	// "rm" alias for "remove".
-	mustRunCrib(t, projectDir, cribHome, "rm")
+	mustRunCrib(t, projectDir, cribHome, "rm", "--force")
 	out = mustRunCrib(t, projectDir, cribHome, "ls")
 	if !strings.Contains(strings.ToLower(out), "no workspaces") {
 		t.Errorf("ls after rm: want 'no workspaces', got %q", out)

--- a/e2e/compose_test.go
+++ b/e2e/compose_test.go
@@ -96,7 +96,7 @@ func TestE2ECompose(t *testing.T) {
 
 	// Best-effort cleanup so containers don't linger if the test fails mid-way.
 	t.Cleanup(func() {
-		cmd := cribCmd(projectDir, cribHome, "remove")
+		cmd := cribCmd(projectDir, cribHome, "remove", "--force")
 		_ = cmd.Run()
 	})
 

--- a/e2e/compose_test.go
+++ b/e2e/compose_test.go
@@ -139,7 +139,7 @@ func TestE2ECompose(t *testing.T) {
 	mustRunCrib(t, projectDir, cribHome, "up")
 
 	// 7. remove - must remove all compose services and workspace state.
-	mustRunCrib(t, projectDir, cribHome, "remove")
+	mustRunCrib(t, projectDir, cribHome, "remove", "--force")
 
 	out = mustRunCrib(t, projectDir, cribHome, "list")
 	if !strings.Contains(strings.ToLower(out), "no workspaces") {

--- a/e2e/doctor_test.go
+++ b/e2e/doctor_test.go
@@ -21,7 +21,7 @@ func TestE2EDoctor(t *testing.T) {
 
 	// Bring up a workspace so there's something to check.
 	t.Cleanup(func() {
-		cmd := cribCmd(projectDir, cribHome, "rm")
+		cmd := cribCmd(projectDir, cribHome, "rm", "--force")
 		_ = cmd.Run()
 	})
 

--- a/e2e/down_up_test.go
+++ b/e2e/down_up_test.go
@@ -18,7 +18,7 @@ func TestE2EDownUpCycle(t *testing.T) {
 	cribHome := t.TempDir()
 
 	t.Cleanup(func() {
-		cmd := cribCmd(projectDir, cribHome, "rm")
+		cmd := cribCmd(projectDir, cribHome, "rm", "--force")
 		_ = cmd.Run()
 	})
 
@@ -76,7 +76,7 @@ func TestE2EDownUpComposeSkipsBuild(t *testing.T) {
 	cribHome := t.TempDir()
 
 	t.Cleanup(func() {
-		cmd := cribCmd(projectDir, cribHome, "rm")
+		cmd := cribCmd(projectDir, cribHome, "rm", "--force")
 		_ = cmd.Run()
 	})
 

--- a/e2e/down_up_test.go
+++ b/e2e/down_up_test.go
@@ -59,7 +59,7 @@ func TestE2EDownUpCycle(t *testing.T) {
 	mustRunCrib(t, projectDir, cribHome, "exec", "--", "test", "-f", "/tmp/post-create-ran")
 
 	// Clean up.
-	mustRunCrib(t, projectDir, cribHome, "rm")
+	mustRunCrib(t, projectDir, cribHome, "rm", "--force")
 }
 
 // TestE2EDownUpComposeSkipsBuild verifies that down + up for compose workspaces

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -227,7 +227,7 @@ func TestE2EFullLifecycle(t *testing.T) {
 	}
 
 	// 14. remove - removes container and workspace state.
-	mustRunCrib(t, projectDir, cribHome, "remove")
+	mustRunCrib(t, projectDir, cribHome, "remove", "--force")
 
 	// 15. list - workspace should be gone.
 	out = mustRunCrib(t, projectDir, cribHome, "list")
@@ -269,7 +269,7 @@ func TestE2EUpRecreate(t *testing.T) {
 		t.Errorf("up --recreate: want new container ID, got same %q", id1)
 	}
 
-	mustRunCrib(t, projectDir, cribHome, "remove")
+	mustRunCrib(t, projectDir, cribHome, "remove", "--force")
 }
 
 func TestE2ENoDevcontainer(t *testing.T) {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -314,7 +314,7 @@ func TestE2ERebuildNoContainer(t *testing.T) {
 	cribHome := t.TempDir()
 
 	t.Cleanup(func() {
-		cmd := cribCmd(projectDir, cribHome, "rm")
+		cmd := cribCmd(projectDir, cribHome, "rm", "--force")
 		_ = cmd.Run()
 	})
 

--- a/e2e/logs_test.go
+++ b/e2e/logs_test.go
@@ -14,7 +14,7 @@ func TestE2ELogs(t *testing.T) {
 	cribHome := t.TempDir()
 
 	t.Cleanup(func() {
-		cmd := cribCmd(projectDir, cribHome, "rm")
+		cmd := cribCmd(projectDir, cribHome, "rm", "--force")
 		_ = cmd.Run()
 	})
 

--- a/e2e/plugins_test.go
+++ b/e2e/plugins_test.go
@@ -16,7 +16,7 @@ func TestE2EShellHistory(t *testing.T) {
 	cribHome := t.TempDir()
 
 	t.Cleanup(func() {
-		cmd := cribCmd(projectDir, cribHome, "rm")
+		cmd := cribCmd(projectDir, cribHome, "rm", "--force")
 		_ = cmd.Run()
 	})
 
@@ -97,7 +97,7 @@ func TestE2EComposeShellHistory(t *testing.T) {
 	cribHome := t.TempDir()
 
 	t.Cleanup(func() {
-		cmd := cribCmd(projectDir, cribHome, "remove")
+		cmd := cribCmd(projectDir, cribHome, "remove", "--force")
 		_ = cmd.Run()
 		// Best-effort removal. On rootful Docker, chownWorkspace changes file
 		// ownership to the container user, preventing the test user from

--- a/e2e/ports_test.go
+++ b/e2e/ports_test.go
@@ -31,7 +31,7 @@ func TestE2EForwardPorts(t *testing.T) {
 	cribHome := t.TempDir()
 
 	t.Cleanup(func() {
-		cmd := cribCmd(dir, cribHome, "rm")
+		cmd := cribCmd(dir, cribHome, "rm", "--force")
 		_ = cmd.Run()
 	})
 

--- a/e2e/restart_test.go
+++ b/e2e/restart_test.go
@@ -18,7 +18,7 @@ func TestE2ERestartSimple(t *testing.T) {
 	cribHome := t.TempDir()
 
 	t.Cleanup(func() {
-		cmd := cribCmd(projectDir, cribHome, "rm")
+		cmd := cribCmd(projectDir, cribHome, "rm", "--force")
 		_ = cmd.Run()
 	})
 
@@ -64,7 +64,7 @@ func TestE2ERestartRecreate(t *testing.T) {
 	cribHome := t.TempDir()
 
 	t.Cleanup(func() {
-		cmd := cribCmd(projectDir, cribHome, "rm")
+		cmd := cribCmd(projectDir, cribHome, "rm", "--force")
 		_ = cmd.Run()
 	})
 

--- a/e2e/snapshot_test.go
+++ b/e2e/snapshot_test.go
@@ -17,10 +17,8 @@ func TestE2ESnapshotCreatedAfterUp(t *testing.T) {
 	cribHome := t.TempDir()
 
 	t.Cleanup(func() {
-		cmd := cribCmd(projectDir, cribHome, "rm")
+		cmd := cribCmd(projectDir, cribHome, "rm", "--force")
 		_ = cmd.Run()
-		// Clean up snapshot image.
-		removeSnapshotImages(t)
 	})
 
 	// Up should create a container and a snapshot.
@@ -47,9 +45,8 @@ func TestE2ERebuildClearsSnapshot(t *testing.T) {
 	cribHome := t.TempDir()
 
 	t.Cleanup(func() {
-		cmd := cribCmd(projectDir, cribHome, "rm")
+		cmd := cribCmd(projectDir, cribHome, "rm", "--force")
 		_ = cmd.Run()
-		removeSnapshotImages(t)
 	})
 
 	// Up creates the snapshot.
@@ -98,21 +95,4 @@ func hasSnapshotImage(t *testing.T) bool {
 		}
 	}
 	return false
-}
-
-// removeSnapshotImages removes all crib snapshot images.
-func removeSnapshotImages(t *testing.T) {
-	t.Helper()
-	for _, rt := range []string{"docker", "podman"} {
-		cmd := exec.Command(rt, "images", "--format", "{{.Repository}}:{{.Tag}}", "--filter", "reference=crib-*:snapshot")
-		out, err := cmd.Output()
-		if err != nil {
-			continue
-		}
-		for img := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
-			if img != "" {
-				_ = exec.Command(rt, "rmi", img).Run()
-			}
-		}
-	}
 }

--- a/internal/engine/build_test.go
+++ b/internal/engine/build_test.go
@@ -125,21 +125,9 @@ func TestResolveFeatureMetadata_NoFeatures(t *testing.T) {
 	}
 }
 
-// buildMockDriver extends mockDriver to track RemoveImage calls.
-type buildMockDriver struct {
-	mockDriver
-	removedImages []string
-	removeErr     error
-}
-
-func (m *buildMockDriver) RemoveImage(ctx context.Context, imageName string) error {
-	m.removedImages = append(m.removedImages, imageName)
-	return m.removeErr
-}
-
 func TestCleanupPreviousBuildImage_NewHashReplacesOld(t *testing.T) {
 	store := workspace.NewStoreAt(t.TempDir())
-	md := &buildMockDriver{}
+	md := &imageTrackingDriver{}
 	eng := &Engine{driver: md, store: store, logger: slog.Default()}
 
 	oldImage := "crib-myws:crib-oldhash"
@@ -156,7 +144,7 @@ func TestCleanupPreviousBuildImage_NewHashReplacesOld(t *testing.T) {
 
 func TestCleanupPreviousBuildImage_CacheHit_NoRemoval(t *testing.T) {
 	store := workspace.NewStoreAt(t.TempDir())
-	md := &buildMockDriver{}
+	md := &imageTrackingDriver{}
 	eng := &Engine{driver: md, store: store, logger: slog.Default()}
 
 	sameImage := "crib-myws:crib-samehash"
@@ -173,7 +161,7 @@ func TestCleanupPreviousBuildImage_CacheHit_NoRemoval(t *testing.T) {
 
 func TestCleanupPreviousBuildImage_BaseImage_NotRemoved(t *testing.T) {
 	store := workspace.NewStoreAt(t.TempDir())
-	md := &buildMockDriver{}
+	md := &imageTrackingDriver{}
 	eng := &Engine{driver: md, store: store, logger: slog.Default()}
 
 	if err := store.SaveResult("myws", &workspace.Result{ImageName: "ubuntu:22.04"}); err != nil {
@@ -189,7 +177,7 @@ func TestCleanupPreviousBuildImage_BaseImage_NotRemoved(t *testing.T) {
 
 func TestCleanupPreviousBuildImage_RemoveFailure_NoError(t *testing.T) {
 	store := workspace.NewStoreAt(t.TempDir())
-	md := &buildMockDriver{removeErr: fmt.Errorf("image in use")}
+	md := &imageTrackingDriver{removeErr: fmt.Errorf("image in use")}
 	eng := &Engine{driver: md, store: store, logger: slog.Default()}
 
 	oldImage := "crib-myws:crib-oldhash"
@@ -207,7 +195,7 @@ func TestCleanupPreviousBuildImage_RemoveFailure_NoError(t *testing.T) {
 
 func TestCleanupPreviousBuildImage_FirstBuild_NoRemoval(t *testing.T) {
 	store := workspace.NewStoreAt(t.TempDir())
-	md := &buildMockDriver{}
+	md := &imageTrackingDriver{}
 	eng := &Engine{driver: md, store: store, logger: slog.Default()}
 
 	// No stored result exists.

--- a/internal/engine/compose.go
+++ b/internal/engine/compose.go
@@ -144,11 +144,6 @@ func (e *Engine) generateComposeOverride(ws *workspace.Workspace, cfg *config.De
 	b.WriteString("    labels:\n")
 	fmt.Fprintf(&b, "      %s: %q\n", ocidriver.LabelWorkspace, ws.ID)
 
-	// Add build.labels so compose-built images get the workspace label.
-	b.WriteString("    build:\n")
-	b.WriteString("      labels:\n")
-	fmt.Fprintf(&b, "        %s: %q\n", ocidriver.LabelWorkspace, ws.ID)
-
 	// Override image if a feature image was built.
 	if featureImage != "" {
 		fmt.Fprintf(&b, "    image: %s\n", featureImage)

--- a/internal/engine/compose_integration_test.go
+++ b/internal/engine/compose_integration_test.go
@@ -66,18 +66,19 @@ func writeComposeDevcontainer(t *testing.T, projectDir, wsID string) *workspace.
 
 	return &workspace.Workspace{
 		ID:               wsID,
-		Source:            projectDir,
+		Source:           projectDir,
 		DevContainerPath: ".devcontainer/devcontainer.json",
 		CreatedAt:        time.Now(),
 		LastUsedAt:       time.Now(),
 	}
 }
 
-// cleanupCompose tears down any containers/networks for the workspace.
-func cleanupCompose(t *testing.T, e *Engine, ws *workspace.Workspace) {
+// cleanupCompose tears down containers/networks and removes labeled images.
+func cleanupCompose(t *testing.T, e *Engine, d *oci.OCIDriver, ws *workspace.Workspace) {
 	t.Helper()
 	ctx := context.Background()
 	_ = e.Down(ctx, ws)
+	cleanupWorkspaceImages(t, d, ws.ID)
 }
 
 // TestIntegrationComposeDownUpSkipsBuild verifies that after a down + up cycle,
@@ -88,14 +89,14 @@ func TestIntegrationComposeDownUpSkipsBuild(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	e, _, store := newTestEngineWithCompose(t)
+	e, d, store := newTestEngineWithCompose(t)
 
 	projectDir := t.TempDir()
 	wsID := "test-compose-down-up"
 	ws := writeComposeDevcontainer(t, projectDir, wsID)
 
-	t.Cleanup(func() { cleanupCompose(t, e, ws) })
-	cleanupCompose(t, e, ws)
+	t.Cleanup(func() { cleanupCompose(t, e, d, ws) })
+	cleanupCompose(t, e, d, ws)
 
 	// Initial Up — full creation path.
 	result1, err := e.Up(ctx, ws, UpOptions{})
@@ -160,7 +161,7 @@ func TestIntegrationComposeRestartWithStoppedDeps(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	e, _, _ := newTestEngineWithCompose(t)
+	e, d, _ := newTestEngineWithCompose(t)
 
 	projectDir := t.TempDir()
 	wsID := "test-compose-restart-deps"
@@ -198,14 +199,14 @@ func TestIntegrationComposeRestartWithStoppedDeps(t *testing.T) {
 
 	ws := &workspace.Workspace{
 		ID:               wsID,
-		Source:            projectDir,
+		Source:           projectDir,
 		DevContainerPath: ".devcontainer/devcontainer.json",
 		CreatedAt:        time.Now(),
 		LastUsedAt:       time.Now(),
 	}
 
-	t.Cleanup(func() { cleanupCompose(t, e, ws) })
-	cleanupCompose(t, e, ws)
+	t.Cleanup(func() { cleanupCompose(t, e, d, ws) })
+	cleanupCompose(t, e, d, ws)
 
 	// Initial Up.
 	result, err := e.Up(ctx, ws, UpOptions{})
@@ -247,14 +248,14 @@ func TestIntegrationComposeDownClearsMarkers(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	e, _, store := newTestEngineWithCompose(t)
+	e, d, store := newTestEngineWithCompose(t)
 
 	projectDir := t.TempDir()
 	wsID := "test-compose-markers"
 	ws := writeComposeDevcontainer(t, projectDir, wsID)
 
-	t.Cleanup(func() { cleanupCompose(t, e, ws) })
-	cleanupCompose(t, e, ws)
+	t.Cleanup(func() { cleanupCompose(t, e, d, ws) })
+	cleanupCompose(t, e, d, ws)
 
 	// Initial Up.
 	if _, err := e.Up(ctx, ws, UpOptions{}); err != nil {
@@ -292,7 +293,7 @@ func TestIntegrationComposeRecreateRebuildsImage(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	e, _, store := newTestEngineWithCompose(t)
+	e, d, store := newTestEngineWithCompose(t)
 
 	projectDir := t.TempDir()
 	wsID := "test-compose-recreate-rebuild"
@@ -330,14 +331,14 @@ func TestIntegrationComposeRecreateRebuildsImage(t *testing.T) {
 
 	ws := &workspace.Workspace{
 		ID:               wsID,
-		Source:            projectDir,
+		Source:           projectDir,
 		DevContainerPath: ".devcontainer/devcontainer.json",
 		CreatedAt:        time.Now(),
 		LastUsedAt:       time.Now(),
 	}
 
-	t.Cleanup(func() { cleanupCompose(t, e, ws) })
-	cleanupCompose(t, e, ws)
+	t.Cleanup(func() { cleanupCompose(t, e, d, ws) })
+	cleanupCompose(t, e, d, ws)
 
 	// Initial Up — builds image with v1.
 	result1, err := e.Up(ctx, ws, UpOptions{})
@@ -396,14 +397,14 @@ func TestIntegrationComposeImageNamePersisted(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	e, _, store := newTestEngineWithCompose(t)
+	e, d, store := newTestEngineWithCompose(t)
 
 	projectDir := t.TempDir()
 	wsID := "test-compose-imagename"
 	ws := writeComposeDevcontainer(t, projectDir, wsID)
 
-	t.Cleanup(func() { cleanupCompose(t, e, ws) })
-	cleanupCompose(t, e, ws)
+	t.Cleanup(func() { cleanupCompose(t, e, d, ws) })
+	cleanupCompose(t, e, d, ws)
 
 	if _, err := e.Up(ctx, ws, UpOptions{}); err != nil {
 		t.Fatalf("Up: %v", err)

--- a/internal/engine/compose_test.go
+++ b/internal/engine/compose_test.go
@@ -409,7 +409,7 @@ func TestGenerateComposeOverride_OmitsImageWhenEmpty(t *testing.T) {
 	}
 }
 
-func TestGenerateComposeOverride_IncludesBuildLabels(t *testing.T) {
+func TestGenerateComposeOverride_NoBuildSection(t *testing.T) {
 	ws := &workspace.Workspace{ID: "test-ws", Source: "/tmp/project"}
 	e := newComposeTestEngine(t, "docker", ws)
 
@@ -427,12 +427,16 @@ func TestGenerateComposeOverride_IncludesBuildLabels(t *testing.T) {
 	}
 	content := string(data)
 
-	// Should include build.labels for compose-built images.
-	if !strings.Contains(content, "build:") {
-		t.Errorf("expected build section, got:\n%s", content)
+	// Override must NOT include a build: section for image-only services.
+	// Adding build: to the override makes Docker Compose attempt a build
+	// even when the service has no Dockerfile.
+	if strings.Contains(content, "build:") {
+		t.Errorf("override should not contain build section for image-only service, got:\n%s", content)
 	}
-	if !strings.Contains(content, "crib.workspace: \"test-ws\"") {
-		t.Errorf("expected workspace label in build.labels, got:\n%s", content)
+
+	// Container labels should still be present.
+	if !strings.Contains(content, "crib.workspace") {
+		t.Errorf("expected container label, got:\n%s", content)
 	}
 }
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -14,6 +14,7 @@ import (
 	"github.com/fgrehm/crib/internal/compose"
 	"github.com/fgrehm/crib/internal/config"
 	"github.com/fgrehm/crib/internal/driver"
+	ocidriver "github.com/fgrehm/crib/internal/driver/oci"
 	"github.com/fgrehm/crib/internal/plugin"
 	"github.com/fgrehm/crib/internal/workspace"
 )
@@ -426,6 +427,45 @@ func (e *Engine) Down(ctx context.Context, ws *workspace.Workspace) error {
 	return e.driver.DeleteContainer(ctx, ws.ID, container.ID)
 }
 
+// RemovePreview describes what Remove() will delete.
+type RemovePreview struct {
+	ContainerID string   // empty if no container found
+	Images      []string // image references that will be removed
+}
+
+// PreviewRemove returns what Remove() would delete without actually removing anything.
+func (e *Engine) PreviewRemove(ctx context.Context, ws *workspace.Workspace) *RemovePreview {
+	preview := &RemovePreview{}
+
+	if container, err := e.driver.FindContainer(ctx, ws.ID); err == nil && container != nil {
+		preview.ContainerID = container.ID
+	}
+
+	if result, err := e.store.LoadResult(ws.ID); err == nil && result != nil {
+		if result.SnapshotImage != "" {
+			preview.Images = append(preview.Images, result.SnapshotImage)
+		}
+		if result.ImageName != "" && strings.HasPrefix(result.ImageName, "crib-") {
+			preview.Images = append(preview.Images, result.ImageName)
+		}
+	}
+
+	label := ocidriver.WorkspaceLabel(ws.ID)
+	if images, err := e.driver.ListImages(ctx, label); err == nil {
+		seen := make(map[string]bool)
+		for _, img := range preview.Images {
+			seen[img] = true
+		}
+		for _, img := range images {
+			if !seen[img.Reference] {
+				preview.Images = append(preview.Images, img.Reference)
+			}
+		}
+	}
+
+	return preview
+}
+
 // Remove stops and removes the container, then deletes all workspace state.
 func (e *Engine) Remove(ctx context.Context, ws *workspace.Workspace) error {
 	e.logger.Debug("remove", "workspace", ws.ID)
@@ -455,6 +495,9 @@ func (e *Engine) Remove(ctx context.Context, ws *workspace.Workspace) error {
 			e.logger.Warn("failed to remove container", "error", err)
 		}
 	}
+
+	// Clean up workspace images (best-effort).
+	e.cleanupWorkspaceImages(ctx, ws.ID)
 
 	return e.store.Delete(ws.ID)
 }
@@ -493,6 +536,32 @@ func (e *Engine) Status(ctx context.Context, ws *workspace.Workspace) (*StatusRe
 	}
 
 	return result, nil
+}
+
+// cleanupWorkspaceImages removes the build image and any remaining labeled
+// images for a workspace. Best-effort: failures are logged, not returned.
+func (e *Engine) cleanupWorkspaceImages(ctx context.Context, wsID string) {
+	// Remove the active build image if it's crib-built.
+	if result, err := e.store.LoadResult(wsID); err == nil && result != nil {
+		if result.ImageName != "" && strings.HasPrefix(result.ImageName, "crib-") {
+			if err := e.driver.RemoveImage(ctx, result.ImageName); err != nil {
+				e.logger.Debug("failed to remove build image", "image", result.ImageName, "error", err)
+			}
+		}
+	}
+
+	// Sweep any remaining labeled images (stale builds, etc).
+	label := ocidriver.WorkspaceLabel(wsID)
+	images, err := e.driver.ListImages(ctx, label)
+	if err != nil {
+		e.logger.Debug("failed to list workspace images for cleanup", "error", err)
+		return
+	}
+	for _, img := range images {
+		if err := e.driver.RemoveImage(ctx, img.Reference); err != nil {
+			e.logger.Debug("failed to remove workspace image", "image", img.Reference, "error", err)
+		}
+	}
 }
 
 // --- shared helpers ---

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -541,25 +541,26 @@ func (e *Engine) Status(ctx context.Context, ws *workspace.Workspace) (*StatusRe
 // cleanupWorkspaceImages removes the build image and any remaining labeled
 // images for a workspace. Best-effort: failures are logged, not returned.
 func (e *Engine) cleanupWorkspaceImages(ctx context.Context, wsID string) {
-	// Remove the active build image if it's crib-built.
-	if result, err := e.store.LoadResult(wsID); err == nil && result != nil {
-		if result.ImageName != "" && strings.HasPrefix(result.ImageName, "crib-") {
-			if err := e.driver.RemoveImage(ctx, result.ImageName); err != nil {
-				e.logger.Debug("failed to remove build image", "image", result.ImageName, "error", err)
-			}
+	// Collect images to remove: labeled images + unlabeled build image (legacy).
+	seen := make(map[string]bool)
+
+	label := ocidriver.WorkspaceLabel(wsID)
+	if images, err := e.driver.ListImages(ctx, label); err == nil {
+		for _, img := range images {
+			seen[img.Reference] = true
 		}
 	}
 
-	// Sweep any remaining labeled images (stale builds, etc).
-	label := ocidriver.WorkspaceLabel(wsID)
-	images, err := e.driver.ListImages(ctx, label)
-	if err != nil {
-		e.logger.Debug("failed to list workspace images for cleanup", "error", err)
-		return
+	// Also target the stored build image in case it predates labeling.
+	if result, err := e.store.LoadResult(wsID); err == nil && result != nil {
+		if result.ImageName != "" && strings.HasPrefix(result.ImageName, "crib-") {
+			seen[result.ImageName] = true
+		}
 	}
-	for _, img := range images {
-		if err := e.driver.RemoveImage(ctx, img.Reference); err != nil {
-			e.logger.Debug("failed to remove workspace image", "image", img.Reference, "error", err)
+
+	for ref := range seen {
+		if err := e.driver.RemoveImage(ctx, ref); err != nil {
+			e.logger.Debug("failed to remove workspace image", "image", ref, "error", err)
 		}
 	}
 }

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -220,6 +220,109 @@ func TestEnsureContainerRunning_EmptyState_FindReturnsRunning(t *testing.T) {
 	}
 }
 
+// removeMockDriver extends mockDriver to track image removal and listing.
+type removeMockDriver struct {
+	mockDriver
+	removedImages []string
+	images        []driver.ImageInfo
+}
+
+func (m *removeMockDriver) RemoveImage(ctx context.Context, imageName string) error {
+	m.removedImages = append(m.removedImages, imageName)
+	return nil
+}
+
+func (m *removeMockDriver) ListImages(ctx context.Context, label string) ([]driver.ImageInfo, error) {
+	return m.images, nil
+}
+
+func TestRemove_CleansUpBuildAndLabeledImages(t *testing.T) {
+	store := workspace.NewStoreAt(t.TempDir())
+
+	ws := &workspace.Workspace{
+		ID:               "test-ws",
+		Source:           t.TempDir(),
+		DevContainerPath: ".devcontainer/devcontainer.json",
+	}
+	if err := store.Save(ws); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveResult(ws.ID, &workspace.Result{
+		ImageName:     "crib-test-ws:crib-abc",
+		SnapshotImage: "crib-test-ws:snapshot",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	md := &removeMockDriver{
+		images: []driver.ImageInfo{
+			{Reference: "crib-test-ws:crib-old", ID: "sha256:stale", Size: 100, WorkspaceID: "test-ws"},
+		},
+	}
+	eng := &Engine{
+		driver: md,
+		store:  store,
+		logger: slog.Default(),
+		stdout: io.Discard,
+		stderr: io.Discard,
+	}
+
+	if err := eng.Remove(context.Background(), ws); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+
+	// Should have removed: snapshot, build image, and the stale labeled image.
+	want := map[string]bool{
+		"crib-test-ws:snapshot": true,
+		"crib-test-ws:crib-abc": true,
+		"crib-test-ws:crib-old": true,
+	}
+	for _, img := range md.removedImages {
+		delete(want, img)
+	}
+	if len(want) > 0 {
+		t.Errorf("expected images not removed: %v (removed: %v)", want, md.removedImages)
+	}
+}
+
+func TestRemove_SkipsBaseImages(t *testing.T) {
+	store := workspace.NewStoreAt(t.TempDir())
+
+	ws := &workspace.Workspace{
+		ID:               "test-ws",
+		Source:           t.TempDir(),
+		DevContainerPath: ".devcontainer/devcontainer.json",
+	}
+	if err := store.Save(ws); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveResult(ws.ID, &workspace.Result{
+		ImageName: "ubuntu:22.04",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	md := &removeMockDriver{}
+	eng := &Engine{
+		driver: md,
+		store:  store,
+		logger: slog.Default(),
+		stdout: io.Discard,
+		stderr: io.Discard,
+	}
+
+	if err := eng.Remove(context.Background(), ws); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+
+	// Should not remove the base image (ubuntu:22.04).
+	for _, img := range md.removedImages {
+		if img == "ubuntu:22.04" {
+			t.Errorf("should not have removed base image %s", img)
+		}
+	}
+}
+
 func TestNewComposeInvocation_IncludesService(t *testing.T) {
 	ws := &workspace.Workspace{
 		ID:               "web",

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -220,22 +220,6 @@ func TestEnsureContainerRunning_EmptyState_FindReturnsRunning(t *testing.T) {
 	}
 }
 
-// removeMockDriver extends mockDriver to track image removal and listing.
-type removeMockDriver struct {
-	mockDriver
-	removedImages []string
-	images        []driver.ImageInfo
-}
-
-func (m *removeMockDriver) RemoveImage(ctx context.Context, imageName string) error {
-	m.removedImages = append(m.removedImages, imageName)
-	return nil
-}
-
-func (m *removeMockDriver) ListImages(ctx context.Context, label string) ([]driver.ImageInfo, error) {
-	return m.images, nil
-}
-
 func TestRemove_CleansUpBuildAndLabeledImages(t *testing.T) {
 	store := workspace.NewStoreAt(t.TempDir())
 
@@ -254,7 +238,7 @@ func TestRemove_CleansUpBuildAndLabeledImages(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	md := &removeMockDriver{
+	md := &imageTrackingDriver{
 		images: []driver.ImageInfo{
 			{Reference: "crib-test-ws:crib-old", ID: "sha256:stale", Size: 100, WorkspaceID: "test-ws"},
 		},
@@ -302,7 +286,7 @@ func TestRemove_SkipsBaseImages(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	md := &removeMockDriver{}
+	md := &imageTrackingDriver{}
 	eng := &Engine{
 		driver: md,
 		store:  store,

--- a/internal/engine/integration_test.go
+++ b/internal/engine/integration_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fgrehm/crib/internal/driver"
 	"github.com/fgrehm/crib/internal/driver/oci"
 	"github.com/fgrehm/crib/internal/plugin"
 	"github.com/fgrehm/crib/internal/plugin/shellhistory"
@@ -29,6 +30,20 @@ func newTestEngine(t *testing.T) (*Engine, *oci.OCIDriver, *workspace.Store) {
 
 	// compose helper is optional for these tests.
 	return New(d, nil, store, slog.Default()), d, store
+}
+
+// cleanupWorkspaceImages removes all labeled images for a workspace during
+// test teardown. Prevents crib-test-* images from accumulating on disk.
+func cleanupWorkspaceImages(t *testing.T, d driver.Driver, wsID string) {
+	t.Helper()
+	ctx := context.Background()
+	images, err := d.ListImages(ctx, oci.WorkspaceLabel(wsID))
+	if err != nil {
+		return
+	}
+	for _, img := range images {
+		_ = d.RemoveImage(ctx, img.Reference)
+	}
 }
 
 func TestIntegrationUpImageBased(t *testing.T) {
@@ -70,6 +85,7 @@ func TestIntegrationUpImageBased(t *testing.T) {
 	_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
 	t.Cleanup(func() {
 		_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
+		cleanupWorkspaceImages(t, d, wsID)
 	})
 
 	// Up.
@@ -180,6 +196,7 @@ func TestIntegrationUpWithLifecycleHooks(t *testing.T) {
 	_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
 	t.Cleanup(func() {
 		_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
+		cleanupWorkspaceImages(t, d, wsID)
 	})
 
 	result, err := e.Up(ctx, ws, UpOptions{})
@@ -239,6 +256,7 @@ func TestIntegrationUpWithInitializeCommand(t *testing.T) {
 	_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
 	t.Cleanup(func() {
 		_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
+		cleanupWorkspaceImages(t, d, wsID)
 	})
 
 	_, err := e.Up(ctx, ws, UpOptions{})
@@ -286,6 +304,7 @@ func TestIntegrationUpWithRecreate(t *testing.T) {
 	_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
 	t.Cleanup(func() {
 		_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
+		cleanupWorkspaceImages(t, d, wsID)
 	})
 
 	// First up.
@@ -377,6 +396,7 @@ USER dev
 	_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
 	t.Cleanup(func() {
 		_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
+		cleanupWorkspaceImages(t, d, wsID)
 	})
 
 	result, err := e.Up(ctx, ws, UpOptions{})
@@ -476,6 +496,7 @@ func TestIntegrationUpWithPlugins(t *testing.T) {
 	_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
 	t.Cleanup(func() {
 		_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
+		cleanupWorkspaceImages(t, d, wsID)
 	})
 
 	result, err := e.Up(ctx, ws, UpOptions{})
@@ -534,6 +555,7 @@ func TestIntegrationLogs(t *testing.T) {
 	_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
 	t.Cleanup(func() {
 		_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
+		cleanupWorkspaceImages(t, d, wsID)
 	})
 
 	if _, err := e.Up(ctx, ws, UpOptions{}); err != nil {
@@ -601,7 +623,7 @@ func TestIntegrationSnapshot(t *testing.T) {
 	_ = d.RemoveImage(ctx, snapshotName)
 	t.Cleanup(func() {
 		_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
-		_ = d.RemoveImage(ctx, snapshotName)
+		cleanupWorkspaceImages(t, d, wsID)
 	})
 
 	// Up should create the container and commit a snapshot.

--- a/internal/engine/prune_test.go
+++ b/internal/engine/prune_test.go
@@ -4,49 +4,11 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"strings"
 	"testing"
 
 	"github.com/fgrehm/crib/internal/driver"
 	"github.com/fgrehm/crib/internal/workspace"
 )
-
-// pruneMockDriver tracks ListImages and RemoveImage calls.
-type pruneMockDriver struct {
-	mockDriver
-	images        []driver.ImageInfo
-	listErr       error
-	removedImages []string
-	removeErrs    map[string]error
-}
-
-func (m *pruneMockDriver) ListImages(ctx context.Context, label string) ([]driver.ImageInfo, error) {
-	if m.listErr != nil {
-		return nil, m.listErr
-	}
-	// Simulate label filtering: if label contains "=", filter by workspace ID.
-	var filtered []driver.ImageInfo
-	for _, img := range m.images {
-		if strings.Contains(label, "=") {
-			wsID := strings.SplitN(label, "=", 2)[1]
-			if img.WorkspaceID != wsID {
-				continue
-			}
-		}
-		filtered = append(filtered, img)
-	}
-	return filtered, nil
-}
-
-func (m *pruneMockDriver) RemoveImage(ctx context.Context, imageName string) error {
-	m.removedImages = append(m.removedImages, imageName)
-	if m.removeErrs != nil {
-		if err, ok := m.removeErrs[imageName]; ok {
-			return err
-		}
-	}
-	return nil
-}
 
 func TestPruneImages_StaleRemoved_ActiveKept(t *testing.T) {
 	store := workspace.NewStoreAt(t.TempDir())
@@ -62,7 +24,7 @@ func TestPruneImages_StaleRemoved_ActiveKept(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	md := &pruneMockDriver{
+	md := &imageTrackingDriver{
 		images: []driver.ImageInfo{
 			{Reference: "crib-myws:crib-abc1234", ID: "sha256:active", Size: 100, WorkspaceID: "myws"},
 			{Reference: "crib-myws:snapshot", ID: "sha256:snap", Size: 200, WorkspaceID: "myws"},
@@ -96,7 +58,7 @@ func TestPruneImages_OrphanImagesRemoved(t *testing.T) {
 	store := workspace.NewStoreAt(t.TempDir())
 	// No workspace saved for "gone-ws" -- it's orphaned.
 
-	md := &pruneMockDriver{
+	md := &imageTrackingDriver{
 		images: []driver.ImageInfo{
 			{Reference: "crib-gone-ws:crib-abc", ID: "sha256:orphan1", Size: 500, WorkspaceID: "gone-ws"},
 			{Reference: "crib-gone-ws:snapshot", ID: "sha256:orphan2", Size: 600, WorkspaceID: "gone-ws"},
@@ -132,7 +94,7 @@ func TestPruneImages_WorkspaceFilter(t *testing.T) {
 		}
 	}
 
-	md := &pruneMockDriver{
+	md := &imageTrackingDriver{
 		images: []driver.ImageInfo{
 			{Reference: "crib-ws1:crib-active", ID: "sha256:a1", Size: 100, WorkspaceID: "ws1"},
 			{Reference: "crib-ws1:crib-stale", ID: "sha256:s1", Size: 200, WorkspaceID: "ws1"},
@@ -165,7 +127,7 @@ func TestPruneImages_DryRun(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	md := &pruneMockDriver{
+	md := &imageTrackingDriver{
 		images: []driver.ImageInfo{
 			{Reference: "crib-myws:crib-active", ID: "sha256:a", Size: 100, WorkspaceID: "myws"},
 			{Reference: "crib-myws:crib-stale", ID: "sha256:s", Size: 200, WorkspaceID: "myws"},
@@ -196,7 +158,7 @@ func TestPruneImages_RemoveFailure_Continues(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	md := &pruneMockDriver{
+	md := &imageTrackingDriver{
 		images: []driver.ImageInfo{
 			{Reference: "crib-myws:crib-active", ID: "sha256:a", Size: 100, WorkspaceID: "myws"},
 			{Reference: "crib-myws:crib-stale1", ID: "sha256:s1", Size: 200, WorkspaceID: "myws"},

--- a/internal/engine/restart_integration_test.go
+++ b/internal/engine/restart_integration_test.go
@@ -51,6 +51,7 @@ func TestIntegrationRestartSimple(t *testing.T) {
 	_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
 	t.Cleanup(func() {
 		_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
+		cleanupWorkspaceImages(t, d, wsID)
 	})
 
 	// Initial Up — runs all hooks.
@@ -147,6 +148,7 @@ func TestIntegrationRestartSafeChange(t *testing.T) {
 	_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
 	t.Cleanup(func() {
 		_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
+		cleanupWorkspaceImages(t, d, wsID)
 	})
 
 	// Initial Up.
@@ -257,6 +259,7 @@ func TestIntegrationRestartNeedsRebuild(t *testing.T) {
 	_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
 	t.Cleanup(func() {
 		_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
+		cleanupWorkspaceImages(t, d, wsID)
 	})
 
 	// Initial Up.
@@ -369,6 +372,7 @@ func TestIntegrationRestartMountChange(t *testing.T) {
 	_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
 	t.Cleanup(func() {
 		_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
+		cleanupWorkspaceImages(t, d, wsID)
 	})
 
 	// Initial Up without the extra mount.

--- a/internal/engine/setup_test.go
+++ b/internal/engine/setup_test.go
@@ -133,6 +133,45 @@ func (m *mockDriver) RemoveVolume(ctx context.Context, name string) error {
 	return nil
 }
 
+// imageTrackingDriver extends mockDriver to track RemoveImage and ListImages
+// calls. Used by build, remove, and prune tests.
+type imageTrackingDriver struct {
+	mockDriver
+	removedImages []string
+	removeErr     error              // single error for all removals
+	removeErrs    map[string]error   // per-image errors (overrides removeErr)
+	images        []driver.ImageInfo // images returned by ListImages
+	listErr       error
+}
+
+func (m *imageTrackingDriver) RemoveImage(ctx context.Context, imageName string) error {
+	m.removedImages = append(m.removedImages, imageName)
+	if m.removeErrs != nil {
+		if err, ok := m.removeErrs[imageName]; ok {
+			return err
+		}
+	}
+	return m.removeErr
+}
+
+func (m *imageTrackingDriver) ListImages(ctx context.Context, label string) ([]driver.ImageInfo, error) {
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
+	// Simulate label filtering: if label contains "=", filter by workspace ID.
+	var filtered []driver.ImageInfo
+	for _, img := range m.images {
+		if strings.Contains(label, "=") {
+			wsID := strings.SplitN(label, "=", 2)[1]
+			if img.WorkspaceID != wsID {
+				continue
+			}
+		}
+		filtered = append(filtered, img)
+	}
+	return filtered, nil
+}
+
 func TestParseEnvLines(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
## Summary

Completes the image pruning feature by wiring the engine methods (already on main) to CLI commands and adding test cleanup to prevent image accumulation.

- `crib remove` now shows what will be deleted and prompts for confirmation (`--force` to skip)
- New `crib prune` command for removing stale/orphan images (`--all`, `--force`)
- Integration and e2e tests clean up workspace images in teardown

## Changes

- **`cmd/remove.go`** - Add `PreviewRemove()` showing container, images, and state before prompting. `--force`/`-f` flag to skip.
- **`cmd/prune.go`** - New command: dry-run preview with sizes, confirmation prompt, then actual removal. `--all` for global, `--force` to skip prompt.
- **`cmd/exec.go`** - Extract shared `confirmPrompt()` helper (replaces duplicate logic in remove, prune, cache).
- **`internal/engine/engine.go`** - `PreviewRemove()`, `cleanupWorkspaceImages()` called from `Remove()`.
- **Integration tests** - `cleanupWorkspaceImages` helper wired into all teardown blocks.
- **E2e tests** - All `crib rm`/`crib remove` calls pass `--force`. Remove now-unnecessary `removeSnapshotImages` helper.
- **Test mocks** - Consolidate `buildMockDriver`, `removeMockDriver`, `pruneMockDriver` into single `imageTrackingDriver`.

## Manual testing

```bash
# Build
make build

# Test remove confirmation
cd /path/to/project/with/devcontainer
crib up
crib remove        # should show preview + prompt
# answer N, verify nothing removed
crib remove -f     # should skip prompt and remove

# Test prune
crib up
# rebuild a couple times to create stale images
crib rebuild
crib rebuild
crib prune         # should list stale images + prompt
crib prune --force # should remove without prompt
crib prune --all   # should include orphan images from other workspaces
```