### PR TITLE
feat(sandbox): auto-detect git worktrees, add hideFiles config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `aliases`: transparent wrappers that run agent commands through the sandbox
   - Auto-detection of git worktrees: sibling worktree directories are added
     as writable paths so sandboxed agents can operate on worktree checkouts
+  - `hideFiles`: mask individual files with `/dev/null` so the agent sees
+    empty content (for standalone secret files that the app doesn't need at
+    runtime)
   - Graceful degradation: network failures don't prevent filesystem sandboxing
 - **Plugin system**: `PostContainerCreator` interface for plugins that run commands
   inside containers after creation. `PostContainerCreateEnabler` companion interface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `blockLocalNetwork`: blocks RFC 1918, cloud metadata endpoints, and other
     private ranges via iptables OUTPUT chain rules
   - `aliases`: transparent wrappers that run agent commands through the sandbox
+  - Auto-detection of git worktrees: sibling worktree directories are added
+    as writable paths so sandboxed agents can operate on worktree checkouts
   - Graceful degradation: network failures don't prevent filesystem sandboxing
 - **Plugin system**: `PostContainerCreator` interface for plugins that run commands
   inside containers after creation. `PostContainerCreateEnabler` companion interface

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -50,6 +50,7 @@ The sandbox makes the entire filesystem read-only, then selectively opens up wri
 |------|--------|-----|
 | `/` (everything) | read-only | Default for all paths not listed below |
 | `workspaceFolder` | read-write | The agent needs to edit project files |
+| git worktree dirs | read-write | Auto-detected sibling worktree directories |
 | `/tmp` | read-write | Scratch space for temp files |
 | `~/.crib_history/` | deny-read | May contain credentials (`export TOKEN=...`) |
 | `~/.ssh/` | deny-read | Injected by the ssh plugin, contains host info |
@@ -143,6 +144,18 @@ The sandbox plugin automatically scans `~/.crib/workspaces/{id}/plugins/*/` to d
 | `shell-history` | `~/.crib_history/` | deny-read |
 
 User-specified `denyRead`/`denyWrite`/`allowWrite` in the config are merged on top of these defaults.
+
+### Git worktree detection
+
+If your workflow uses [git worktrees](https://git-scm.com/docs/git-worktree), the sandbox automatically detects them. At container setup time, the plugin runs `git worktree list` inside the container. When worktrees exist outside the workspace folder (the common pattern with sibling directories like `/workspaces/project-worktrees/`), the plugin adds their parent directory as a writable path.
+
+This means a sandboxed agent can read and write to worktree checkouts without any manual configuration. The detection is logged at debug level:
+
+```
+sandbox: auto-detected git worktree directory  path=/workspaces/project-worktrees
+```
+
+If git is not installed or the workspace is not a git repository, detection is silently skipped. You can always add writable paths manually via `allowWrite` if needed.
 
 ### SSH agent socket
 

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -265,7 +265,7 @@ What the sandbox enforces regardless of Claude's permission settings:
 | Concern | What the sandbox does |
 |---------|----------------------|
 | Filesystem writes | Limited to workspace folder, worktree dirs, and `/tmp` |
-| Credential files | `~/.ssh/`, `~/.claude/`, `~/.crib_history/` hidden from the agent |
+| Credential files | `~/.ssh/` and `~/.crib_history/` hidden; `~/.claude/` read-only (agent needs its own config) |
 | Network | Local network and cloud metadata endpoints blocked (when `blockLocalNetwork` is on) |
 | SSH keys | Agent can use keys for signing (git push) but cannot read private key material |
 

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -83,9 +83,10 @@ All options go under `customizations.crib.sandbox` in `devcontainer.json`:
       "sandbox": {
         // Filesystem restrictions.
         // workspaceFolder and /tmp are always writable.
-        "denyRead": [],              // extra paths to block reads on
-        "denyWrite": [],             // extra paths to block writes on
+        "denyRead": [],              // extra directory paths to block reads on
+        "denyWrite": [],             // extra directory paths to block writes on
         "allowWrite": [],            // extra writable paths beyond workspace + /tmp
+        "hideFiles": [],             // individual files to mask (relative to workspace)
 
         // Network restrictions.
         "blockLocalNetwork": true,   // block RFC 1918 + metadata endpoints
@@ -100,12 +101,24 @@ All options go under `customizations.crib.sandbox` in `devcontainer.json`:
 
 ### Path syntax
 
-Paths in `denyRead`, `denyWrite`, and `allowWrite` must be **directories** (bubblewrap's `--tmpfs` and `--bind` operate on mount points, not individual files). To deny access to a specific file, deny the parent directory.
+Paths in `denyRead`, `denyWrite`, and `allowWrite` must be **directories** (bubblewrap's `--tmpfs` and `--bind` operate on mount points, not individual files).
 
 | Prefix | Meaning | Example |
 |--------|---------|---------|
 | `~/` | Relative to container user's home | `~/.ssh` |
 | `/` | Absolute path inside the container | `/etc/secrets` |
+
+### Hiding individual files
+
+The `hideFiles` option masks specific files so the agent sees empty content when reading them. Paths are **relative to the workspace folder**:
+
+```jsonc
+"hideFiles": [".netrc", "secrets/api-key.txt"]
+```
+
+Under the hood, each listed file is replaced with `/dev/null` via `bwrap --ro-bind-try`. If the file doesn't exist, the entry is silently skipped.
+
+**Important tradeoff**: file hiding applies to the agent's entire process tree, including any child processes the agent spawns. If you hide `.env` or `config/master.key`, commands like `rails runner`, `rake`, or `bundle exec` that the agent runs will also be unable to read those files, breaking application boot. Use `hideFiles` only for files that no child process needs at runtime (standalone API key files, `.netrc`, token files, etc.). For files like `.env` that the application reads at startup, use agent-level restrictions (e.g. Claude Code's `permissions.deny` in [settings.json](https://docs.anthropic.com/en/docs/claude-code/settings)) instead.
 
 ### Aliases
 
@@ -217,6 +230,62 @@ Filesystem isolation plus network protection against metadata endpoint access an
 ```
 
 Blocks metadata endpoints and RFC 1918 ranges, SSH agent access, and writes to config directories. The agent can only write to the workspace and `/tmp`.
+
+## Running agents in autonomous mode
+
+The sandbox makes it safer to run coding agents with reduced permission prompts. By containing filesystem access and network reach at the OS level, you get a safety net that the agent cannot bypass, even when you relax the agent's own permission model.
+
+### Claude Code
+
+Claude Code's `--dangerously-skip-permissions` flag (sometimes called "yolo mode") disables all interactive permission prompts, letting the agent run commands and edit files without confirmation. Combining it with the crib sandbox gives you autonomous operation with OS-level guardrails:
+
+```jsonc
+// devcontainer.json
+{
+  "customizations": {
+    "crib": {
+      "sandbox": {
+        "blockLocalNetwork": true,
+        "aliases": ["claude"],
+        "denyWrite": ["~/.config", "~/.local"]
+      }
+    }
+  }
+}
+```
+
+Then run Claude Code in autonomous mode:
+
+```bash
+crib run claude --dangerously-skip-permissions
+```
+
+What the sandbox enforces regardless of Claude's permission settings:
+
+| Concern | What the sandbox does |
+|---------|----------------------|
+| Filesystem writes | Limited to workspace folder, worktree dirs, and `/tmp` |
+| Credential files | `~/.ssh/`, `~/.claude/`, `~/.crib_history/` hidden from the agent |
+| Network | Local network and cloud metadata endpoints blocked (when `blockLocalNetwork` is on) |
+| SSH keys | Agent can use keys for signing (git push) but cannot read private key material |
+
+What the sandbox does **not** cover:
+
+- **Reading project files**: the agent can read everything in the workspace, including `.env`, `config/master.key`, and other secrets checked into (or gitignored within) the project. Use the agent's own `permissions.deny` settings to restrict reads on specific files.
+- **Git operations**: the agent can commit, push, and create branches. It has full git access to the repository.
+- **External API calls**: outbound internet traffic (except local network) is allowed. The agent can call any public API.
+- **Process spawning**: the agent can run any command available in the container, subject to the filesystem restrictions above.
+
+### Other agents
+
+The same pattern works with any agent that supports unattended operation. Run it through the sandbox alias:
+
+```bash
+crib run pi --dangerously-skip-permissions
+crib run aider --yes  # aider's equivalent flag
+```
+
+The sandbox restrictions are agent-agnostic. They apply to whatever process the wrapper launches.
 
 ## Limitations
 

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -54,7 +54,7 @@ The sandbox makes the entire filesystem read-only, then selectively opens up wri
 | `/tmp` | read-write | Scratch space for temp files |
 | `~/.crib_history/` | deny-read | May contain credentials (`export TOKEN=...`) |
 | `~/.ssh/` | deny-read | Injected by the ssh plugin, contains host info |
-| `~/.claude/` | deny-read | Injected by the `coding-agents` plugin |
+| `~/.claude/` | read-only | Claude Code needs to read its own config to authenticate |
 
 The sandbox automatically discovers what other `crib` plugins have injected and applies appropriate restrictions. You don't need to manually list credential paths.
 
@@ -151,7 +151,7 @@ The sandbox plugin automatically scans `~/.crib/workspaces/{id}/plugins/*/` to d
 
 | Plugin | What it injected | Sandbox rule |
 |--------|-----------------|--------------|
-| `coding-agents` | `~/.claude/` | deny-read |
+| `coding-agents` | `~/.claude/` | read-only (agent needs its own config) |
 | `ssh` | `~/.ssh/` | deny-read |
 | `ssh` | `/tmp/ssh-agent.sock` | allowed (see below) |
 | `shell-history` | `~/.crib_history/` | deny-read |

--- a/internal/plugin/sandbox/config.go
+++ b/internal/plugin/sandbox/config.go
@@ -6,6 +6,7 @@ type sandboxConfig struct {
 	DenyRead          []string // extra paths to deny reads on
 	DenyWrite         []string // extra paths to deny writes on
 	AllowWrite        []string // extra writable paths beyond workspace + /tmp
+	HideFiles         []string // extra files to mask (relative to workspace folder)
 	BlockLocalNetwork bool
 	Aliases           []string // agent commands to wrap (e.g. "claude", "pi")
 }
@@ -30,6 +31,7 @@ func parseConfig(customizations map[string]any) *sandboxConfig {
 	cfg.DenyRead = toStringSlice(m["denyRead"])
 	cfg.DenyWrite = toStringSlice(m["denyWrite"])
 	cfg.AllowWrite = toStringSlice(m["allowWrite"])
+	cfg.HideFiles = toStringSlice(m["hideFiles"])
 	cfg.Aliases = toStringSlice(m["aliases"])
 
 	if v, ok := m["blockLocalNetwork"].(bool); ok {

--- a/internal/plugin/sandbox/config_test.go
+++ b/internal/plugin/sandbox/config_test.go
@@ -41,6 +41,7 @@ func TestParseConfig_Full(t *testing.T) {
 			"denyRead":          []any{"~/.ssh/config"},
 			"denyWrite":         []any{"~/.ssh", "~/.claude"},
 			"allowWrite":        []any{"/var/log"},
+			"hideFiles":         []any{".env.staging", "config/secrets.yml"},
 			"blockLocalNetwork": true,
 			"aliases":           []any{"claude", "pi", "aider"},
 		},
@@ -59,6 +60,9 @@ func TestParseConfig_Full(t *testing.T) {
 	}
 	if len(cfg.AllowWrite) != 1 || cfg.AllowWrite[0] != "/var/log" {
 		t.Errorf("unexpected allowWrite: %v", cfg.AllowWrite)
+	}
+	if len(cfg.HideFiles) != 2 || cfg.HideFiles[0] != ".env.staging" {
+		t.Errorf("unexpected hideFiles: %v", cfg.HideFiles)
 	}
 	if len(cfg.Aliases) != 3 {
 		t.Errorf("expected 3 aliases, got %d", len(cfg.Aliases))

--- a/internal/plugin/sandbox/discover.go
+++ b/internal/plugin/sandbox/discover.go
@@ -21,11 +21,14 @@ func discoverPluginArtifacts(workspaceDir, remoteUser string) []denyRule {
 
 	pluginsDir := filepath.Join(workspaceDir, "plugins")
 
-	// coding-agents: ~/.claude/.credentials.json
+	// coding-agents: ~/.claude/ (read-only, not hidden).
+	// Claude Code needs to read its own credentials to authenticate API calls.
+	// Deny-write prevents a compromised agent from tampering with settings or
+	// credentials, while still allowing the binary to function.
 	if dirExists(filepath.Join(pluginsDir, "coding-agents")) {
 		rules = append(rules, denyRule{
 			Path:     filepath.Join(remoteHome, ".claude"),
-			DenyRead: true,
+			DenyRead: false,
 		})
 	}
 

--- a/internal/plugin/sandbox/discover_test.go
+++ b/internal/plugin/sandbox/discover_test.go
@@ -27,8 +27,8 @@ func TestDiscoverPluginArtifacts_AllPlugins(t *testing.T) {
 		t.Fatalf("expected 3 rules, got %d", len(rules))
 	}
 
-	// codingagents -> ~/.claude
-	if rules[0].Path != "/home/vscode/.claude" || !rules[0].DenyRead {
+	// codingagents -> ~/.claude (deny-write, not deny-read: agent needs to read its own config)
+	if rules[0].Path != "/home/vscode/.claude" || rules[0].DenyRead {
 		t.Errorf("unexpected codingagents rule: %+v", rules[0])
 	}
 

--- a/internal/plugin/sandbox/discover_test.go
+++ b/internal/plugin/sandbox/discover_test.go
@@ -27,9 +27,9 @@ func TestDiscoverPluginArtifacts_AllPlugins(t *testing.T) {
 		t.Fatalf("expected 3 rules, got %d", len(rules))
 	}
 
-	// codingagents -> ~/.claude (deny-write, not deny-read: agent needs to read its own config)
+	// coding-agents -> ~/.claude (deny-write, not deny-read: agent needs to read its own config)
 	if rules[0].Path != "/home/vscode/.claude" || rules[0].DenyRead {
-		t.Errorf("unexpected codingagents rule: %+v", rules[0])
+		t.Errorf("unexpected coding-agents rule: %+v", rules[0])
 	}
 
 	// ssh -> ~/.ssh

--- a/internal/plugin/sandbox/postcreate.go
+++ b/internal/plugin/sandbox/postcreate.go
@@ -59,15 +59,24 @@ func (p *Plugin) PostContainerCreate(ctx context.Context, req *plugin.PostContai
 	for _, rel := range cfg.HideFiles {
 		abs := req.WorkspaceFolder + "/" + rel
 		pol.HiddenFiles = append(pol.HiddenFiles, abs)
-		slog.Info("sandbox: hiding file", "path", abs)
+		slog.Debug("sandbox: hiding file", "path", abs)
 	}
 
 	// 3c. Auto-detect git worktrees and add their base dirs as writable.
 	// Non-fatal: git may not be installed or workspace may not be a repo.
+	// Deduplicate against existing AllowWritePaths (user may have configured
+	// the same path via allowWrite in devcontainer.json).
 	wtDirs := detectWorktreeWritePaths(ctx, req)
+	existing := make(map[string]struct{}, len(pol.AllowWritePaths))
+	for _, p := range pol.AllowWritePaths {
+		existing[p] = struct{}{}
+	}
 	for _, d := range wtDirs {
+		if _, dup := existing[d]; dup {
+			continue
+		}
 		pol.AllowWritePaths = append(pol.AllowWritePaths, d)
-		slog.Info("sandbox: auto-detected git worktree directory", "path", d)
+		slog.Debug("sandbox: auto-detected git worktree directory", "path", d)
 	}
 
 	// 4. Generate and write the sandbox wrapper script.

--- a/internal/plugin/sandbox/postcreate.go
+++ b/internal/plugin/sandbox/postcreate.go
@@ -3,6 +3,7 @@ package sandbox
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"regexp"
 	"strings"
 
@@ -54,6 +55,14 @@ func (p *Plugin) PostContainerCreate(ctx context.Context, req *plugin.PostContai
 	// 3. Build the sandbox policy.
 	pol := buildPolicy(cfg, req.WorkspaceDir, req.RemoteUser, req.WorkspaceFolder)
 
+	// 3b. Auto-detect git worktrees and add their base dirs as writable.
+	// Non-fatal: git may not be installed or workspace may not be a repo.
+	wtDirs := detectWorktreeWritePaths(ctx, req)
+	for _, d := range wtDirs {
+		pol.AllowWritePaths = append(pol.AllowWritePaths, d)
+		slog.Info("sandbox: auto-detected git worktree directory", "path", d)
+	}
+
 	// 4. Generate and write the sandbox wrapper script.
 	sandboxPath := localBin + "/sandbox"
 	wrapperContent := generateWrapperScript(pol)
@@ -102,6 +111,21 @@ func execScriptViaFile(ctx context.Context, req *plugin.PostContainerCreateReque
 	execErr := req.ExecFunc(ctx, []string{"sh", tmpScript}, "root")
 	_ = req.ExecFunc(ctx, []string{"rm", "-f", tmpScript}, "root")
 	return execErr
+}
+
+// detectWorktreeWritePaths runs `git worktree list --porcelain` inside the
+// container and returns directories that need write access for worktree
+// checkouts. Returns nil when no external worktrees are found or when git
+// is unavailable.
+func detectWorktreeWritePaths(ctx context.Context, req *plugin.PostContainerCreateRequest) []string {
+	out, err := req.ExecOutputFunc(ctx, []string{
+		"git", "-C", req.WorkspaceFolder, "worktree", "list", "--porcelain",
+	}, req.RemoteUser)
+	if err != nil {
+		return nil
+	}
+	paths := parseWorktreePaths(out)
+	return worktreeBaseDirs(paths, req.WorkspaceFolder)
 }
 
 // resolveRealBinary finds the real path of a binary inside the container,

--- a/internal/plugin/sandbox/postcreate.go
+++ b/internal/plugin/sandbox/postcreate.go
@@ -79,10 +79,10 @@ func (p *Plugin) PostContainerCreate(ctx context.Context, req *plugin.PostContai
 	wtDirs := detectWorktreeWritePaths(ctx, req)
 	existing := make(map[string]struct{}, len(pol.AllowWritePaths))
 	for _, p := range pol.AllowWritePaths {
-		existing[p] = struct{}{}
+		existing[filepath.Clean(p)] = struct{}{}
 	}
 	for _, d := range wtDirs {
-		if _, dup := existing[d]; dup {
+		if _, dup := existing[filepath.Clean(d)]; dup {
 			continue
 		}
 		pol.AllowWritePaths = append(pol.AllowWritePaths, d)
@@ -164,8 +164,12 @@ func resolveRealBinary(ctx context.Context, req *plugin.PostContainerCreateReque
 	// creates ~/.local/bin/claude as a symlink to ~/.local/share/claude/...,
 	// so readlink -f gives us the real binary path that won't self-reference
 	// when we overwrite the symlink with our alias wrapper.
+	//
+	// Filter excludeDir from PATH so that a wrapper from a previous run
+	// doesn't shadow the real binary, keeping alias updates deterministic.
 	resolveCmd := fmt.Sprintf(
-		"p=$(command -v '%s' 2>/dev/null) && readlink -f \"$p\" || true", name)
+		"p=$(PATH=$(echo \"$PATH\" | tr ':' '\\n' | grep -Fxv '%s' | tr '\\n' ':') command -v '%s' 2>/dev/null) && readlink -f \"$p\" || true",
+		excludeDir, name)
 	result, err := req.ExecOutputFunc(ctx, []string{"sh", "-c", resolveCmd}, user)
 	if err != nil {
 		return "", err

--- a/internal/plugin/sandbox/postcreate.go
+++ b/internal/plugin/sandbox/postcreate.go
@@ -55,7 +55,14 @@ func (p *Plugin) PostContainerCreate(ctx context.Context, req *plugin.PostContai
 	// 3. Build the sandbox policy.
 	pol := buildPolicy(cfg, req.WorkspaceDir, req.RemoteUser, req.WorkspaceFolder)
 
-	// 3b. Auto-detect git worktrees and add their base dirs as writable.
+	// 3b. Apply user-configured hideFiles (paths relative to workspace folder).
+	for _, rel := range cfg.HideFiles {
+		abs := req.WorkspaceFolder + "/" + rel
+		pol.HiddenFiles = append(pol.HiddenFiles, abs)
+		slog.Info("sandbox: hiding file", "path", abs)
+	}
+
+	// 3c. Auto-detect git worktrees and add their base dirs as writable.
 	// Non-fatal: git may not be installed or workspace may not be a repo.
 	wtDirs := detectWorktreeWritePaths(ctx, req)
 	for _, d := range wtDirs {

--- a/internal/plugin/sandbox/postcreate.go
+++ b/internal/plugin/sandbox/postcreate.go
@@ -155,16 +155,29 @@ func detectWorktreeWritePaths(ctx context.Context, req *plugin.PostContainerCrea
 }
 
 // resolveRealBinary finds the real path of a binary inside the container,
-// excluding ~/.local/bin to avoid self-reference from our generated aliases.
+// following symlinks to get the canonical path. If the canonical path lands
+// inside excludeDir (e.g. our own alias from a previous run), returns empty.
 // Runs as the specified user so the lookup sees the user's PATH.
 func resolveRealBinary(ctx context.Context, req *plugin.PostContainerCreateRequest, name, excludeDir, user string) (string, error) {
+	// Resolve the binary and follow symlinks. Claude Code's native installer
+	// creates ~/.local/bin/claude as a symlink to ~/.local/share/claude/...,
+	// so readlink -f gives us the real binary path that won't self-reference
+	// when we overwrite the symlink with our alias wrapper.
 	resolveCmd := fmt.Sprintf(
-		"PATH=$(echo \"$PATH\" | tr ':' '\\n' | grep -v -x -F '%s' | paste -sd ':') "+
-			"command -v '%s' 2>/dev/null || true",
-		plugin.ShellQuote(excludeDir), name)
+		"p=$(command -v '%s' 2>/dev/null) && readlink -f \"$p\" || true", name)
 	result, err := req.ExecOutputFunc(ctx, []string{"sh", "-c", resolveCmd}, user)
 	if err != nil {
 		return "", err
 	}
-	return strings.TrimSpace(result), nil
+	resolved := strings.TrimSpace(result)
+	if resolved == "" {
+		return "", nil
+	}
+	// If the resolved path is still inside the alias directory, it is our own
+	// generated script from a previous run (not a symlink). Skip to avoid
+	// self-reference.
+	if strings.HasPrefix(resolved, excludeDir+"/") {
+		return "", nil
+	}
+	return resolved, nil
 }

--- a/internal/plugin/sandbox/postcreate.go
+++ b/internal/plugin/sandbox/postcreate.go
@@ -168,8 +168,8 @@ func resolveRealBinary(ctx context.Context, req *plugin.PostContainerCreateReque
 	// Filter excludeDir from PATH so that a wrapper from a previous run
 	// doesn't shadow the real binary, keeping alias updates deterministic.
 	resolveCmd := fmt.Sprintf(
-		"p=$(PATH=$(echo \"$PATH\" | tr ':' '\\n' | grep -Fxv '%s' | tr '\\n' ':') command -v '%s' 2>/dev/null) && readlink -f \"$p\" || true",
-		excludeDir, name)
+		"p=$(PATH=$(echo \"$PATH\" | tr ':' '\\n' | grep -Fxv '%s' | paste -sd ':') command -v '%s' 2>/dev/null) && readlink -f \"$p\" || true",
+		plugin.ShellQuote(excludeDir), plugin.ShellQuote(name))
 	result, err := req.ExecOutputFunc(ctx, []string{"sh", "-c", resolveCmd}, user)
 	if err != nil {
 		return "", err

--- a/internal/plugin/sandbox/postcreate.go
+++ b/internal/plugin/sandbox/postcreate.go
@@ -122,6 +122,7 @@ func detectWorktreeWritePaths(ctx context.Context, req *plugin.PostContainerCrea
 		"git", "-C", req.WorkspaceFolder, "worktree", "list", "--porcelain",
 	}, req.RemoteUser)
 	if err != nil {
+		slog.Debug("sandbox: git worktree detection skipped", "error", err)
 		return nil
 	}
 	paths := parseWorktreePaths(out)

--- a/internal/plugin/sandbox/postcreate.go
+++ b/internal/plugin/sandbox/postcreate.go
@@ -63,6 +63,10 @@ func (p *Plugin) PostContainerCreate(ctx context.Context, req *plugin.PostContai
 		if rel == "" || rel == "." {
 			continue
 		}
+		if filepath.IsAbs(rel) {
+			slog.Debug("sandbox: hideFiles entry must be relative, skipping", "path", rel)
+			continue
+		}
 		abs := filepath.Clean(filepath.Join(wsFolder, rel))
 		if !strings.HasPrefix(abs, wsFolder+"/") {
 			slog.Debug("sandbox: hideFiles path escapes workspace, skipping", "path", rel)
@@ -168,7 +172,7 @@ func resolveRealBinary(ctx context.Context, req *plugin.PostContainerCreateReque
 	// Filter excludeDir from PATH so that a wrapper from a previous run
 	// doesn't shadow the real binary, keeping alias updates deterministic.
 	resolveCmd := fmt.Sprintf(
-		"p=$(PATH=$(echo \"$PATH\" | tr ':' '\\n' | grep -Fxv '%s' | paste -sd ':') command -v '%s' 2>/dev/null) && readlink -f \"$p\" || true",
+		"p=$(PATH=$(echo \"$PATH\" | tr ':' '\\n' | grep -Fxv '%s' | paste -sd ':') command -v '%s' 2>/dev/null) && { readlink -f \"$p\" 2>/dev/null || echo \"$p\"; } || true",
 		plugin.ShellQuote(excludeDir), plugin.ShellQuote(name))
 	result, err := req.ExecOutputFunc(ctx, []string{"sh", "-c", resolveCmd}, user)
 	if err != nil {

--- a/internal/plugin/sandbox/postcreate.go
+++ b/internal/plugin/sandbox/postcreate.go
@@ -58,12 +58,13 @@ func (p *Plugin) PostContainerCreate(ctx context.Context, req *plugin.PostContai
 
 	// 3b. Apply user-configured hideFiles (paths relative to workspace folder).
 	// Validate that resolved paths stay within the workspace.
+	wsFolder := filepath.Clean(req.WorkspaceFolder)
 	for _, rel := range cfg.HideFiles {
 		if rel == "" || rel == "." {
 			continue
 		}
-		abs := filepath.Clean(filepath.Join(req.WorkspaceFolder, rel))
-		if !strings.HasPrefix(abs, req.WorkspaceFolder+"/") {
+		abs := filepath.Clean(filepath.Join(wsFolder, rel))
+		if !strings.HasPrefix(abs, wsFolder+"/") {
 			slog.Debug("sandbox: hideFiles path escapes workspace, skipping", "path", rel)
 			continue
 		}

--- a/internal/plugin/sandbox/postcreate.go
+++ b/internal/plugin/sandbox/postcreate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -56,8 +57,16 @@ func (p *Plugin) PostContainerCreate(ctx context.Context, req *plugin.PostContai
 	pol := buildPolicy(cfg, req.WorkspaceDir, req.RemoteUser, req.WorkspaceFolder)
 
 	// 3b. Apply user-configured hideFiles (paths relative to workspace folder).
+	// Validate that resolved paths stay within the workspace.
 	for _, rel := range cfg.HideFiles {
-		abs := req.WorkspaceFolder + "/" + rel
+		if rel == "" || rel == "." {
+			continue
+		}
+		abs := filepath.Clean(filepath.Join(req.WorkspaceFolder, rel))
+		if !strings.HasPrefix(abs, req.WorkspaceFolder+"/") {
+			slog.Debug("sandbox: hideFiles path escapes workspace, skipping", "path", rel)
+			continue
+		}
 		pol.HiddenFiles = append(pol.HiddenFiles, abs)
 		slog.Debug("sandbox: hiding file", "path", abs)
 	}

--- a/internal/plugin/sandbox/postcreate_test.go
+++ b/internal/plugin/sandbox/postcreate_test.go
@@ -194,6 +194,62 @@ func TestPostContainerCreate_HideFilesConfig(t *testing.T) {
 	}
 }
 
+func TestPostContainerCreate_HideFilesPathTraversal(t *testing.T) {
+	wsDir := t.TempDir()
+	copiedFiles := map[string]string{}
+
+	p := New()
+	req := &plugin.PostContainerCreateRequest{
+		WorkspaceID:     "test-ws",
+		WorkspaceDir:    wsDir,
+		ContainerID:     "abc123",
+		RemoteUser:      "vscode",
+		WorkspaceFolder: "/workspaces/project",
+		Runtime:         "docker",
+		Customizations: map[string]any{
+			"sandbox": map[string]any{
+				"hideFiles": []any{
+					"legit.txt",
+					"../../etc/passwd",
+					"../escape",
+					".",
+					"",
+					"sub/../../../outside",
+				},
+			},
+		},
+		ExecFunc: func(_ context.Context, _ []string, _ string) error {
+			return nil
+		},
+		ExecOutputFunc: func(_ context.Context, _ []string, _ string) (string, error) {
+			return "", nil
+		},
+		CopyFileFunc: func(_ context.Context, content []byte, dest, _, _ string) error {
+			copiedFiles[dest] = string(content)
+			return nil
+		},
+	}
+
+	if err := p.PostContainerCreate(context.Background(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wrapper, ok := copiedFiles["/home/vscode/.local/bin/sandbox"]
+	if !ok {
+		t.Fatal("expected sandbox wrapper to be copied")
+	}
+	// Only legit.txt should be hidden.
+	if !strings.Contains(wrapper, "--ro-bind-try /dev/null '/workspaces/project/legit.txt'") {
+		t.Errorf("sandbox wrapper should hide legit.txt, got:\n%s", wrapper)
+	}
+	// Traversal paths must be rejected.
+	for _, bad := range []string{"etc/passwd", "../escape", "outside"} {
+		if strings.Contains(wrapper, bad) {
+			t.Errorf("sandbox wrapper should not contain path-traversal entry %q, got:\n%s", bad, wrapper)
+		}
+	}
+}
+
 func TestPostContainerCreate_WorktreeAutoDetection(t *testing.T) {
 	wsDir := t.TempDir()
 	copiedFiles := map[string]string{}

--- a/internal/plugin/sandbox/postcreate_test.go
+++ b/internal/plugin/sandbox/postcreate_test.go
@@ -149,6 +149,51 @@ func TestPostContainerCreate_WithAliases(t *testing.T) {
 	}
 }
 
+func TestPostContainerCreate_HideFilesConfig(t *testing.T) {
+	wsDir := t.TempDir()
+	copiedFiles := map[string]string{}
+
+	p := New()
+	req := &plugin.PostContainerCreateRequest{
+		WorkspaceID:     "test-ws",
+		WorkspaceDir:    wsDir,
+		ContainerID:     "abc123",
+		RemoteUser:      "vscode",
+		WorkspaceFolder: "/workspaces/project",
+		Runtime:         "docker",
+		Customizations: map[string]any{
+			"sandbox": map[string]any{
+				"hideFiles": []any{".env.staging", "config/secrets.yml"},
+			},
+		},
+		ExecFunc: func(_ context.Context, _ []string, _ string) error {
+			return nil
+		},
+		ExecOutputFunc: func(_ context.Context, _ []string, _ string) (string, error) {
+			return "", nil // no auto-detected files
+		},
+		CopyFileFunc: func(_ context.Context, content []byte, dest, _, _ string) error {
+			copiedFiles[dest] = string(content)
+			return nil
+		},
+	}
+
+	if err := p.PostContainerCreate(context.Background(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wrapper, ok := copiedFiles["/home/vscode/.local/bin/sandbox"]
+	if !ok {
+		t.Fatal("expected sandbox wrapper to be copied")
+	}
+	if !strings.Contains(wrapper, "--ro-bind-try /dev/null '/workspaces/project/.env.staging'") {
+		t.Errorf("sandbox wrapper should hide user-configured .env.staging, got:\n%s", wrapper)
+	}
+	if !strings.Contains(wrapper, "--ro-bind-try /dev/null '/workspaces/project/config/secrets.yml'") {
+		t.Errorf("sandbox wrapper should hide user-configured config/secrets.yml, got:\n%s", wrapper)
+	}
+}
+
 func TestPostContainerCreate_WorktreeAutoDetection(t *testing.T) {
 	wsDir := t.TempDir()
 	copiedFiles := map[string]string{}

--- a/internal/plugin/sandbox/postcreate_test.go
+++ b/internal/plugin/sandbox/postcreate_test.go
@@ -118,9 +118,10 @@ func TestPostContainerCreate_WithAliases(t *testing.T) {
 			if len(cmd) > 2 {
 				cmdStr = cmd[2]
 			}
-			// Simulate: claude exists at /usr/local/bin/claude, missing-tool does not.
-			if strings.Contains(cmdStr, "claude") {
-				return "/usr/local/bin/claude\n", nil
+			// Simulate: claude exists, readlink -f resolves the symlink.
+			// The resolve command is: p=$(command -v 'claude' ...) && readlink -f "$p"
+			if strings.Contains(cmdStr, "'claude'") {
+				return "/home/vscode/.local/share/claude/claude-v2\n", nil
 			}
 			return "", nil
 		},
@@ -367,7 +368,7 @@ func TestPostContainerCreate_InvalidAliasNamesSkipped(t *testing.T) {
 			return nil
 		},
 		ExecOutputFunc: func(_ context.Context, cmd []string, _ string) (string, error) {
-			if len(cmd) > 2 && strings.Contains(cmd[2], "valid-name") {
+			if len(cmd) > 2 && strings.Contains(cmd[2], "'valid-name'") {
 				return "/usr/bin/valid-name\n", nil
 			}
 			return "", nil

--- a/internal/plugin/sandbox/postcreate_test.go
+++ b/internal/plugin/sandbox/postcreate_test.go
@@ -2,6 +2,7 @@ package sandbox
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -145,6 +146,102 @@ func TestPostContainerCreate_WithAliases(t *testing.T) {
 	// missing-tool should not have an alias.
 	if _, ok := copiedFiles["/home/vscode/.local/bin/missing-tool"]; ok {
 		t.Error("missing-tool should not have an alias written")
+	}
+}
+
+func TestPostContainerCreate_WorktreeAutoDetection(t *testing.T) {
+	wsDir := t.TempDir()
+	copiedFiles := map[string]string{}
+
+	porcelainOutput := "worktree /workspaces/project\n" +
+		"HEAD abc123\n" +
+		"branch refs/heads/main\n" +
+		"\n" +
+		"worktree /workspaces/project-worktrees/feature-a\n" +
+		"HEAD def456\n" +
+		"branch refs/heads/feature-a\n" +
+		"\n"
+
+	p := New()
+	req := &plugin.PostContainerCreateRequest{
+		WorkspaceID:     "test-ws",
+		WorkspaceDir:    wsDir,
+		ContainerID:     "abc123",
+		RemoteUser:      "vscode",
+		WorkspaceFolder: "/workspaces/project",
+		Runtime:         "docker",
+		Customizations: map[string]any{
+			"sandbox": map[string]any{},
+		},
+		ExecFunc: func(_ context.Context, _ []string, _ string) error {
+			return nil
+		},
+		ExecOutputFunc: func(_ context.Context, cmd []string, _ string) (string, error) {
+			if len(cmd) >= 3 && cmd[0] == "git" && cmd[2] == "/workspaces/project" {
+				return porcelainOutput, nil
+			}
+			return "", nil
+		},
+		CopyFileFunc: func(_ context.Context, content []byte, dest, _, _ string) error {
+			copiedFiles[dest] = string(content)
+			return nil
+		},
+	}
+
+	if err := p.PostContainerCreate(context.Background(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wrapper, ok := copiedFiles["/home/vscode/.local/bin/sandbox"]
+	if !ok {
+		t.Fatal("expected sandbox wrapper to be copied")
+	}
+	if !strings.Contains(wrapper, "--bind-try '/workspaces/project-worktrees' '/workspaces/project-worktrees'") {
+		t.Errorf("sandbox wrapper should allow writes to worktree base dir, got:\n%s", wrapper)
+	}
+}
+
+func TestPostContainerCreate_WorktreeDetectionFailsGracefully(t *testing.T) {
+	wsDir := t.TempDir()
+	copiedFiles := map[string]string{}
+
+	p := New()
+	req := &plugin.PostContainerCreateRequest{
+		WorkspaceID:     "test-ws",
+		WorkspaceDir:    wsDir,
+		ContainerID:     "abc123",
+		RemoteUser:      "vscode",
+		WorkspaceFolder: "/workspaces/project",
+		Runtime:         "docker",
+		Customizations: map[string]any{
+			"sandbox": map[string]any{},
+		},
+		ExecFunc: func(_ context.Context, _ []string, _ string) error {
+			return nil
+		},
+		ExecOutputFunc: func(_ context.Context, cmd []string, _ string) (string, error) {
+			if len(cmd) >= 3 && cmd[0] == "git" {
+				return "", fmt.Errorf("git not found")
+			}
+			return "", nil
+		},
+		CopyFileFunc: func(_ context.Context, content []byte, dest, _, _ string) error {
+			copiedFiles[dest] = string(content)
+			return nil
+		},
+	}
+
+	if err := p.PostContainerCreate(context.Background(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should still generate wrapper without worktree paths.
+	wrapper, ok := copiedFiles["/home/vscode/.local/bin/sandbox"]
+	if !ok {
+		t.Fatal("expected sandbox wrapper to be copied even when git fails")
+	}
+	if strings.Contains(wrapper, "worktree") {
+		t.Errorf("wrapper should not reference worktrees when git fails, got:\n%s", wrapper)
 	}
 }
 

--- a/internal/plugin/sandbox/worktree.go
+++ b/internal/plugin/sandbox/worktree.go
@@ -2,6 +2,7 @@ package sandbox
 
 import (
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -66,5 +67,6 @@ func worktreeBaseDirs(worktreePaths []string, workspaceFolder string) []string {
 		}
 	}
 
+	sort.Strings(result)
 	return result
 }

--- a/internal/plugin/sandbox/worktree.go
+++ b/internal/plugin/sandbox/worktree.go
@@ -1,0 +1,70 @@
+package sandbox
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// parseWorktreePaths extracts worktree paths from `git worktree list --porcelain`
+// output. Each block starts with "worktree <path>".
+func parseWorktreePaths(porcelain string) []string {
+	var paths []string
+	for line := range strings.SplitSeq(porcelain, "\n") {
+		if after, ok := strings.CutPrefix(line, "worktree "); ok {
+			p := strings.TrimSpace(after)
+			if p != "" {
+				paths = append(paths, p)
+			}
+		}
+	}
+	return paths
+}
+
+// worktreeBaseDirs computes the unique parent directories of worktrees that
+// live outside the workspace folder. These directories need write access so
+// the sandboxed agent can operate on worktree checkouts.
+//
+// When one parent is a prefix of another, only the shorter (broader) path is
+// kept to avoid redundant bwrap --bind-try entries.
+func worktreeBaseDirs(worktreePaths []string, workspaceFolder string) []string {
+	wsClean := filepath.Clean(workspaceFolder)
+
+	// Collect parent dirs of worktrees that are outside the workspace folder.
+	parentSet := make(map[string]struct{})
+	for _, wt := range worktreePaths {
+		wt = filepath.Clean(wt)
+		if wt == wsClean {
+			continue // main worktree, already writable
+		}
+		if strings.HasPrefix(wt, wsClean+"/") {
+			continue // inside workspace folder, already writable
+		}
+		parentSet[filepath.Dir(wt)] = struct{}{}
+	}
+
+	if len(parentSet) == 0 {
+		return nil
+	}
+
+	// Collect unique parents, removing any that are subdirectories of another.
+	parents := make([]string, 0, len(parentSet))
+	for p := range parentSet {
+		parents = append(parents, p)
+	}
+
+	var result []string
+	for _, p := range parents {
+		covered := false
+		for _, other := range parents {
+			if other != p && strings.HasPrefix(p, other+"/") {
+				covered = true
+				break
+			}
+		}
+		if !covered {
+			result = append(result, p)
+		}
+	}
+
+	return result
+}

--- a/internal/plugin/sandbox/worktree.go
+++ b/internal/plugin/sandbox/worktree.go
@@ -40,7 +40,11 @@ func worktreeBaseDirs(worktreePaths []string, workspaceFolder string) []string {
 		if strings.HasPrefix(wt, wsClean+"/") {
 			continue // inside workspace folder, already writable
 		}
-		parentSet[filepath.Dir(wt)] = struct{}{}
+		parent := filepath.Dir(wt)
+		if parent == "/" {
+			continue // too broad; would make entire filesystem writable
+		}
+		parentSet[parent] = struct{}{}
 	}
 
 	if len(parentSet) == 0 {

--- a/internal/plugin/sandbox/worktree.go
+++ b/internal/plugin/sandbox/worktree.go
@@ -42,7 +42,10 @@ func worktreeBaseDirs(worktreePaths []string, workspaceFolder string) []string {
 		}
 		parent := filepath.Dir(wt)
 		if parent == "/" {
-			continue // too broad; would make entire filesystem writable
+			// Parent is root: adding "/" would make the entire filesystem
+			// writable. Grant write access to the worktree path itself instead.
+			parentSet[wt] = struct{}{}
+			continue
 		}
 		parentSet[parent] = struct{}{}
 	}

--- a/internal/plugin/sandbox/worktree_test.go
+++ b/internal/plugin/sandbox/worktree_test.go
@@ -121,6 +121,23 @@ func TestWorktreeBaseDirs_NestedParentsDeduped(t *testing.T) {
 	}
 }
 
+func TestWorktreeBaseDirs_RootLevelWorktree(t *testing.T) {
+	// Worktree directly under /: parent would be "/" which must not be added
+	// as a writable path (that would make the entire filesystem writable).
+	// The worktree path itself should be used instead.
+	paths := []string{
+		"/workspaces/project",
+		"/branch-x",
+	}
+	dirs := worktreeBaseDirs(paths, "/workspaces/project")
+	if len(dirs) != 1 {
+		t.Fatalf("expected 1 base dir, got %d: %v", len(dirs), dirs)
+	}
+	if dirs[0] != "/branch-x" {
+		t.Errorf("expected /branch-x (worktree path itself), got %s", dirs[0])
+	}
+}
+
 func TestWorktreeBaseDirs_Empty(t *testing.T) {
 	dirs := worktreeBaseDirs(nil, "/workspaces/project")
 	if len(dirs) != 0 {

--- a/internal/plugin/sandbox/worktree_test.go
+++ b/internal/plugin/sandbox/worktree_test.go
@@ -1,0 +1,131 @@
+package sandbox
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestParseWorktreePaths_MultipleWorktrees(t *testing.T) {
+	porcelain := `worktree /workspaces/web
+HEAD b9d421b1d
+branch refs/heads/main
+
+worktree /workspaces/web-worktrees/fr-pdf-kickoff
+HEAD aa308ae94
+branch refs/heads/fr-pdf-kickoff
+
+worktree /workspaces/web-worktrees/jt-3/9-bootstrap-optimizations
+HEAD d17ce1e0c
+branch refs/heads/jt-3/9-bootstrap-optimizations
+
+`
+	paths := parseWorktreePaths(porcelain)
+	if len(paths) != 3 {
+		t.Fatalf("expected 3 paths, got %d: %v", len(paths), paths)
+	}
+	if paths[0] != "/workspaces/web" {
+		t.Errorf("expected /workspaces/web, got %s", paths[0])
+	}
+	if paths[1] != "/workspaces/web-worktrees/fr-pdf-kickoff" {
+		t.Errorf("expected fr-pdf-kickoff worktree, got %s", paths[1])
+	}
+	if paths[2] != "/workspaces/web-worktrees/jt-3/9-bootstrap-optimizations" {
+		t.Errorf("expected nested worktree, got %s", paths[2])
+	}
+}
+
+func TestParseWorktreePaths_SingleWorktree(t *testing.T) {
+	porcelain := `worktree /workspaces/project
+HEAD abc123
+branch refs/heads/main
+
+`
+	paths := parseWorktreePaths(porcelain)
+	if len(paths) != 1 {
+		t.Fatalf("expected 1 path, got %d: %v", len(paths), paths)
+	}
+}
+
+func TestParseWorktreePaths_Empty(t *testing.T) {
+	paths := parseWorktreePaths("")
+	if len(paths) != 0 {
+		t.Errorf("expected 0 paths, got %d", len(paths))
+	}
+}
+
+func TestWorktreeBaseDirs_SiblingWorktrees(t *testing.T) {
+	paths := []string{
+		"/workspaces/web",
+		"/workspaces/web-worktrees/fr-pdf-kickoff",
+		"/workspaces/web-worktrees/visual-regression-pt-2",
+		"/workspaces/web-worktrees/jt-3/9-bootstrap-optimizations",
+	}
+	dirs := worktreeBaseDirs(paths, "/workspaces/web")
+	if len(dirs) != 1 {
+		t.Fatalf("expected 1 base dir, got %d: %v", len(dirs), dirs)
+	}
+	if dirs[0] != "/workspaces/web-worktrees" {
+		t.Errorf("expected /workspaces/web-worktrees, got %s", dirs[0])
+	}
+}
+
+func TestWorktreeBaseDirs_NoExternalWorktrees(t *testing.T) {
+	paths := []string{"/workspaces/project"}
+	dirs := worktreeBaseDirs(paths, "/workspaces/project")
+	if len(dirs) != 0 {
+		t.Errorf("expected 0 dirs for single worktree, got %d: %v", len(dirs), dirs)
+	}
+}
+
+func TestWorktreeBaseDirs_WorktreeInsideWorkspace(t *testing.T) {
+	paths := []string{
+		"/workspaces/project",
+		"/workspaces/project/.worktrees/branch-a",
+	}
+	dirs := worktreeBaseDirs(paths, "/workspaces/project")
+	if len(dirs) != 0 {
+		t.Errorf("expected 0 dirs for worktree inside workspace, got %d: %v", len(dirs), dirs)
+	}
+}
+
+func TestWorktreeBaseDirs_ScatteredWorktrees(t *testing.T) {
+	paths := []string{
+		"/workspaces/web",
+		"/workspaces/web-worktrees/branch-a",
+		"/other/place/branch-b",
+	}
+	dirs := worktreeBaseDirs(paths, "/workspaces/web")
+	sort.Strings(dirs)
+	if len(dirs) != 2 {
+		t.Fatalf("expected 2 base dirs, got %d: %v", len(dirs), dirs)
+	}
+	if dirs[0] != "/other/place" {
+		t.Errorf("expected /other/place, got %s", dirs[0])
+	}
+	if dirs[1] != "/workspaces/web-worktrees" {
+		t.Errorf("expected /workspaces/web-worktrees, got %s", dirs[1])
+	}
+}
+
+func TestWorktreeBaseDirs_NestedParentsDeduped(t *testing.T) {
+	// All worktrees under the same base, some nested deeper.
+	paths := []string{
+		"/workspaces/project",
+		"/workspaces/worktrees/branch-a",
+		"/workspaces/worktrees/sub/branch-b",
+	}
+	dirs := worktreeBaseDirs(paths, "/workspaces/project")
+	if len(dirs) != 1 {
+		t.Fatalf("expected 1 base dir after dedup, got %d: %v", len(dirs), dirs)
+	}
+	if dirs[0] != "/workspaces/worktrees" {
+		t.Errorf("expected /workspaces/worktrees, got %s", dirs[0])
+	}
+}
+
+func TestWorktreeBaseDirs_Empty(t *testing.T) {
+	dirs := worktreeBaseDirs(nil, "/workspaces/project")
+	if len(dirs) != 0 {
+		t.Errorf("expected 0 dirs, got %d", len(dirs))
+	}
+}

--- a/internal/plugin/sandbox/worktree_test.go
+++ b/internal/plugin/sandbox/worktree_test.go
@@ -1,7 +1,6 @@
 package sandbox
 
 import (
-	"sort"
 	"testing"
 )
 
@@ -95,7 +94,6 @@ func TestWorktreeBaseDirs_ScatteredWorktrees(t *testing.T) {
 		"/other/place/branch-b",
 	}
 	dirs := worktreeBaseDirs(paths, "/workspaces/web")
-	sort.Strings(dirs)
 	if len(dirs) != 2 {
 		t.Fatalf("expected 2 base dirs, got %d: %v", len(dirs), dirs)
 	}

--- a/internal/plugin/sandbox/wrapper.go
+++ b/internal/plugin/sandbox/wrapper.go
@@ -14,6 +14,7 @@ type policy struct {
 	RemoteHome      string
 	DenyPaths       []denyRule // from discovery + user config
 	AllowWritePaths []string   // extra writable paths from user config
+	HiddenFiles     []string   // individual files masked with /dev/null
 }
 
 // buildPolicy merges discovered plugin artifacts with user config into a
@@ -103,6 +104,13 @@ func generateWrapperScript(pol *policy) string {
 		} else {
 			fmt.Fprintf(&b, "  --ro-bind-try '%s' '%s' \\\n", ep, ep)
 		}
+	}
+
+	// Hidden files: mask individual files with /dev/null so reads return empty.
+	// Uses --ro-bind-try so missing files don't break the sandbox.
+	for _, f := range pol.HiddenFiles {
+		ef := plugin.ShellQuote(f)
+		fmt.Fprintf(&b, "  --ro-bind-try /dev/null '%s' \\\n", ef)
 	}
 
 	b.WriteString("  -- \"$@\"\n")

--- a/internal/plugin/sandbox/wrapper_test.go
+++ b/internal/plugin/sandbox/wrapper_test.go
@@ -183,6 +183,31 @@ func TestGenerateWrapperScript_QuotedPaths(t *testing.T) {
 	}
 }
 
+func TestGenerateWrapperScript_WithHiddenFiles(t *testing.T) {
+	pol := &policy{
+		WorkspaceFolder: "/workspaces/project",
+		RemoteHome:      "/home/vscode",
+		HiddenFiles: []string{
+			"/workspaces/project/.env",
+			"/workspaces/project/config/master.key",
+		},
+	}
+	script := generateWrapperScript(pol)
+
+	if !strings.Contains(script, "--ro-bind-try /dev/null '/workspaces/project/.env'") {
+		t.Error("missing /dev/null bind for .env")
+	}
+	if !strings.Contains(script, "--ro-bind-try /dev/null '/workspaces/project/config/master.key'") {
+		t.Error("missing /dev/null bind for master.key")
+	}
+	// Hidden file entries should appear before the passthrough args.
+	idxHidden := strings.Index(script, "--ro-bind-try /dev/null")
+	idxArgs := strings.Index(script, "-- \"$@\"")
+	if idxHidden > idxArgs {
+		t.Error("hidden file entries should appear before passthrough args")
+	}
+}
+
 func TestGenerateAliasScript(t *testing.T) {
 	script := generateAliasScript("claude", "/usr/local/bin/claude", "/home/vscode/.local/bin/sandbox")
 


### PR DESCRIPTION
## Summary

### Git worktree auto-detection
- The sandbox plugin now runs \`git worktree list --porcelain\` inside the container at setup time
- When worktrees exist outside the workspace folder (e.g. \`/workspaces/project-worktrees/\`), their base directory is added as a writable path in the bwrap policy
- When a worktree lives directly under \`/\` (e.g. \`/branch-x\`), the worktree path itself is used instead of \`/\`, keeping the rest of the filesystem read-only
- Detection is non-fatal: silently skipped when git is unavailable or the workspace is not a repo
- Nested worktree parents are deduplicated (only the broadest parent is kept); user-configured \`allowWrite\` paths are also deduplicated against auto-detected dirs

### hideFiles config option
- New \`hideFiles\` config option masks individual files from sandboxed agents via \`bwrap --ro-bind-try /dev/null\`
- Paths are relative to the workspace folder and validated to stay within it (rejects traversal attempts)
- Documented tradeoff: OS-level masking affects the agent's entire process tree, so files needed by child processes (\`.env\`, \`config/master.key\`) should use agent-level restrictions instead

### Alias wrappers
- Aliases are now resolved via \`readlink -f\` to follow symlinks (handles Claude Code's native installer, which puts a symlink at \`~/.local/bin/claude\`)
- \`excludeDir\` is filtered from PATH before lookup so aliases are correctly refreshed on rebuild (a previous wrapper no longer shadows the real binary)

### Docs
- Documented autonomous/yolo mode pattern for running Claude Code with \`--dangerously-skip-permissions\` inside the sandbox

## Test plan

- [x] Unit tests for porcelain output parsing (\`parseWorktreePaths\`)
- [x] Unit tests for base dir computation (\`worktreeBaseDirs\`): sibling worktrees, nested parents, scattered locations, inside-workspace, root-level, empty
- [x] Integration test: \`PostContainerCreate\` with mock git output produces \`--bind-try\` in wrapper script
- [x] Integration test: git failure does not break sandbox setup
- [x] Integration test: \`hideFiles\` config produces \`--ro-bind-try /dev/null\` entries in wrapper
- [x] Integration test: \`hideFiles\` path traversal attempts are rejected
- [x] \`make build && make test && make lint\` all green
- [ ] Manual test with a real worktree setup inside a dev container