### PR TITLE
fix: detect compose file content changes during smart restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `crib restart` now detects changes inside Docker Compose files (volumes,
+  ports, environment, etc.) and recreates the container. Previously, only
+  changes to `devcontainer.json` fields were detected, so editing a compose
+  file's volumes had no effect until a full `crib rebuild`.
+
 ## [0.7.0] - 2026-03-10
 
 ### Added

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -118,6 +118,12 @@ Color-code `crib logs` lines by service name when the terminal supports it, simi
 
 Detect when a container is unhealthy or stuck and surface it in `crib status` / `crib ps`.
 
+#### Dockerfile content change detection in smart restart
+
+`crib restart` detects changes to devcontainer.json fields and compose file contents, but not changes to files referenced by those configs. If a Dockerfile used by a compose `build:` section or by `devcontainer.json`'s `dockerfile` field changes (e.g. a Ruby version bump in `FROM`), `restart` doesn't notice and does a simple restart instead of suggesting `crib rebuild`.
+
+Options: hash Dockerfile contents alongside compose files, parse compose YAML to discover referenced Dockerfiles and `.env` files, or add a lighter-weight mtime check. The tricky part is knowing which files to track (Dockerfiles, `.dockerignore`, build context files, `.env` files) without reimplementing `docker build`'s dependency graph.
+
 ### Housekeeping
 
 #### XDG-based cache provider

--- a/docs/smart-restart.md
+++ b/docs/smart-restart.md
@@ -42,6 +42,18 @@ Use **`crib rebuild`** when you changed:
 
 **Rule of thumb:** if the change affects how the container runs, use `restart`. If it affects what the image contains, use `rebuild`.
 
-:::note
-Compose file change detection uses a content hash, not a parsed comparison. If you change build-related fields in a compose file (like `build:` or `image:`), `restart` will recreate the container but will not rebuild the image. Use `crib rebuild` to pick up compose build changes.
-:::
+## What restart doesn't detect
+
+`restart` compares devcontainer.json fields and compose file contents, but it does not read files referenced by those configs. If you change the contents of a Dockerfile used by your compose `build:` section (e.g. upgrading a Ruby version in `FROM ruby:3.3` to `FROM ruby:3.4`), `restart` won't notice because the compose YAML itself didn't change. The same applies to Dockerfiles referenced by `dockerfile` in devcontainer.json.
+
+In these cases, use `crib rebuild`:
+
+```bash
+# Changed FROM ruby:3.3 to FROM ruby:3.4 in your Dockerfile?
+crib rebuild   # full image rebuild + container recreation
+
+# Changed a volume in docker-compose.yml?
+crib restart   # container recreation, no rebuild needed
+```
+
+Compose file change detection also uses a content fingerprint, not a parsed comparison. If you change build-related fields in a compose file (like `build:` or `image:`), `restart` will recreate the container but will not rebuild the image. Use `crib rebuild` for those too.

--- a/docs/smart-restart.md
+++ b/docs/smart-restart.md
@@ -9,6 +9,7 @@ description: How crib restart detects changes and picks the fastest strategy.
 |---|---|---|
 | Nothing | Simple container restart (`docker restart`) | `postStartCommand` + `postAttachCommand` |
 | Volumes, mounts, ports, env, runArgs, user | Container recreated with new config | `postStartCommand` + `postAttachCommand` |
+| Compose file contents (volumes, ports, env, etc.) | Container recreated with new config | `postStartCommand` + `postAttachCommand` |
 | Image, Dockerfile, features, build args | Error, suggests `crib rebuild` | - |
 
 This follows the [devcontainer spec's Resume Flow](https://containers.dev/implementors/spec/#lifecycle): on restart, only `postStartCommand` and `postAttachCommand` run. Creation-time hooks (`onCreateCommand`, `updateContentCommand`, `postCreateCommand`) are skipped since they already ran when the container was first created.
@@ -30,7 +31,7 @@ Use **`crib restart`** when you changed:
 - Volume mounts or bind mounts
 - Port mappings (`forwardPorts`, `appPort`)
 - `runArgs` or `remoteUser`
-- Docker Compose service config (environment, volumes, ports)
+- Docker Compose file contents (volumes, ports, environment, networks, etc.)
 
 Use **`crib rebuild`** when you changed:
 - The base image (`image` or `FROM` in Dockerfile)
@@ -40,3 +41,7 @@ Use **`crib rebuild`** when you changed:
 - Anything that affects the built image
 
 **Rule of thumb:** if the change affects how the container runs, use `restart`. If it affects what the image contains, use `rebuild`.
+
+:::note
+Compose file change detection uses a content hash, not a parsed comparison. If you change build-related fields in a compose file (like `build:` or `image:`), `restart` will recreate the container but will not rebuild the image. Use `crib rebuild` to pick up compose build changes.
+:::

--- a/e2e/compose_test.go
+++ b/e2e/compose_test.go
@@ -83,6 +83,58 @@ func lastLine(out string) string {
 	return ""
 }
 
+// TestE2EComposeRestartOnFileChange verifies that "crib restart" detects
+// a volume change inside a compose file and recreates the container, even
+// though devcontainer.json itself hasn't changed.
+func TestE2EComposeRestartOnFileChange(t *testing.T) {
+	if !hasRuntime() {
+		t.Fatal("container runtime not available or not working (docker or podman required)")
+	}
+	if !hasCompose() {
+		t.Fatal("docker compose or podman compose not available")
+	}
+
+	projectDir := setupComposeProject(t)
+	cribHome := t.TempDir()
+
+	t.Cleanup(func() {
+		cmd := cribCmd(projectDir, cribHome, "remove", "--force")
+		_ = cmd.Run()
+	})
+
+	// Initial up.
+	mustRunCrib(t, projectDir, cribHome, "up")
+
+	// Restart with no changes: should be a simple restart.
+	out := mustRunCrib(t, projectDir, cribHome, "restart")
+	if strings.Contains(strings.ToLower(out), "recreated") {
+		t.Errorf("restart without changes: want simple restart, got recreate; output: %q", out)
+	}
+
+	// Modify compose file: add a volume.
+	composeFile := filepath.Join(projectDir, ".devcontainer", "docker-compose.yml")
+	updated := composeDockerCompose + `    volumes:
+      - appdata:/data
+volumes:
+  appdata:
+`
+	if err := os.WriteFile(composeFile, []byte(updated), 0o644); err != nil {
+		t.Fatalf("writing updated compose file: %v", err)
+	}
+
+	// Restart should detect the compose file change and recreate.
+	out = mustRunCrib(t, projectDir, cribHome, "restart")
+	if !strings.Contains(strings.ToLower(out), "recreated") {
+		t.Errorf("restart after compose change: want 'recreated' in output, got %q", out)
+	}
+
+	// Container should still be running after recreate.
+	out = mustRunCrib(t, projectDir, cribHome, "status")
+	if !strings.Contains(strings.ToLower(out), "running") {
+		t.Errorf("status after restart recreate: want 'running', got %q", out)
+	}
+}
+
 func TestE2ECompose(t *testing.T) {
 	if !hasRuntime() {
 		t.Fatal("container runtime not available or not working (docker or podman required)")

--- a/internal/engine/change.go
+++ b/internal/engine/change.go
@@ -1,7 +1,11 @@
 package engine
 
 import (
+	"crypto/sha256"
+	"fmt"
+	"os"
 	"reflect"
+	"sort"
 
 	"github.com/fgrehm/crib/internal/config"
 )
@@ -180,4 +184,41 @@ func buildOptsEqual(a, b *config.ConfigBuildOptions) bool {
 
 func featuresEqual(a, b map[string]any) bool {
 	return reflect.DeepEqual(a, b)
+}
+
+// computeComposeFilesHash computes a hash of the contents of all compose files.
+// This catches changes inside compose files (volumes, ports, env, etc.) that
+// are invisible to detectConfigChange, which only compares devcontainer.json
+// fields.
+//
+// Limitation: this is a raw content hash, not a parsed comparison. Any change
+// in the compose files (including build-affecting fields like "build:" or
+// "image:") is classified as changeSafe (recreate without rebuild). If build
+// config changed, the recreated container will still use the old image. Run
+// "crib rebuild" to pick up compose build changes.
+func computeComposeFilesHash(files []string) string {
+	if len(files) == 0 {
+		return ""
+	}
+
+	// Sort for stable ordering regardless of config order.
+	sorted := make([]string, len(files))
+	copy(sorted, files)
+	sort.Strings(sorted)
+
+	h := sha256.New()
+	for _, f := range sorted {
+		data, err := os.ReadFile(f)
+		if err != nil {
+			// Include the error so a missing file still changes the hash.
+			h.Write([]byte("err:" + f + ":" + err.Error()))
+			continue
+		}
+		// Include filename as separator to avoid collisions when file
+		// contents are moved between files.
+		h.Write([]byte(f))
+		h.Write([]byte{0})
+		h.Write(data)
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)[:8])
 }

--- a/internal/engine/change.go
+++ b/internal/engine/change.go
@@ -186,14 +186,15 @@ func featuresEqual(a, b map[string]any) bool {
 	return reflect.DeepEqual(a, b)
 }
 
-// computeComposeFilesHash computes a hash of the contents of all compose files.
-// This catches changes inside compose files (volumes, ports, env, etc.) that
-// are invisible to detectConfigChange, which only compares devcontainer.json
-// fields.
+// computeComposeFilesHash computes a short fingerprint (truncated SHA-256) of
+// the contents of all compose files. This catches changes inside compose files
+// (volumes, ports, env, etc.) that are invisible to detectConfigChange, which
+// only compares devcontainer.json fields. The fingerprint is 16 hex characters
+// (8 bytes), matching the truncation used by computeHookHash.
 //
-// Limitation: this is a raw content hash, not a parsed comparison. Any change
-// in the compose files (including build-affecting fields like "build:" or
-// "image:") is classified as changeSafe (recreate without rebuild). If build
+// Limitation: this is a raw content fingerprint, not a parsed comparison. Any
+// change in the compose files (including build-affecting fields like "build:"
+// or "image:") is classified as changeSafe (recreate without rebuild). If build
 // config changed, the recreated container will still use the old image. Run
 // "crib rebuild" to pick up compose build changes.
 func computeComposeFilesHash(files []string) string {

--- a/internal/engine/compose_integration_test.go
+++ b/internal/engine/compose_integration_test.go
@@ -389,6 +389,140 @@ func checkFileContent(ctx context.Context, e *Engine, wsID, containerID, path, e
 	return nil
 }
 
+// TestIntegrationComposeRestartDetectsFileContentChange verifies that changing
+// a volume (or any content) inside a compose file triggers a container recreate
+// during restart, even though devcontainer.json hasn't changed.
+func TestIntegrationComposeRestartDetectsFileContentChange(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	e, d, store := newTestEngineWithCompose(t)
+
+	projectDir := t.TempDir()
+	wsID := "test-compose-restart-content"
+	devcontainerDir := filepath.Join(projectDir, ".devcontainer")
+	if err := os.MkdirAll(devcontainerDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	composeFile := filepath.Join(devcontainerDir, "compose.yml")
+	composeContent := `services:
+  app:
+    image: alpine:3.20
+    command: ["sleep", "infinity"]
+`
+	if err := os.WriteFile(composeFile, []byte(composeContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	configContent := `{
+		"dockerComposeFile": "compose.yml",
+		"service": "app",
+		"overrideCommand": true
+	}`
+	if err := os.WriteFile(filepath.Join(devcontainerDir, "devcontainer.json"), []byte(configContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ws := &workspace.Workspace{
+		ID:               wsID,
+		Source:           projectDir,
+		DevContainerPath: ".devcontainer/devcontainer.json",
+		CreatedAt:        time.Now(),
+		LastUsedAt:       time.Now(),
+	}
+
+	t.Cleanup(func() { cleanupCompose(t, e, d, ws) })
+	cleanupCompose(t, e, d, ws)
+
+	// Initial Up.
+	result1, err := e.Up(ctx, ws, UpOptions{})
+	if err != nil {
+		t.Fatalf("Up: %v", err)
+	}
+
+	// Verify compose files hash was stored.
+	stored, err := store.LoadResult(wsID)
+	if err != nil {
+		t.Fatalf("LoadResult: %v", err)
+	}
+	if stored.ComposeFilesHash == "" {
+		t.Fatal("ComposeFilesHash should be set after Up")
+	}
+
+	// Modify compose file (add a volume).
+	composeContentV2 := `services:
+  app:
+    image: alpine:3.20
+    command: ["sleep", "infinity"]
+    volumes:
+      - appdata:/data
+volumes:
+  appdata:
+`
+	if err := os.WriteFile(composeFile, []byte(composeContentV2), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Restart should detect the change and recreate.
+	restartResult, err := e.Restart(ctx, ws)
+	if err != nil {
+		t.Fatalf("Restart: %v", err)
+	}
+
+	if !restartResult.Recreated {
+		t.Error("Restart should have set Recreated=true after compose file change")
+	}
+
+	if restartResult.ContainerID == result1.ContainerID {
+		t.Error("expected different container ID after recreate")
+	}
+
+	// Verify hash was updated.
+	stored2, err := store.LoadResult(wsID)
+	if err != nil {
+		t.Fatalf("LoadResult after restart: %v", err)
+	}
+	if stored2.ComposeFilesHash == stored.ComposeFilesHash {
+		t.Error("ComposeFilesHash should have changed after restart with new compose content")
+	}
+}
+
+// TestIntegrationComposeRestartNoChangeSimple verifies that restart does a
+// simple restart (no recreate) when compose file contents haven't changed.
+func TestIntegrationComposeRestartNoChangeSimple(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	e, d, _ := newTestEngineWithCompose(t)
+
+	projectDir := t.TempDir()
+	wsID := "test-compose-restart-nochange"
+	ws := writeComposeDevcontainer(t, projectDir, wsID)
+
+	t.Cleanup(func() { cleanupCompose(t, e, d, ws) })
+	cleanupCompose(t, e, d, ws)
+
+	// Initial Up.
+	if _, err := e.Up(ctx, ws, UpOptions{}); err != nil {
+		t.Fatalf("Up: %v", err)
+	}
+
+	// Restart without any changes should be simple (no recreate).
+	restartResult, err := e.Restart(ctx, ws)
+	if err != nil {
+		t.Fatalf("Restart: %v", err)
+	}
+
+	if restartResult.Recreated {
+		t.Error("Restart should not recreate when nothing changed")
+	}
+}
+
 // TestIntegrationComposeImageNamePersisted verifies that the ImageName field
 // is saved in the workspace result after a compose Up.
 func TestIntegrationComposeImageNamePersisted(t *testing.T) {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -388,6 +388,12 @@ func (e *Engine) saveResult(ws *workspace.Workspace, cfg *config.DevContainerCon
 	wsResult.RemoteUser = result.RemoteUser
 	wsResult.HasFeatureEntrypoints = result.HasFeatureEntrypoints
 
+	if len(cfg.DockerComposeFile) > 0 {
+		cd := configDir(ws)
+		composeFiles := resolveComposeFiles(cd, cfg.DockerComposeFile)
+		wsResult.ComposeFilesHash = computeComposeFilesHash(composeFiles)
+	}
+
 	if err := e.store.SaveResult(ws.ID, wsResult); err != nil {
 		e.logger.Warn("failed to save workspace result", "error", err)
 	}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -392,6 +392,8 @@ func (e *Engine) saveResult(ws *workspace.Workspace, cfg *config.DevContainerCon
 		cd := configDir(ws)
 		composeFiles := resolveComposeFiles(cd, cfg.DockerComposeFile)
 		wsResult.ComposeFilesHash = computeComposeFilesHash(composeFiles)
+	} else {
+		wsResult.ComposeFilesHash = ""
 	}
 
 	if err := e.store.SaveResult(ws.ID, wsResult); err != nil {

--- a/internal/engine/restart.go
+++ b/internal/engine/restart.go
@@ -73,6 +73,20 @@ func (e *Engine) Restart(ctx context.Context, ws *workspace.Workspace) (*Restart
 
 	change := detectConfigChange(&storedCfg, cfg)
 
+	// If devcontainer.json looks unchanged, check compose file contents.
+	// detectConfigChange only compares the compose file list, not their
+	// contents. A volume, port, or env change inside a compose file would
+	// otherwise be missed.
+	if change == changeNone && len(cfg.DockerComposeFile) > 0 && storedResult.ComposeFilesHash != "" {
+		cd := configDir(ws)
+		composeFiles := resolveComposeFiles(cd, cfg.DockerComposeFile)
+		currentHash := computeComposeFilesHash(composeFiles)
+		if currentHash != storedResult.ComposeFilesHash {
+			e.logger.Debug("compose file contents changed", "stored", storedResult.ComposeFilesHash, "current", currentHash)
+			change = changeSafe
+		}
+	}
+
 	b := e.newBackend(ws, cfg, workspaceFolder)
 
 	switch change {

--- a/internal/engine/restart.go
+++ b/internal/engine/restart.go
@@ -77,11 +77,17 @@ func (e *Engine) Restart(ctx context.Context, ws *workspace.Workspace) (*Restart
 	// detectConfigChange only compares the compose file list, not their
 	// contents. A volume, port, or env change inside a compose file would
 	// otherwise be missed.
-	if change == changeNone && len(cfg.DockerComposeFile) > 0 && storedResult.ComposeFilesHash != "" {
+	if change == changeNone && len(cfg.DockerComposeFile) > 0 {
 		cd := configDir(ws)
 		composeFiles := resolveComposeFiles(cd, cfg.DockerComposeFile)
 		currentHash := computeComposeFilesHash(composeFiles)
-		if currentHash != storedResult.ComposeFilesHash {
+		if storedResult.ComposeFilesHash == "" {
+			// Pre-existing workspace with no stored hash (created before
+			// compose content tracking was added). Treat as changed so the
+			// hash gets persisted on this restart.
+			e.logger.Debug("no stored compose files hash, forcing recreate to persist hash")
+			change = changeSafe
+		} else if currentHash != storedResult.ComposeFilesHash {
 			e.logger.Debug("compose file contents changed", "stored", storedResult.ComposeFilesHash, "current", currentHash)
 			change = changeSafe
 		}

--- a/internal/engine/restart_test.go
+++ b/internal/engine/restart_test.go
@@ -163,6 +163,68 @@ func TestDetectConfigChange_ComposeServiceChanged(t *testing.T) {
 	}
 }
 
+func TestComputeComposeFilesHash_StableAcrossCalls(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "docker-compose.yml")
+	if err := os.WriteFile(f, []byte("services:\n  app:\n    image: ubuntu\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h1 := computeComposeFilesHash([]string{f})
+	h2 := computeComposeFilesHash([]string{f})
+	if h1 != h2 {
+		t.Errorf("hash not stable: %q != %q", h1, h2)
+	}
+	if h1 == "" {
+		t.Error("expected non-empty hash")
+	}
+}
+
+func TestComputeComposeFilesHash_ChangesOnContentChange(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "docker-compose.yml")
+	if err := os.WriteFile(f, []byte("services:\n  app:\n    image: ubuntu\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h1 := computeComposeFilesHash([]string{f})
+
+	if err := os.WriteFile(f, []byte("services:\n  app:\n    image: ubuntu\n    volumes:\n      - data:/data\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h2 := computeComposeFilesHash([]string{f})
+
+	if h1 == h2 {
+		t.Error("hash should change when file content changes")
+	}
+}
+
+func TestComputeComposeFilesHash_MultipleFiles(t *testing.T) {
+	dir := t.TempDir()
+	f1 := filepath.Join(dir, "docker-compose.yml")
+	f2 := filepath.Join(dir, "docker-compose.override.yml")
+	if err := os.WriteFile(f1, []byte("services:\n  app:\n    image: ubuntu\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(f2, []byte("services:\n  app:\n    volumes:\n      - data:/data\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Order should not matter.
+	h1 := computeComposeFilesHash([]string{f1, f2})
+	h2 := computeComposeFilesHash([]string{f2, f1})
+	if h1 != h2 {
+		t.Errorf("hash should be order-independent: %q != %q", h1, h2)
+	}
+}
+
+func TestComputeComposeFilesHash_EmptyFiles(t *testing.T) {
+	if got := computeComposeFilesHash(nil); got != "" {
+		t.Errorf("expected empty string for nil files, got %q", got)
+	}
+	if got := computeComposeFilesHash([]string{}); got != "" {
+		t.Errorf("expected empty string for empty files, got %q", got)
+	}
+}
+
 func mustLoadResult(t *testing.T, store *workspace.Store, wsID string) *workspace.Result {
 	t.Helper()
 	r, err := store.LoadResult(wsID)

--- a/internal/workspace/result.go
+++ b/internal/workspace/result.go
@@ -38,4 +38,10 @@ type Result struct {
 	// that declare entrypoints (e.g. docker-in-docker). Used by restart
 	// paths to know whether to override the container entrypoint.
 	HasFeatureEntrypoints bool `json:"hasFeatureEntrypoints,omitempty"`
+
+	// ComposeFilesHash is a hash of the compose file contents at the time
+	// the result was saved. Used by restart to detect changes inside compose
+	// files (volumes, ports, etc.) that are invisible to devcontainer.json
+	// config comparison.
+	ComposeFilesHash string `json:"composeFilesHash,omitempty"`
 }

--- a/internal/workspace/result.go
+++ b/internal/workspace/result.go
@@ -39,9 +39,9 @@ type Result struct {
 	// paths to know whether to override the container entrypoint.
 	HasFeatureEntrypoints bool `json:"hasFeatureEntrypoints,omitempty"`
 
-	// ComposeFilesHash is a hash of the compose file contents at the time
-	// the result was saved. Used by restart to detect changes inside compose
-	// files (volumes, ports, etc.) that are invisible to devcontainer.json
-	// config comparison.
+	// ComposeFilesHash is a short fingerprint (truncated SHA-256) of the
+	// compose file contents at the time the result was saved. Used by restart
+	// to detect changes inside compose files (volumes, ports, etc.) that are
+	// invisible to devcontainer.json config comparison.
 	ComposeFilesHash string `json:"composeFilesHash,omitempty"`
 }


### PR DESCRIPTION
## Summary

- `crib restart` now detects changes inside Docker Compose files (volumes, ports, environment, etc.) and recreates the container
- Previously, only changes to `devcontainer.json` fields were compared, so editing a compose file's volumes had no effect until a full `crib rebuild`
- Stores a SHA-256 content hash of compose files in the workspace result; on restart, recomputes and compares

## Limitation

Raw content hash, not a parsed YAML comparison. Build-related changes in compose files (`build:`, `image:`) trigger a recreate but not a rebuild. `crib rebuild` is needed for those. Documented in the smart-restart guide.

## Test plan

- [x] Unit tests for `computeComposeFilesHash` (stable, detects changes, multi-file order-independent, empty)
- [x] Integration tests (recreate on change, no-recreate when unchanged)
- [x] E2E test (`TestE2EComposeRestartOnFileChange`) - full lifecycle through the binary
- [x] All existing tests pass (`make test && make lint`)