### PR TITLE
feat: dispatch feature lifecycle hooks, spec compliance fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Parse the `updateContentCommand` lifecycle hook from `devcontainer-feature.json`.
+  Previously this was the only feature lifecycle hook not recognized by the parser.
+  Note: feature-declared lifecycle hooks are parsed and propagated to image metadata
+  but not yet dispatched by the lifecycle runner (tracked in roadmap).
 - `crib restart` now detects changes inside Docker Compose files (volumes,
   ports, environment, etc.) and recreates the container. Previously, only
   changes to `devcontainer.json` fields were detected, so editing a compose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Parse the `updateContentCommand` lifecycle hook from `devcontainer-feature.json`.
-  Previously this was the only feature lifecycle hook not recognized by the parser.
-  Note: feature-declared lifecycle hooks are parsed and propagated to image metadata
-  but not yet dispatched by the lifecycle runner (tracked in roadmap).
+- Dispatch feature-declared lifecycle hooks. Features can declare `onCreateCommand`,
+  `updateContentCommand`, `postCreateCommand`, `postStartCommand`, and
+  `postAttachCommand` in `devcontainer-feature.json`. These now execute before
+  user-defined hooks at each stage, in feature installation order (per the spec).
+  Feature hooks are stored in `result.json` so they persist across restarts without
+  re-resolving features from OCI registries. Also parses the previously-missing
+  `updateContentCommand` field from feature configs.
 - `crib restart` now detects changes inside Docker Compose files (volumes,
   ports, environment, etc.) and recreates the container. Previously, only
   changes to `devcontainer.json` fields were detected, so editing a compose

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,28 @@ make test-integration # integration tests (requires Docker or Podman)
 
 Run a single test: `go test ./internal/config/ -short -run TestParseFull`
 
+### Integration tests
+
+Integration tests live alongside unit tests in `*_integration_test.go` files
+(primarily in `internal/engine/`). They require Docker or Podman and are skipped
+by `-short`. Run them with `make test-integration`.
+
+**Pattern**: `newTestEngine(t)` creates an engine with a real `OCIDriver` and a
+temp-dir workspace store. Tests create a temp project dir, write
+`.devcontainer/devcontainer.json`, build a `workspace.Workspace` struct, call
+`e.Up(ctx, ws, UpOptions{})`, then verify side effects via
+`d.ExecContainer(ctx, ...)`. Cleanup with `t.Cleanup` deletes containers and
+images via `cleanupWorkspaceImages(t, d, wsID)`.
+
+**Convention**: Test function names start with `TestIntegration`. Workspace IDs
+use `test-engine-<suffix>` to avoid collisions. Use `alpine:3.20` as the base
+image (small, fast to pull). Local features go in the temp project's
+`.devcontainer/` directory.
+
+**Requirement**: Always write integration tests for new engine features that
+touch the container lifecycle (hooks, env, user, features). Unit tests with mock
+drivers are good for logic but miss real Docker/Podman behavior.
+
 ## Conventions
 
 - Go module: `github.com/fgrehm/crib`

--- a/docs/devcontainers-spec.md
+++ b/docs/devcontainers-spec.md
@@ -141,7 +141,7 @@ Properties inside `portsAttributes` entries:
 
 | Variable | Usable In | Description |
 |---|---|---|
-| `${localEnv:VAR}` | Any property | Host env var. Supports default: `${localEnv:VAR:fallback}` |
+| `${localEnv:VAR}` | Any property | Host env var. Supports default: `${localEnv:VAR:fallback}`. `${env:VAR}` is an alias. |
 | `${containerEnv:VAR}` | `remoteEnv` only | Container env var. Supports default: `${containerEnv:VAR:fallback}` |
 | `${localWorkspaceFolder}` | Any property | Full path to the opened local folder |
 | `${containerWorkspaceFolder}` | Any property | Full path inside the container |
@@ -295,8 +295,9 @@ The array format is preferred because subsequent builds can simply append entrie
 These properties can appear in image metadata: `forwardPorts`, `portsAttributes`,
 `otherPortsAttributes`, `containerEnv`, `remoteEnv`, `remoteUser`, `containerUser`,
 `updateRemoteUserUID`, `userEnvProbe`, `overrideCommand`, `shutdownAction`, `init`,
-`privileged`, `capAdd`, `securityOpt`, `mounts`, `customizations`, `hostRequirements`,
-all lifecycle hooks (`onCreateCommand` through `postAttachCommand`), and `waitFor`.
+`privileged`, `capAdd`, `securityOpt`, `entrypoint`, `mounts`, `customizations`,
+`hostRequirements`, all lifecycle hooks (`onCreateCommand` through `postAttachCommand`),
+and `waitFor`.
 
 ### Metadata Merge Rules
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -66,11 +66,19 @@ Accept arguments to filter/show state details (container status, services, ports
 
 Build the image / container without starting it. Useful for CI or pre-warming caches.
 
+#### Feature lockfile for reproducible resolution
+
+The official devcontainers CLI has an experimental `devcontainer-lock.json` that records resolved digests, versions, and integrity hashes for each feature. Enables `--frozen-lockfile` for deterministic builds. crib currently re-resolves features on every build. A lockfile would help teams pin exact feature versions in CI. Not part of the spec (CLI extension), but useful. Format: `{ features: { "<id>": { version, resolved, integrity, dependsOn } } }`.
+
 ### Plugins
 
 #### Standardize container-side plugin paths
 
 Currently plugin mounts land at ad-hoc paths (`~/.crib_history/`, `/tmp/ssh-agent.sock`). A standard base (XDG `$XDG_DATA_HOME/crib/` for persistent data, `/tmp/crib/` for runtime sockets) would be cleaner, but we need more plugins and real-world usage to understand the right shape before committing to a convention. The cartage plugin (above) would be a good forcing function for settling on a convention.
+
+#### Dotfiles plugin
+
+Clone and install a user's [dotfiles repository](https://dotfiles.github.io/) inside the container on creation. The devcontainer spec doesn't standardize dotfiles, but VS Code, GitHub Codespaces, and DevPod all support them. A crib plugin would clone the repo to a configurable path (default `~/dotfiles`) and run an install script (`install.sh`, `bootstrap.sh`, or a custom command). Configuration via `.cribrc` or global config (`dotfiles.repository`, `dotfiles.installCommand`). See [#17](https://github.com/fgrehm/crib/issues/17).
 
 #### Cartage plugin
 
@@ -97,6 +105,14 @@ When Claude Code runs inside a container, it builds a project hash from the work
 Mounting the host's `~/.claude/projects/<hash>/` directory at the container's expected hash path would fix this, but it requires reverse-engineering Claude's hashing logic and would break on upstream changes. A Claude Code config to override the project directory association would make this trivial. Parked until an upstream escape hatch appears. As of March 2026, no such config exists in Claude Code's [settings](https://code.claude.com/docs/en/settings).
 
 ### UX
+
+#### Structured log events with progress tracking
+
+The official devcontainers CLI uses a typed log event system (`text`, `raw`, `start`, `stop`, `progress`) instead of plain text output. Lifecycle hooks emit `::step::` and `::endstep::` markers that the log handler converts to progress events, enabling rich terminal UI (spinners per hook step) without coupling hooks to the display layer. crib currently uses plain `slog` and a progress callback. A typed event system would decouple output formatting from execution and enable richer feedback during long-running operations.
+
+#### Rich error context
+
+crib's errors are mostly `fmt.Errorf` chains. The official devcontainers CLI wraps errors with structured data: container ID, config that caused the error, suggested recovery actions, and the original error. This enables better error messages ("failed to start container X because feature Y requires privileged mode, try adding `privileged: true`") and potential auto-recovery. Worth adopting incrementally, starting with the most common failure modes (build failures, hook failures, container start failures).
 
 #### Debug mode and build log capture
 
@@ -126,12 +142,6 @@ Options: hash Dockerfile contents alongside compose files, parse compose YAML to
 
 ### Spec Compliance
 
-#### Feature lifecycle hooks not dispatched
-
-Feature metadata entries can declare lifecycle hooks (`onCreateCommand`, `updateContentCommand`, `postCreateCommand`, `postStartCommand`, `postAttachCommand`). These are parsed from `devcontainer-feature.json`, propagated via `featureToMetadata()`, and merged into `MergedConfigProperties` (the plural `OnCreateCommands`, `UpdateContentCommands`, etc.). However, the lifecycle runner in `internal/engine/lifecycle.go` only dispatches the base config's singular hooks (`cfg.OnCreateCommand`), not the merged lists. Feature-declared hooks are silently ignored.
-
-Per the spec, feature hooks should execute before user-defined hooks, in feature installation order.
-
 #### Recursive `dependsOn` resolution for features
 
 The spec says `dependsOn` should be resolved recursively: if feature A depends on feature B (not explicitly listed in `devcontainer.json`), the tool should automatically pull and install feature B. crib's `OrderFeatures()` in `internal/feature/order.go` instead errors with "not in the feature set." Few real-world features exercise this today, but it's a spec gap.
@@ -141,6 +151,22 @@ The spec says `dependsOn` should be resolved recursively: if feature A depends o
 The spec describes a round-based priority system where `overrideFeatureInstallOrder` assigns `roundPriority = n - index`, and within each round only features at the max priority are committed. crib uses topological sort (Kahn's algorithm) with a post-hoc reorder that moves override entries to the front. These produce the same result in most cases but can diverge when override features have dependencies that should interleave with non-override features.
 
 ### Housekeeping
+
+#### Workspace flock
+
+Concurrent `crib up` invocations on the same workspace can race (two processes building, creating containers, or writing `result.json` simultaneously). DevPod uses [`gofrs/flock`](https://github.com/gofrs/flock) for file-based workspace locking. Small effort, prevents a real (if uncommon) bug class. Lock file would live at `~/.crib/workspaces/{id}/lock`.
+
+#### Adopt compose-go library for Compose YAML parsing
+
+crib currently generates compose override YAML via string concatenation in `generateComposeOverride` (cyclomatic complexity 26) and shells out to `docker compose` for service inspection. The official [`compose-spec/compose-go/v2`](https://github.com/compose-spec/compose-go) library (used by DevPod) provides programmatic access to service definitions, environment files, build configs, and override generation. Would simplify `generateComposeOverride`, `resolveComposeDockerfileInfo`, and the Dockerfile content change detection item above.
+
+#### `userEnvProbe` session caching
+
+crib re-probes the container's user environment on every `crib up` (twice: pre-hook and post-hook). The official devcontainers CLI caches probe results in a container-side session file. Caching the pre-hook probe and only re-probing post-hook could save ~1s per start.
+
+#### Shell persistence for exec commands
+
+The official devcontainers CLI keeps a persistent shell open inside the container and delimits commands/output with a UTF-8 sentinel character (EOT). A streaming parser extracts stdout, stderr, and exit code per command, avoiding the overhead of spawning a new `docker exec` per lifecycle hook or plugin dispatch. Lower priority since individual `docker exec` calls are fast enough today, but would matter for workspaces with many hooks.
 
 #### XDG-based cache provider
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -124,6 +124,22 @@ Detect when a container is unhealthy or stuck and surface it in `crib status` / 
 
 Options: hash Dockerfile contents alongside compose files, parse compose YAML to discover referenced Dockerfiles and `.env` files, or add a lighter-weight mtime check. The tricky part is knowing which files to track (Dockerfiles, `.dockerignore`, build context files, `.env` files) without reimplementing `docker build`'s dependency graph.
 
+### Spec Compliance
+
+#### Feature lifecycle hooks not dispatched
+
+Feature metadata entries can declare lifecycle hooks (`onCreateCommand`, `updateContentCommand`, `postCreateCommand`, `postStartCommand`, `postAttachCommand`). These are parsed from `devcontainer-feature.json`, propagated via `featureToMetadata()`, and merged into `MergedConfigProperties` (the plural `OnCreateCommands`, `UpdateContentCommands`, etc.). However, the lifecycle runner in `internal/engine/lifecycle.go` only dispatches the base config's singular hooks (`cfg.OnCreateCommand`), not the merged lists. Feature-declared hooks are silently ignored.
+
+Per the spec, feature hooks should execute before user-defined hooks, in feature installation order.
+
+#### Recursive `dependsOn` resolution for features
+
+The spec says `dependsOn` should be resolved recursively: if feature A depends on feature B (not explicitly listed in `devcontainer.json`), the tool should automatically pull and install feature B. crib's `OrderFeatures()` in `internal/feature/order.go` instead errors with "not in the feature set." Few real-world features exercise this today, but it's a spec gap.
+
+#### Round-based feature installation ordering
+
+The spec describes a round-based priority system where `overrideFeatureInstallOrder` assigns `roundPriority = n - index`, and within each round only features at the max priority are committed. crib uses topological sort (Kahn's algorithm) with a post-hoc reorder that moves override entries to the front. These produce the same result in most cases but can diverge when override features have dependencies that should interleave with non-override features.
+
 ### Housekeeping
 
 #### XDG-based cache provider

--- a/internal/engine/build.go
+++ b/internal/engine/build.go
@@ -393,6 +393,7 @@ func featureToMetadata(f *feature.FeatureSet) *config.ImageMetadata {
 	m.Mounts = f.Config.Mounts
 	m.ContainerEnv = f.Config.ContainerEnv
 	m.OnCreateCommand = f.Config.OnCreateCommand
+	m.UpdateContentCommand = f.Config.UpdateContentCommand
 	m.PostCreateCommand = f.Config.PostCreateCommand
 	m.PostStartCommand = f.Config.PostStartCommand
 	m.PostAttachCommand = f.Config.PostAttachCommand

--- a/internal/engine/build_test.go
+++ b/internal/engine/build_test.go
@@ -91,11 +91,12 @@ func TestFeatureToMetadata_Minimal(t *testing.T) {
 func TestFeatureToMetadata_LifecycleHooks(t *testing.T) {
 	f := &feature.FeatureSet{
 		Config: &feature.FeatureConfig{
-			ID:                "test-feature",
-			OnCreateCommand:   config.LifecycleHook{"": {"echo oncreate"}},
-			PostCreateCommand: config.LifecycleHook{"": {"echo postcreate"}},
-			PostStartCommand:  config.LifecycleHook{"": {"echo poststart"}},
-			PostAttachCommand: config.LifecycleHook{"": {"echo postattach"}},
+			ID:                   "test-feature",
+			OnCreateCommand:      config.LifecycleHook{"": {"echo oncreate"}},
+			UpdateContentCommand: config.LifecycleHook{"": {"echo updatecontent"}},
+			PostCreateCommand:    config.LifecycleHook{"": {"echo postcreate"}},
+			PostStartCommand:     config.LifecycleHook{"": {"echo poststart"}},
+			PostAttachCommand:    config.LifecycleHook{"": {"echo postattach"}},
 		},
 	}
 
@@ -103,6 +104,9 @@ func TestFeatureToMetadata_LifecycleHooks(t *testing.T) {
 
 	if len(m.OnCreateCommand) == 0 {
 		t.Error("OnCreateCommand should be set")
+	}
+	if len(m.UpdateContentCommand) == 0 {
+		t.Error("UpdateContentCommand should be set")
 	}
 	if len(m.PostCreateCommand) == 0 {
 		t.Error("PostCreateCommand should be set")

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -317,6 +317,7 @@ func (e *Engine) upCreate(ctx context.Context, ws *workspace.Workspace, cfg *con
 		imageName:      buildRes.imageName,
 		hasEntrypoints: buildRes.hasEntrypoints,
 		pluginResp:     pluginResp,
+		imageMetadata:  buildRes.imageMetadata,
 	})
 }
 

--- a/internal/engine/finalize.go
+++ b/internal/engine/finalize.go
@@ -18,6 +18,7 @@ type finalizeOpts struct {
 	storedResult    *workspace.Result               // non-nil for snapshot/stored resume
 	fromSnapshot    bool                            // true = restore env + resume hooks
 	skipVolumeChown bool                            // true for restart (volumes exist)
+	imageMetadata   []*config.ImageMetadata         // feature metadata for hook merging (nil = no features)
 }
 
 // finalize runs post-creation/post-restart steps: plugin file copies, volume
@@ -98,11 +99,17 @@ func (e *Engine) finalizeFreshPath(ctx context.Context, ws *workspace.Workspace,
 	envb := NewEnvBuilder(cfg.RemoteEnv)
 	envb.AddPluginResponse(opts.pluginResp)
 
+	// Store feature hooks so the resume/restart path can dispatch them
+	// without re-resolving features from OCI registries.
+	if len(opts.imageMetadata) > 0 {
+		e.storeFeatureHooks(ws.ID, cfg, opts.imageMetadata)
+	}
+
 	// Early save so crib exec/shell work while setup runs.
 	e.saveResult(ws, cfg, result)
 
 	// Run container setup (UID sync, env probe, lifecycle hooks).
-	finalEnv, err := e.setupContainer(ctx, ws, cfg, cc, envb)
+	finalEnv, err := e.setupContainer(ctx, ws, cfg, cc, envb, opts.imageMetadata)
 	cfg.RemoteEnv = finalEnv
 	if err != nil {
 		// Persist probed env even on hook failure so crib exec/shell
@@ -118,6 +125,58 @@ func (e *Engine) finalizeFreshPath(ctx context.Context, ws *workspace.Workspace,
 	e.saveResult(ws, cfg, result)
 
 	return result, nil
+}
+
+// storeFeatureHooks extracts feature-only hooks from image metadata and
+// persists them to workspace.Result. These are the hooks declared in
+// devcontainer-feature.json files, stored separately from user hooks so
+// the resume path can dispatch them without the full metadata.
+func (e *Engine) storeFeatureHooks(wsID string, cfg *config.DevContainerConfig, metadata []*config.ImageMetadata) {
+	// MergeConfiguration produces lists with feature hooks first and user hook
+	// last. We store only the feature hooks (everything except the last entry
+	// which is the user's hook).
+	merged := config.MergeConfiguration(cfg, metadata)
+
+	result, _ := e.store.LoadResult(wsID)
+	if result == nil {
+		result = &workspace.Result{}
+	}
+
+	result.FeatureOnCreateCommands = toWorkspaceHooks(featureOnly(merged.OnCreateCommands, cfg.OnCreateCommand))
+	result.FeatureUpdateContentCommands = toWorkspaceHooks(featureOnly(merged.UpdateContentCommands, cfg.UpdateContentCommand))
+	result.FeaturePostCreateCommands = toWorkspaceHooks(featureOnly(merged.PostCreateCommands, cfg.PostCreateCommand))
+	result.FeaturePostStartCommands = toWorkspaceHooks(featureOnly(merged.PostStartCommands, cfg.PostStartCommand))
+	result.FeaturePostAttachCommands = toWorkspaceHooks(featureOnly(merged.PostAttachCommands, cfg.PostAttachCommand))
+
+	_ = e.store.SaveResult(wsID, result)
+}
+
+// featureOnly returns the merged hook list without the user's hook (last entry).
+// If the merged list only contains the user's hook, returns nil.
+func featureOnly(merged []config.LifecycleHook, userHook config.LifecycleHook) []config.LifecycleHook {
+	if len(merged) == 0 {
+		return nil
+	}
+	// The user's hook is the last entry (appended by mergeLifecycleHooks).
+	// If it's the only entry, there are no feature hooks.
+	if len(userHook) > 0 && len(merged) > 0 {
+		return merged[:len(merged)-1]
+	}
+	// No user hook means all entries are feature hooks.
+	return merged
+}
+
+// toWorkspaceHooks converts config.LifecycleHook slices to workspace.LifecycleHook slices.
+// The types are structurally identical (map[string][]string) but belong to different packages.
+func toWorkspaceHooks(hooks []config.LifecycleHook) []workspace.LifecycleHook {
+	if len(hooks) == 0 {
+		return nil
+	}
+	result := make([]workspace.LifecycleHook, len(hooks))
+	for i, h := range hooks {
+		result[i] = workspace.LifecycleHook(h)
+	}
+	return result
 }
 
 // toRestartResult converts an UpResult to a RestartResult.

--- a/internal/engine/finalize.go
+++ b/internal/engine/finalize.go
@@ -110,6 +110,8 @@ func (e *Engine) finalizeFreshPath(ctx context.Context, ws *workspace.Workspace,
 		// Store feature-only hooks so the resume/restart path can dispatch them
 		// without re-resolving features from OCI registries.
 		e.storeFeatureHooks(ws.ID, merged, cfg)
+	} else if opts.storedResult != nil {
+		hooks = hookSetWithStoredFeatures(cfg, opts.storedResult)
 	} else {
 		hooks = hookSetFromConfig(cfg)
 	}

--- a/internal/engine/finalize.go
+++ b/internal/engine/finalize.go
@@ -140,7 +140,11 @@ func (e *Engine) finalizeFreshPath(ctx context.Context, ws *workspace.Workspace,
 // persists them to workspace.Result. Uses the already-merged config to avoid a
 // redundant MergeConfiguration call.
 func (e *Engine) storeFeatureHooks(wsID string, merged *config.MergedDevContainerConfig, cfg *config.DevContainerConfig) {
-	result, _ := e.store.LoadResult(wsID)
+	result, err := e.store.LoadResult(wsID)
+	if err != nil {
+		e.logger.Warn("failed to load result for feature hook storage, skipping", "error", err)
+		return
+	}
 	if result == nil {
 		result = &workspace.Result{}
 	}
@@ -204,7 +208,7 @@ func prependStoredHooks(stored []workspace.LifecycleHook, existing []config.Life
 	if len(stored) == 0 {
 		return existing
 	}
-	result := make([]config.LifecycleHook, 0, len(stored)+len(existing))
+	result := make([]config.LifecycleHook, 0, len(stored))
 	for _, h := range stored {
 		result = append(result, config.LifecycleHook(h))
 	}

--- a/internal/engine/finalize.go
+++ b/internal/engine/finalize.go
@@ -86,7 +86,9 @@ func (e *Engine) finalizeFromSnapshotPath(ctx context.Context, ws *workspace.Wor
 	e.saveResult(ws, cfg, result)
 
 	// Run only resume-flow hooks (create-time effects are in the snapshot).
-	if err := e.runResumeHooks(ctx, ws, cfg, cc); err != nil {
+	// Include stored feature hooks so features' postStart/postAttach run too.
+	hooks := hookSetWithStoredFeatures(cfg, opts.storedResult)
+	if err := e.runResumeHooksWithSet(ctx, ws, cc, hooks); err != nil {
 		e.logger.Warn("resume hooks failed", "error", err)
 	}
 
@@ -177,6 +179,34 @@ func toWorkspaceHooks(hooks []config.LifecycleHook) []workspace.LifecycleHook {
 		result[i] = workspace.LifecycleHook(h)
 	}
 	return result
+}
+
+// hookSetWithStoredFeatures builds a hookSet by prepending stored feature hooks
+// from a workspace.Result to the user's hooks from the config.
+func hookSetWithStoredFeatures(cfg *config.DevContainerConfig, stored *workspace.Result) *hookSet {
+	hs := hookSetFromConfig(cfg)
+	if stored == nil {
+		return hs
+	}
+	hs.OnCreate = prependStoredHooks(stored.FeatureOnCreateCommands, hs.OnCreate)
+	hs.UpdateContent = prependStoredHooks(stored.FeatureUpdateContentCommands, hs.UpdateContent)
+	hs.PostCreate = prependStoredHooks(stored.FeaturePostCreateCommands, hs.PostCreate)
+	hs.PostStart = prependStoredHooks(stored.FeaturePostStartCommands, hs.PostStart)
+	hs.PostAttach = prependStoredHooks(stored.FeaturePostAttachCommands, hs.PostAttach)
+	return hs
+}
+
+// prependStoredHooks prepends workspace.LifecycleHook entries (feature hooks)
+// before the existing hook list (user hooks).
+func prependStoredHooks(stored []workspace.LifecycleHook, existing []config.LifecycleHook) []config.LifecycleHook {
+	if len(stored) == 0 {
+		return existing
+	}
+	result := make([]config.LifecycleHook, 0, len(stored)+len(existing))
+	for _, h := range stored {
+		result = append(result, config.LifecycleHook(h))
+	}
+	return append(result, existing...)
 }
 
 // toRestartResult converts an UpResult to a RestartResult.

--- a/internal/engine/finalize.go
+++ b/internal/engine/finalize.go
@@ -88,7 +88,8 @@ func (e *Engine) finalizeFromSnapshotPath(ctx context.Context, ws *workspace.Wor
 	// Run only resume-flow hooks (create-time effects are in the snapshot).
 	// Include stored feature hooks so features' postStart/postAttach run too.
 	hooks := hookSetWithStoredFeatures(cfg, opts.storedResult)
-	if err := e.runResumeHooksWithSet(ctx, ws, cc, hooks); err != nil {
+	runner := e.newLifecycleRunner(ws, cc, cfg.RemoteEnv)
+	if err := runner.runResumeHooks(ctx, hooks, cc.workspaceFolder); err != nil {
 		e.logger.Warn("resume hooks failed", "error", err)
 	}
 
@@ -101,17 +102,23 @@ func (e *Engine) finalizeFreshPath(ctx context.Context, ws *workspace.Workspace,
 	envb := NewEnvBuilder(cfg.RemoteEnv)
 	envb.AddPluginResponse(opts.pluginResp)
 
-	// Store feature hooks so the resume/restart path can dispatch them
-	// without re-resolving features from OCI registries.
+	// Merge feature hooks with user hooks once (used for both storage and dispatch).
+	var hooks *hookSet
 	if len(opts.imageMetadata) > 0 {
-		e.storeFeatureHooks(ws.ID, cfg, opts.imageMetadata)
+		merged := config.MergeConfiguration(cfg, opts.imageMetadata)
+		hooks = hookSetFromMerged(merged)
+		// Store feature-only hooks so the resume/restart path can dispatch them
+		// without re-resolving features from OCI registries.
+		e.storeFeatureHooks(ws.ID, merged, cfg)
+	} else {
+		hooks = hookSetFromConfig(cfg)
 	}
 
 	// Early save so crib exec/shell work while setup runs.
 	e.saveResult(ws, cfg, result)
 
 	// Run container setup (UID sync, env probe, lifecycle hooks).
-	finalEnv, err := e.setupContainer(ctx, ws, cfg, cc, envb, opts.imageMetadata)
+	finalEnv, err := e.setupContainer(ctx, ws, cfg, cc, envb, hooks)
 	cfg.RemoteEnv = finalEnv
 	if err != nil {
 		// Persist probed env even on hook failure so crib exec/shell
@@ -129,16 +136,10 @@ func (e *Engine) finalizeFreshPath(ctx context.Context, ws *workspace.Workspace,
 	return result, nil
 }
 
-// storeFeatureHooks extracts feature-only hooks from image metadata and
-// persists them to workspace.Result. These are the hooks declared in
-// devcontainer-feature.json files, stored separately from user hooks so
-// the resume path can dispatch them without the full metadata.
-func (e *Engine) storeFeatureHooks(wsID string, cfg *config.DevContainerConfig, metadata []*config.ImageMetadata) {
-	// MergeConfiguration produces lists with feature hooks first and user hook
-	// last. We store only the feature hooks (everything except the last entry
-	// which is the user's hook).
-	merged := config.MergeConfiguration(cfg, metadata)
-
+// storeFeatureHooks extracts feature-only hooks from the pre-merged config and
+// persists them to workspace.Result. Uses the already-merged config to avoid a
+// redundant MergeConfiguration call.
+func (e *Engine) storeFeatureHooks(wsID string, merged *config.MergedDevContainerConfig, cfg *config.DevContainerConfig) {
 	result, _ := e.store.LoadResult(wsID)
 	if result == nil {
 		result = &workspace.Result{}
@@ -150,7 +151,9 @@ func (e *Engine) storeFeatureHooks(wsID string, cfg *config.DevContainerConfig, 
 	result.FeaturePostStartCommands = toWorkspaceHooks(featureOnly(merged.PostStartCommands, cfg.PostStartCommand))
 	result.FeaturePostAttachCommands = toWorkspaceHooks(featureOnly(merged.PostAttachCommands, cfg.PostAttachCommand))
 
-	_ = e.store.SaveResult(wsID, result)
+	if err := e.store.SaveResult(wsID, result); err != nil {
+		e.logger.Warn("failed to store feature hooks", "error", err)
+	}
 }
 
 // featureOnly returns the merged hook list without the user's hook (last entry).
@@ -160,8 +163,7 @@ func featureOnly(merged []config.LifecycleHook, userHook config.LifecycleHook) [
 		return nil
 	}
 	// The user's hook is the last entry (appended by mergeLifecycleHooks).
-	// If it's the only entry, there are no feature hooks.
-	if len(userHook) > 0 && len(merged) > 0 {
+	if len(userHook) > 0 {
 		return merged[:len(merged)-1]
 	}
 	// No user hook means all entries are feature hooks.

--- a/internal/engine/finalize.go
+++ b/internal/engine/finalize.go
@@ -104,15 +104,16 @@ func (e *Engine) finalizeFreshPath(ctx context.Context, ws *workspace.Workspace,
 
 	// Merge feature hooks with user hooks once (used for both storage and dispatch).
 	var hooks *hookSet
-	if len(opts.imageMetadata) > 0 {
+	switch {
+	case len(opts.imageMetadata) > 0:
 		merged := config.MergeConfiguration(cfg, opts.imageMetadata)
 		hooks = hookSetFromMerged(merged)
 		// Store feature-only hooks so the resume/restart path can dispatch them
 		// without re-resolving features from OCI registries.
 		e.storeFeatureHooks(ws.ID, merged, cfg)
-	} else if opts.storedResult != nil {
+	case opts.storedResult != nil:
 		hooks = hookSetWithStoredFeatures(cfg, opts.storedResult)
-	} else {
+	default:
 		hooks = hookSetFromConfig(cfg)
 	}
 

--- a/internal/engine/integration_test.go
+++ b/internal/engine/integration_test.go
@@ -667,6 +667,155 @@ func TestIntegrationSnapshot(t *testing.T) {
 	}
 }
 
+func TestIntegrationFeatureLifecycleHooks(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	e, d, _ := newTestEngine(t)
+	e.SetOutput(os.Stdout, os.Stderr)
+
+	projectDir := t.TempDir()
+	devcontainerDir := filepath.Join(projectDir, ".devcontainer")
+	featureDir := filepath.Join(devcontainerDir, "test-feature")
+	if err := os.MkdirAll(featureDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Local feature with lifecycle hooks. The feature's onCreateCommand should
+	// run before the user's onCreateCommand, and postStartCommand should run
+	// on every start.
+	featureJSON := `{
+		"id": "test-feature",
+		"version": "1.0.0",
+		"name": "Test Feature",
+		"onCreateCommand": "echo feature-oncreate > /tmp/feature-oncreate-ran",
+		"postStartCommand": "echo feature-poststart > /tmp/feature-poststart-ran"
+	}`
+	if err := os.WriteFile(filepath.Join(featureDir, "devcontainer-feature.json"), []byte(featureJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Minimal install.sh (required by feature spec).
+	if err := os.WriteFile(filepath.Join(featureDir, "install.sh"), []byte("#!/bin/sh\necho 'test-feature installed'\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// devcontainer.json references the local feature and has its own hooks.
+	// The user's onCreateCommand writes a timestamp so we can verify ordering:
+	// feature hook should have written its marker before the user hook runs.
+	configContent := `{
+		"image": "alpine:3.20",
+		"overrideCommand": true,
+		"features": {
+			"./test-feature": {}
+		},
+		"onCreateCommand": "test -f /tmp/feature-oncreate-ran && echo user-after-feature > /tmp/user-oncreate-ran",
+		"postStartCommand": "echo user-poststart > /tmp/user-poststart-ran"
+	}`
+	if err := os.WriteFile(filepath.Join(devcontainerDir, "devcontainer.json"), []byte(configContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	wsID := "test-engine-feature-hooks"
+	ws := &workspace.Workspace{
+		ID:               wsID,
+		Source:           projectDir,
+		DevContainerPath: ".devcontainer/devcontainer.json",
+		CreatedAt:        time.Now(),
+		LastUsedAt:       time.Now(),
+	}
+
+	_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
+	t.Cleanup(func() {
+		_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
+		cleanupWorkspaceImages(t, d, wsID)
+	})
+
+	result, err := e.Up(ctx, ws, UpOptions{})
+	if err != nil {
+		t.Fatalf("Up: %v", err)
+	}
+
+	// Verify feature onCreateCommand ran.
+	var stdout bytes.Buffer
+	if err := d.ExecContainer(ctx, wsID, result.ContainerID, []string{"cat", "/tmp/feature-oncreate-ran"}, nil, &stdout, nil, nil, ""); err != nil {
+		t.Errorf("feature onCreateCommand did not run: %v", err)
+	}
+
+	// Verify user onCreateCommand ran AND that it ran after the feature hook
+	// (it checks for /tmp/feature-oncreate-ran before writing its own marker).
+	stdout.Reset()
+	if err := d.ExecContainer(ctx, wsID, result.ContainerID, []string{"cat", "/tmp/user-oncreate-ran"}, nil, &stdout, nil, nil, ""); err != nil {
+		t.Errorf("user onCreateCommand did not run (or ran before feature hook): %v", err)
+	} else if got := strings.TrimSpace(stdout.String()); got != "user-after-feature" {
+		t.Errorf("user onCreateCommand output = %q, want 'user-after-feature'", got)
+	}
+
+	// Verify feature postStartCommand ran.
+	stdout.Reset()
+	if err := d.ExecContainer(ctx, wsID, result.ContainerID, []string{"test", "-f", "/tmp/feature-poststart-ran"}, nil, &stdout, nil, nil, ""); err != nil {
+		t.Errorf("feature postStartCommand did not run: %v", err)
+	}
+
+	// Verify user postStartCommand ran.
+	stdout.Reset()
+	if err := d.ExecContainer(ctx, wsID, result.ContainerID, []string{"test", "-f", "/tmp/user-poststart-ran"}, nil, &stdout, nil, nil, ""); err != nil {
+		t.Errorf("user postStartCommand did not run: %v", err)
+	}
+
+	// Verify feature hooks are stored in result.json for the resume path.
+	storedResult, err := e.store.LoadResult(wsID)
+	if err != nil {
+		t.Fatalf("LoadResult: %v", err)
+	}
+	if len(storedResult.FeatureOnCreateCommands) == 0 {
+		t.Error("FeatureOnCreateCommands should be stored in result")
+	}
+	if len(storedResult.FeaturePostStartCommands) == 0 {
+		t.Error("FeaturePostStartCommands should be stored in result")
+	}
+
+	// Verify snapshot was committed (feature has create-time hooks).
+	if storedResult.SnapshotImage == "" {
+		t.Error("SnapshotImage should be set (feature has onCreateCommand)")
+	}
+
+	// --- Resume path: Down + Up should run feature postStartCommand again ---
+
+	// Remove the postStart markers so we can verify they re-run.
+	_ = d.ExecContainer(ctx, wsID, result.ContainerID, []string{"rm", "-f", "/tmp/feature-poststart-ran", "/tmp/user-poststart-ran"}, nil, nil, nil, nil, "")
+
+	if err := e.Down(ctx, ws); err != nil {
+		t.Fatalf("Down: %v", err)
+	}
+
+	result2, err := e.Up(ctx, ws, UpOptions{})
+	if err != nil {
+		t.Fatalf("Up (resume): %v", err)
+	}
+
+	// Feature postStartCommand should have run again on resume.
+	stdout.Reset()
+	if err := d.ExecContainer(ctx, wsID, result2.ContainerID, []string{"test", "-f", "/tmp/feature-poststart-ran"}, nil, &stdout, nil, nil, ""); err != nil {
+		t.Errorf("feature postStartCommand did not run on resume: %v", err)
+	}
+
+	// User postStartCommand should have run again on resume.
+	stdout.Reset()
+	if err := d.ExecContainer(ctx, wsID, result2.ContainerID, []string{"test", "-f", "/tmp/user-poststart-ran"}, nil, &stdout, nil, nil, ""); err != nil {
+		t.Errorf("user postStartCommand did not run on resume: %v", err)
+	}
+
+	// Feature onCreateCommand should NOT re-run (it is in the snapshot).
+	// The marker should still exist from the snapshot, but let's verify
+	// the hook markers were cleared by Down and not re-created.
+	// Actually, Down clears hook markers, and the resume path skips
+	// create-time hooks because the snapshot is valid. The marker file
+	// exists in the snapshot image, not because the hook re-ran.
+}
+
 func TestIntegrationDoctor(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")

--- a/internal/engine/integration_test.go
+++ b/internal/engine/integration_test.go
@@ -808,12 +808,6 @@ func TestIntegrationFeatureLifecycleHooks(t *testing.T) {
 		t.Errorf("user postStartCommand did not run on resume: %v", err)
 	}
 
-	// Feature onCreateCommand should NOT re-run (it is in the snapshot).
-	// The marker should still exist from the snapshot, but let's verify
-	// the hook markers were cleared by Down and not re-created.
-	// Actually, Down clears hook markers, and the resume path skips
-	// create-time hooks because the snapshot is valid. The marker file
-	// exists in the snapshot image, not because the hook re-ran.
 }
 
 func TestIntegrationDoctor(t *testing.T) {

--- a/internal/engine/lifecycle.go
+++ b/internal/engine/lifecycle.go
@@ -27,6 +27,11 @@ type lifecycleRunner struct {
 	stderr      io.Writer
 	progress    func(string)
 	verbose     bool
+
+	// featureHooks holds lifecycle hooks declared by DevContainer Features.
+	// When non-nil, feature hooks are dispatched before user hooks at each
+	// stage, in feature installation order (per the spec).
+	featureHooks *config.MergedConfigProperties
 }
 
 // newLifecycleRunner creates a lifecycleRunner from the engine's dependencies,
@@ -52,38 +57,45 @@ func (e *Engine) newLifecycleRunner(ws *workspace.Workspace, cc containerContext
 // create-time hooks (onCreate, updateContent, postCreate).
 // After the stage named by cfg.WaitFor (default: "updateContentCommand"),
 // a "Container ready." progress message is emitted.
+//
+// When featureHooks is set, feature-declared hooks are dispatched before
+// user hooks at each stage, in feature installation order.
 func (r *lifecycleRunner) runLifecycleHooks(ctx context.Context, cfg *config.DevContainerConfig, workspaceFolder string) error {
 	waitFor := cfg.WaitFor
 	if waitFor == "" {
 		waitFor = "updateContentCommand"
 	}
 
-	// onCreate hooks: run only once (marker file prevents re-execution).
-	if err := r.runHookWithMarker(ctx, "onCreateCommand", cfg.OnCreateCommand, workspaceFolder); err != nil {
+	fh := func(get func(*config.MergedConfigProperties) []config.LifecycleHook) []config.LifecycleHook {
+		return r.featureHookList(get)
+	}
+
+	// onCreate hooks: feature hooks first, then user hook. Run only once.
+	if err := r.runStageWithMarker(ctx, "onCreateCommand", fh(func(m *config.MergedConfigProperties) []config.LifecycleHook { return m.OnCreateCommands }), cfg.OnCreateCommand, workspaceFolder); err != nil {
 		return err
 	}
 	r.signalReadyAt("onCreateCommand", waitFor)
 
 	// updateContent hooks.
-	if err := r.runHookWithMarker(ctx, "updateContentCommand", cfg.UpdateContentCommand, workspaceFolder); err != nil {
+	if err := r.runStageWithMarker(ctx, "updateContentCommand", fh(func(m *config.MergedConfigProperties) []config.LifecycleHook { return m.UpdateContentCommands }), cfg.UpdateContentCommand, workspaceFolder); err != nil {
 		return err
 	}
 	r.signalReadyAt("updateContentCommand", waitFor)
 
 	// postCreate hooks: run only once.
-	if err := r.runHookWithMarker(ctx, "postCreateCommand", cfg.PostCreateCommand, workspaceFolder); err != nil {
+	if err := r.runStageWithMarker(ctx, "postCreateCommand", fh(func(m *config.MergedConfigProperties) []config.LifecycleHook { return m.PostCreateCommands }), cfg.PostCreateCommand, workspaceFolder); err != nil {
 		return err
 	}
 	r.signalReadyAt("postCreateCommand", waitFor)
 
 	// postStart hooks: run every time the container starts.
-	if err := r.runHook(ctx, "postStartCommand", cfg.PostStartCommand, workspaceFolder); err != nil {
+	if err := r.runStage(ctx, "postStartCommand", fh(func(m *config.MergedConfigProperties) []config.LifecycleHook { return m.PostStartCommands }), cfg.PostStartCommand, workspaceFolder); err != nil {
 		return err
 	}
 	r.signalReadyAt("postStartCommand", waitFor)
 
 	// postAttach hooks: run every time.
-	if err := r.runHook(ctx, "postAttachCommand", cfg.PostAttachCommand, workspaceFolder); err != nil {
+	if err := r.runStage(ctx, "postAttachCommand", fh(func(m *config.MergedConfigProperties) []config.LifecycleHook { return m.PostAttachCommands }), cfg.PostAttachCommand, workspaceFolder); err != nil {
 		return err
 	}
 
@@ -101,39 +113,57 @@ func (r *lifecycleRunner) signalReadyAt(stage, waitFor string) {
 // and postAttachCommand). Per the devcontainer spec, these are the only hooks
 // that run when a container is restarted (as opposed to freshly created).
 func (r *lifecycleRunner) runResumeHooks(ctx context.Context, cfg *config.DevContainerConfig, workspaceFolder string) error {
-	// postStart hooks: run every time the container starts.
-	if err := r.runHook(ctx, "postStartCommand", cfg.PostStartCommand, workspaceFolder); err != nil {
+	fh := func(get func(*config.MergedConfigProperties) []config.LifecycleHook) []config.LifecycleHook {
+		return r.featureHookList(get)
+	}
+
+	// postStart hooks: feature hooks first, then user hook.
+	if err := r.runStage(ctx, "postStartCommand", fh(func(m *config.MergedConfigProperties) []config.LifecycleHook { return m.PostStartCommands }), cfg.PostStartCommand, workspaceFolder); err != nil {
 		return err
 	}
 
-	// postAttach hooks: run every time.
-	if err := r.runHook(ctx, "postAttachCommand", cfg.PostAttachCommand, workspaceFolder); err != nil {
+	// postAttach hooks: feature hooks first, then user hook.
+	if err := r.runStage(ctx, "postAttachCommand", fh(func(m *config.MergedConfigProperties) []config.LifecycleHook { return m.PostAttachCommands }), cfg.PostAttachCommand, workspaceFolder); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-// runHookWithMarker executes a lifecycle hook, using a host-side marker
-// file to ensure it only runs once. Markers are stored in the workspace
-// directory (~/.crib/workspaces/{id}/hooks/) so they survive container
-// recreation (e.g. docker compose up recreating stopped containers).
-func (r *lifecycleRunner) runHookWithMarker(ctx context.Context, name string, hook config.LifecycleHook, workspaceFolder string) error {
-	if len(hook) == 0 {
+// featureHookList returns the feature hook list for a stage, or nil.
+func (r *lifecycleRunner) featureHookList(get func(*config.MergedConfigProperties) []config.LifecycleHook) []config.LifecycleHook {
+	if r.featureHooks == nil {
+		return nil
+	}
+	return get(r.featureHooks)
+}
+
+// runStage dispatches feature hooks followed by the user hook for a stage.
+func (r *lifecycleRunner) runStage(ctx context.Context, name string, featureHooks []config.LifecycleHook, userHook config.LifecycleHook, workspaceFolder string) error {
+	for _, fh := range featureHooks {
+		if err := r.runHook(ctx, name, fh, workspaceFolder); err != nil {
+			return err
+		}
+	}
+	return r.runHook(ctx, name, userHook, workspaceFolder)
+}
+
+// runStageWithMarker dispatches feature hooks followed by the user hook,
+// using a host-side marker file to ensure the entire stage only runs once.
+func (r *lifecycleRunner) runStageWithMarker(ctx context.Context, name string, featureHooks []config.LifecycleHook, userHook config.LifecycleHook, workspaceFolder string) error {
+	if len(featureHooks) == 0 && len(userHook) == 0 {
 		return nil
 	}
 
-	// Check if marker exists on the host (hook already ran).
 	if r.store.IsHookDone(r.workspaceID, name) {
 		r.logger.Debug("skipping hook (already ran)", "hook", name)
 		return nil
 	}
 
-	if err := r.runHook(ctx, name, hook, workspaceFolder); err != nil {
+	if err := r.runStage(ctx, name, featureHooks, userHook, workspaceFolder); err != nil {
 		return err
 	}
 
-	// Create marker file on the host.
 	if err := r.store.MarkHookDone(r.workspaceID, name); err != nil {
 		r.logger.Warn("failed to write hook marker", "hook", name, "error", err)
 	}

--- a/internal/engine/lifecycle.go
+++ b/internal/engine/lifecycle.go
@@ -27,11 +27,6 @@ type lifecycleRunner struct {
 	stderr      io.Writer
 	progress    func(string)
 	verbose     bool
-
-	// featureHooks holds lifecycle hooks declared by DevContainer Features.
-	// When non-nil, feature hooks are dispatched before user hooks at each
-	// stage, in feature installation order (per the spec).
-	featureHooks *config.MergedConfigProperties
 }
 
 // newLifecycleRunner creates a lifecycleRunner from the engine's dependencies,
@@ -52,50 +47,80 @@ func (e *Engine) newLifecycleRunner(ws *workspace.Workspace, cc containerContext
 	}
 }
 
+// hookSet holds the merged lifecycle hook lists for all stages. Each list
+// contains feature hooks (in installation order) followed by the user hook.
+// Built by hookSetFromConfig (no features) or from MergeConfiguration output.
+type hookSet struct {
+	OnCreate      []config.LifecycleHook
+	UpdateContent []config.LifecycleHook
+	PostCreate    []config.LifecycleHook
+	PostStart     []config.LifecycleHook
+	PostAttach    []config.LifecycleHook
+	WaitFor       string
+}
+
+// hookSetFromConfig builds a hookSet from a DevContainerConfig with no feature
+// hooks. Each list contains at most the user's hook.
+func hookSetFromConfig(cfg *config.DevContainerConfig) *hookSet {
+	hs := &hookSet{WaitFor: cfg.WaitFor}
+	if len(cfg.OnCreateCommand) > 0 {
+		hs.OnCreate = []config.LifecycleHook{cfg.OnCreateCommand}
+	}
+	if len(cfg.UpdateContentCommand) > 0 {
+		hs.UpdateContent = []config.LifecycleHook{cfg.UpdateContentCommand}
+	}
+	if len(cfg.PostCreateCommand) > 0 {
+		hs.PostCreate = []config.LifecycleHook{cfg.PostCreateCommand}
+	}
+	if len(cfg.PostStartCommand) > 0 {
+		hs.PostStart = []config.LifecycleHook{cfg.PostStartCommand}
+	}
+	if len(cfg.PostAttachCommand) > 0 {
+		hs.PostAttach = []config.LifecycleHook{cfg.PostAttachCommand}
+	}
+	return hs
+}
+
 // runLifecycleHooks executes the devcontainer lifecycle hooks in order.
 // Hooks run as the remote user. Marker files provide idempotency for
 // create-time hooks (onCreate, updateContent, postCreate).
-// After the stage named by cfg.WaitFor (default: "updateContentCommand"),
+// After the stage named by hooks.WaitFor (default: "updateContentCommand"),
 // a "Container ready." progress message is emitted.
 //
-// When featureHooks is set, feature-declared hooks are dispatched before
-// user hooks at each stage, in feature installation order.
-func (r *lifecycleRunner) runLifecycleHooks(ctx context.Context, cfg *config.DevContainerConfig, workspaceFolder string) error {
-	waitFor := cfg.WaitFor
+// Each hook list may contain feature hooks (first) followed by the user hook
+// (last), as produced by config.MergeConfiguration.
+func (r *lifecycleRunner) runLifecycleHooks(ctx context.Context, hooks *hookSet, workspaceFolder string) error {
+	waitFor := hooks.WaitFor
 	if waitFor == "" {
 		waitFor = "updateContentCommand"
 	}
 
-	fh := func(get func(*config.MergedConfigProperties) []config.LifecycleHook) []config.LifecycleHook {
-		return r.featureHookList(get)
-	}
-
-	// onCreate hooks: feature hooks first, then user hook. Run only once.
-	if err := r.runStageWithMarker(ctx, "onCreateCommand", fh(func(m *config.MergedConfigProperties) []config.LifecycleHook { return m.OnCreateCommands }), cfg.OnCreateCommand, workspaceFolder); err != nil {
+	// onCreate hooks: run only once (marker file prevents re-execution).
+	if err := r.runStageWithMarker(ctx, "onCreateCommand", hooks.OnCreate, workspaceFolder); err != nil {
 		return err
 	}
 	r.signalReadyAt("onCreateCommand", waitFor)
 
 	// updateContent hooks.
-	if err := r.runStageWithMarker(ctx, "updateContentCommand", fh(func(m *config.MergedConfigProperties) []config.LifecycleHook { return m.UpdateContentCommands }), cfg.UpdateContentCommand, workspaceFolder); err != nil {
+	if err := r.runStageWithMarker(ctx, "updateContentCommand", hooks.UpdateContent, workspaceFolder); err != nil {
 		return err
 	}
 	r.signalReadyAt("updateContentCommand", waitFor)
 
 	// postCreate hooks: run only once.
-	if err := r.runStageWithMarker(ctx, "postCreateCommand", fh(func(m *config.MergedConfigProperties) []config.LifecycleHook { return m.PostCreateCommands }), cfg.PostCreateCommand, workspaceFolder); err != nil {
+	if err := r.runStageWithMarker(ctx, "postCreateCommand", hooks.PostCreate, workspaceFolder); err != nil {
 		return err
 	}
 	r.signalReadyAt("postCreateCommand", waitFor)
 
 	// postStart hooks: run every time the container starts.
-	if err := r.runStage(ctx, "postStartCommand", fh(func(m *config.MergedConfigProperties) []config.LifecycleHook { return m.PostStartCommands }), cfg.PostStartCommand, workspaceFolder); err != nil {
+	if err := r.runStage(ctx, "postStartCommand", hooks.PostStart, workspaceFolder); err != nil {
 		return err
 	}
 	r.signalReadyAt("postStartCommand", waitFor)
 
 	// postAttach hooks: run every time.
-	if err := r.runStage(ctx, "postAttachCommand", fh(func(m *config.MergedConfigProperties) []config.LifecycleHook { return m.PostAttachCommands }), cfg.PostAttachCommand, workspaceFolder); err != nil {
+	if err := r.runStage(ctx, "postAttachCommand", hooks.PostAttach, workspaceFolder); err != nil {
 		return err
 	}
 
@@ -112,46 +137,28 @@ func (r *lifecycleRunner) signalReadyAt(stage, waitFor string) {
 // runResumeHooks executes only the resume-flow lifecycle hooks (postStartCommand
 // and postAttachCommand). Per the devcontainer spec, these are the only hooks
 // that run when a container is restarted (as opposed to freshly created).
-func (r *lifecycleRunner) runResumeHooks(ctx context.Context, cfg *config.DevContainerConfig, workspaceFolder string) error {
-	fh := func(get func(*config.MergedConfigProperties) []config.LifecycleHook) []config.LifecycleHook {
-		return r.featureHookList(get)
-	}
-
-	// postStart hooks: feature hooks first, then user hook.
-	if err := r.runStage(ctx, "postStartCommand", fh(func(m *config.MergedConfigProperties) []config.LifecycleHook { return m.PostStartCommands }), cfg.PostStartCommand, workspaceFolder); err != nil {
+func (r *lifecycleRunner) runResumeHooks(ctx context.Context, hooks *hookSet, workspaceFolder string) error {
+	if err := r.runStage(ctx, "postStartCommand", hooks.PostStart, workspaceFolder); err != nil {
 		return err
 	}
-
-	// postAttach hooks: feature hooks first, then user hook.
-	if err := r.runStage(ctx, "postAttachCommand", fh(func(m *config.MergedConfigProperties) []config.LifecycleHook { return m.PostAttachCommands }), cfg.PostAttachCommand, workspaceFolder); err != nil {
-		return err
-	}
-
-	return nil
+	return r.runStage(ctx, "postAttachCommand", hooks.PostAttach, workspaceFolder)
 }
 
-// featureHookList returns the feature hook list for a stage, or nil.
-func (r *lifecycleRunner) featureHookList(get func(*config.MergedConfigProperties) []config.LifecycleHook) []config.LifecycleHook {
-	if r.featureHooks == nil {
-		return nil
-	}
-	return get(r.featureHooks)
-}
-
-// runStage dispatches feature hooks followed by the user hook for a stage.
-func (r *lifecycleRunner) runStage(ctx context.Context, name string, featureHooks []config.LifecycleHook, userHook config.LifecycleHook, workspaceFolder string) error {
-	for _, fh := range featureHooks {
-		if err := r.runHook(ctx, name, fh, workspaceFolder); err != nil {
+// runStage dispatches a merged list of hooks for a stage. The list typically
+// contains feature hooks first (in installation order) then the user hook.
+func (r *lifecycleRunner) runStage(ctx context.Context, name string, hooks []config.LifecycleHook, workspaceFolder string) error {
+	for _, h := range hooks {
+		if err := r.runHook(ctx, name, h, workspaceFolder); err != nil {
 			return err
 		}
 	}
-	return r.runHook(ctx, name, userHook, workspaceFolder)
+	return nil
 }
 
-// runStageWithMarker dispatches feature hooks followed by the user hook,
-// using a host-side marker file to ensure the entire stage only runs once.
-func (r *lifecycleRunner) runStageWithMarker(ctx context.Context, name string, featureHooks []config.LifecycleHook, userHook config.LifecycleHook, workspaceFolder string) error {
-	if len(featureHooks) == 0 && len(userHook) == 0 {
+// runStageWithMarker dispatches a merged hook list, using a host-side marker
+// file to ensure the entire stage only runs once.
+func (r *lifecycleRunner) runStageWithMarker(ctx context.Context, name string, hooks []config.LifecycleHook, workspaceFolder string) error {
+	if len(hooks) == 0 {
 		return nil
 	}
 
@@ -160,7 +167,7 @@ func (r *lifecycleRunner) runStageWithMarker(ctx context.Context, name string, f
 		return nil
 	}
 
-	if err := r.runStage(ctx, name, featureHooks, userHook, workspaceFolder); err != nil {
+	if err := r.runStage(ctx, name, hooks, workspaceFolder); err != nil {
 		return err
 	}
 

--- a/internal/engine/lifecycle.go
+++ b/internal/engine/lifecycle.go
@@ -137,6 +137,7 @@ func (r *lifecycleRunner) runLifecycleHooks(ctx context.Context, hooks *hookSet,
 	if err := r.runStage(ctx, "postAttachCommand", hooks.PostAttach, workspaceFolder); err != nil {
 		return err
 	}
+	r.signalReadyAt("postAttachCommand", waitFor)
 
 	return nil
 }

--- a/internal/engine/lifecycle.go
+++ b/internal/engine/lifecycle.go
@@ -59,6 +59,20 @@ type hookSet struct {
 	WaitFor       string
 }
 
+// hookSetFromMerged builds a hookSet from a MergedDevContainerConfig. The
+// merged config's plural hook lists already contain feature hooks first and
+// user hook last (as produced by config.MergeConfiguration).
+func hookSetFromMerged(m *config.MergedDevContainerConfig) *hookSet {
+	return &hookSet{
+		OnCreate:      m.OnCreateCommands,
+		UpdateContent: m.UpdateContentCommands,
+		PostCreate:    m.PostCreateCommands,
+		PostStart:     m.PostStartCommands,
+		PostAttach:    m.PostAttachCommands,
+		WaitFor:       m.WaitFor,
+	}
+}
+
 // hookSetFromConfig builds a hookSet from a DevContainerConfig with no feature
 // hooks. Each list contains at most the user's hook.
 func hookSetFromConfig(cfg *config.DevContainerConfig) *hookSet {

--- a/internal/engine/lifecycle_test.go
+++ b/internal/engine/lifecycle_test.go
@@ -531,6 +531,40 @@ func TestRunResumeHooks_FeatureHooksBeforeUser(t *testing.T) {
 	}
 }
 
+func TestHookSetWithStoredFeatures(t *testing.T) {
+	cfg := &config.DevContainerConfig{}
+	cfg.PostStartCommand = config.LifecycleHook{"": {"echo user-poststart"}}
+
+	stored := &workspace.Result{
+		FeaturePostStartCommands: []workspace.LifecycleHook{
+			{"": {"echo feature-poststart"}},
+		},
+	}
+
+	hs := hookSetWithStoredFeatures(cfg, stored)
+
+	if len(hs.PostStart) != 2 {
+		t.Fatalf("PostStart length = %d, want 2 (feature + user)", len(hs.PostStart))
+	}
+	// Feature hook first, user hook second.
+	if hs.PostStart[0][""][0] != "echo feature-poststart" {
+		t.Errorf("PostStart[0] = %v, want feature hook", hs.PostStart[0])
+	}
+	if hs.PostStart[1][""][0] != "echo user-poststart" {
+		t.Errorf("PostStart[1] = %v, want user hook", hs.PostStart[1])
+	}
+}
+
+func TestHookSetWithStoredFeatures_NilStored(t *testing.T) {
+	cfg := &config.DevContainerConfig{}
+	cfg.PostStartCommand = config.LifecycleHook{"": {"echo user"}}
+
+	hs := hookSetWithStoredFeatures(cfg, nil)
+	if len(hs.PostStart) != 1 {
+		t.Fatalf("PostStart length = %d, want 1 (user only)", len(hs.PostStart))
+	}
+}
+
 func TestHookSetFromMerged_IncludesAllStages(t *testing.T) {
 	merged := &config.MergedDevContainerConfig{}
 	merged.OnCreateCommands = []config.LifecycleHook{{"": {"echo feature-oncreate"}}, {"": {"echo user-oncreate"}}}

--- a/internal/engine/lifecycle_test.go
+++ b/internal/engine/lifecycle_test.go
@@ -298,7 +298,7 @@ func TestRunLifecycleHooks_WaitFor_Default(t *testing.T) {
 	cfg.PostCreateCommand = config.LifecycleHook{"": {"echo postcreate"}}
 	// WaitFor = "" → defaults to updateContentCommand
 
-	if err := r.runLifecycleHooks(context.Background(), cfg, ""); err != nil {
+	if err := r.runLifecycleHooks(context.Background(), hookSetFromConfig(cfg), ""); err != nil {
 		t.Fatalf("runLifecycleHooks: %v", err)
 	}
 
@@ -336,7 +336,7 @@ func TestRunLifecycleHooks_WaitFor_OnCreate(t *testing.T) {
 	cfg.OnCreateCommand = config.LifecycleHook{"": {"echo create"}}
 	cfg.UpdateContentCommand = config.LifecycleHook{"": {"echo update"}}
 
-	if err := r.runLifecycleHooks(context.Background(), cfg, ""); err != nil {
+	if err := r.runLifecycleHooks(context.Background(), hookSetFromConfig(cfg), ""); err != nil {
 		t.Fatalf("runLifecycleHooks: %v", err)
 	}
 
@@ -370,7 +370,7 @@ func TestRunLifecycleHooks_WaitFor_PostCreate(t *testing.T) {
 	cfg.PostCreateCommand = config.LifecycleHook{"": {"echo postcreate"}}
 	cfg.PostStartCommand = config.LifecycleHook{"": {"echo poststart"}}
 
-	if err := r.runLifecycleHooks(context.Background(), cfg, ""); err != nil {
+	if err := r.runLifecycleHooks(context.Background(), hookSetFromConfig(cfg), ""); err != nil {
 		t.Fatalf("runLifecycleHooks: %v", err)
 	}
 
@@ -404,7 +404,7 @@ func TestRunLifecycleHooks_WaitFor_PostStart(t *testing.T) {
 	cfg.PostStartCommand = config.LifecycleHook{"": {"echo poststart"}}
 	cfg.PostAttachCommand = config.LifecycleHook{"": {"echo postattach"}}
 
-	if err := r.runLifecycleHooks(context.Background(), cfg, ""); err != nil {
+	if err := r.runLifecycleHooks(context.Background(), hookSetFromConfig(cfg), ""); err != nil {
 		t.Fatalf("runLifecycleHooks: %v", err)
 	}
 
@@ -429,23 +429,22 @@ func TestRunLifecycleHooks_WaitFor_PostStart(t *testing.T) {
 
 func TestRunLifecycleHooks_FeatureHooksBeforeUser(t *testing.T) {
 	// Feature hooks should execute before user hooks at each stage.
+	// The merged hookSet contains feature hooks first, user hook last.
 	mock := &mockDriver{}
 	r, _, _ := newTestRunner(t, mock)
 
-	r.featureHooks = &config.MergedConfigProperties{
-		OnCreateCommands: []config.LifecycleHook{
+	hooks := &hookSet{
+		OnCreate: []config.LifecycleHook{
 			{"": {"echo feature-oncreate"}},
+			{"": {"echo user-oncreate"}},
 		},
-		PostStartCommands: []config.LifecycleHook{
+		PostStart: []config.LifecycleHook{
 			{"": {"echo feature-poststart"}},
+			{"": {"echo user-poststart"}},
 		},
 	}
 
-	cfg := &config.DevContainerConfig{}
-	cfg.OnCreateCommand = config.LifecycleHook{"": {"echo user-oncreate"}}
-	cfg.PostStartCommand = config.LifecycleHook{"": {"echo user-poststart"}}
-
-	if err := r.runLifecycleHooks(context.Background(), cfg, ""); err != nil {
+	if err := r.runLifecycleHooks(context.Background(), hooks, ""); err != nil {
 		t.Fatalf("runLifecycleHooks: %v", err)
 	}
 
@@ -479,17 +478,16 @@ func TestRunLifecycleHooks_FeatureHooksOnly(t *testing.T) {
 	mock := &mockDriver{}
 	r, _, _ := newTestRunner(t, mock)
 
-	r.featureHooks = &config.MergedConfigProperties{
-		PostStartCommands: []config.LifecycleHook{
+	hooks := &hookSet{
+		PostStart: []config.LifecycleHook{
 			{"": {"echo feature-poststart"}},
 		},
-		PostAttachCommands: []config.LifecycleHook{
+		PostAttach: []config.LifecycleHook{
 			{"": {"echo feature-postattach"}},
 		},
 	}
 
-	cfg := &config.DevContainerConfig{}
-	if err := r.runLifecycleHooks(context.Background(), cfg, ""); err != nil {
+	if err := r.runLifecycleHooks(context.Background(), hooks, ""); err != nil {
 		t.Fatalf("runLifecycleHooks: %v", err)
 	}
 
@@ -502,20 +500,18 @@ func TestRunResumeHooks_FeatureHooksBeforeUser(t *testing.T) {
 	mock := &mockDriver{}
 	r, _, _ := newTestRunner(t, mock)
 
-	r.featureHooks = &config.MergedConfigProperties{
-		PostStartCommands: []config.LifecycleHook{
+	hooks := &hookSet{
+		PostStart: []config.LifecycleHook{
 			{"": {"echo feature-poststart"}},
+			{"": {"echo user-poststart"}},
 		},
-		PostAttachCommands: []config.LifecycleHook{
+		PostAttach: []config.LifecycleHook{
 			{"": {"echo feature-postattach"}},
+			{"": {"echo user-postattach"}},
 		},
 	}
 
-	cfg := &config.DevContainerConfig{}
-	cfg.PostStartCommand = config.LifecycleHook{"": {"echo user-poststart"}}
-	cfg.PostAttachCommand = config.LifecycleHook{"": {"echo user-postattach"}}
-
-	if err := r.runResumeHooks(context.Background(), cfg, ""); err != nil {
+	if err := r.runResumeHooks(context.Background(), hooks, ""); err != nil {
 		t.Fatalf("runResumeHooks: %v", err)
 	}
 
@@ -556,7 +552,7 @@ func TestRunLifecycleHooks_NoReadyWhenNoHooks(t *testing.T) {
 	cfg := &config.DevContainerConfig{}
 	// No hooks configured; waitFor defaults to updateContentCommand.
 
-	if err := r.runLifecycleHooks(context.Background(), cfg, ""); err != nil {
+	if err := r.runLifecycleHooks(context.Background(), hookSetFromConfig(cfg), ""); err != nil {
 		t.Fatalf("runLifecycleHooks: %v", err)
 	}
 

--- a/internal/engine/lifecycle_test.go
+++ b/internal/engine/lifecycle_test.go
@@ -427,6 +427,124 @@ func TestRunLifecycleHooks_WaitFor_PostStart(t *testing.T) {
 	}
 }
 
+func TestRunLifecycleHooks_FeatureHooksBeforeUser(t *testing.T) {
+	// Feature hooks should execute before user hooks at each stage.
+	mock := &mockDriver{}
+	r, _, _ := newTestRunner(t, mock)
+
+	r.featureHooks = &config.MergedConfigProperties{
+		OnCreateCommands: []config.LifecycleHook{
+			{"": {"echo feature-oncreate"}},
+		},
+		PostStartCommands: []config.LifecycleHook{
+			{"": {"echo feature-poststart"}},
+		},
+	}
+
+	cfg := &config.DevContainerConfig{}
+	cfg.OnCreateCommand = config.LifecycleHook{"": {"echo user-oncreate"}}
+	cfg.PostStartCommand = config.LifecycleHook{"": {"echo user-poststart"}}
+
+	if err := r.runLifecycleHooks(context.Background(), cfg, ""); err != nil {
+		t.Fatalf("runLifecycleHooks: %v", err)
+	}
+
+	// Collect exec commands in order.
+	var cmds []string
+	for _, call := range mock.execCalls {
+		cmds = append(cmds, strings.Join(call.cmd, " "))
+	}
+
+	featureOnCreateIdx := indexOfCmd(cmds, "feature-oncreate")
+	userOnCreateIdx := indexOfCmd(cmds, "user-oncreate")
+	featurePostStartIdx := indexOfCmd(cmds, "feature-poststart")
+	userPostStartIdx := indexOfCmd(cmds, "user-poststart")
+
+	if featureOnCreateIdx < 0 {
+		t.Fatalf("feature-oncreate not found in cmds: %v", cmds)
+	}
+	if userOnCreateIdx < 0 {
+		t.Fatalf("user-oncreate not found in cmds: %v", cmds)
+	}
+	if featureOnCreateIdx >= userOnCreateIdx {
+		t.Errorf("feature onCreate (idx %d) should run before user onCreate (idx %d)", featureOnCreateIdx, userOnCreateIdx)
+	}
+	if featurePostStartIdx >= userPostStartIdx {
+		t.Errorf("feature postStart (idx %d) should run before user postStart (idx %d)", featurePostStartIdx, userPostStartIdx)
+	}
+}
+
+func TestRunLifecycleHooks_FeatureHooksOnly(t *testing.T) {
+	// Feature hooks should run even when user has no hooks.
+	mock := &mockDriver{}
+	r, _, _ := newTestRunner(t, mock)
+
+	r.featureHooks = &config.MergedConfigProperties{
+		PostStartCommands: []config.LifecycleHook{
+			{"": {"echo feature-poststart"}},
+		},
+		PostAttachCommands: []config.LifecycleHook{
+			{"": {"echo feature-postattach"}},
+		},
+	}
+
+	cfg := &config.DevContainerConfig{}
+	if err := r.runLifecycleHooks(context.Background(), cfg, ""); err != nil {
+		t.Fatalf("runLifecycleHooks: %v", err)
+	}
+
+	if len(mock.execCalls) != 2 {
+		t.Fatalf("expected 2 exec calls (feature postStart + postAttach), got %d", len(mock.execCalls))
+	}
+}
+
+func TestRunResumeHooks_FeatureHooksBeforeUser(t *testing.T) {
+	mock := &mockDriver{}
+	r, _, _ := newTestRunner(t, mock)
+
+	r.featureHooks = &config.MergedConfigProperties{
+		PostStartCommands: []config.LifecycleHook{
+			{"": {"echo feature-poststart"}},
+		},
+		PostAttachCommands: []config.LifecycleHook{
+			{"": {"echo feature-postattach"}},
+		},
+	}
+
+	cfg := &config.DevContainerConfig{}
+	cfg.PostStartCommand = config.LifecycleHook{"": {"echo user-poststart"}}
+	cfg.PostAttachCommand = config.LifecycleHook{"": {"echo user-postattach"}}
+
+	if err := r.runResumeHooks(context.Background(), cfg, ""); err != nil {
+		t.Fatalf("runResumeHooks: %v", err)
+	}
+
+	var cmds []string
+	for _, call := range mock.execCalls {
+		cmds = append(cmds, strings.Join(call.cmd, " "))
+	}
+
+	if len(mock.execCalls) != 4 {
+		t.Fatalf("expected 4 exec calls, got %d: %v", len(mock.execCalls), cmds)
+	}
+
+	featurePostStartIdx := indexOfCmd(cmds, "feature-poststart")
+	userPostStartIdx := indexOfCmd(cmds, "user-poststart")
+	if featurePostStartIdx >= userPostStartIdx {
+		t.Errorf("feature postStart (idx %d) should run before user postStart (idx %d)", featurePostStartIdx, userPostStartIdx)
+	}
+}
+
+// indexOfCmd returns the first index where the command string contains substr.
+func indexOfCmd(cmds []string, substr string) int {
+	for i, c := range cmds {
+		if strings.Contains(c, substr) {
+			return i
+		}
+	}
+	return -1
+}
+
 func TestRunLifecycleHooks_NoReadyWhenNoHooks(t *testing.T) {
 	// When there are no hooks at all, "Container ready." is still emitted
 	// (at the waitFor stage, even if nothing ran there).

--- a/internal/engine/lifecycle_test.go
+++ b/internal/engine/lifecycle_test.go
@@ -531,6 +531,67 @@ func TestRunResumeHooks_FeatureHooksBeforeUser(t *testing.T) {
 	}
 }
 
+func TestHookSetFromMerged_IncludesAllStages(t *testing.T) {
+	merged := &config.MergedDevContainerConfig{}
+	merged.OnCreateCommands = []config.LifecycleHook{{"": {"echo feature-oncreate"}}, {"": {"echo user-oncreate"}}}
+	merged.UpdateContentCommands = []config.LifecycleHook{{"": {"echo feature-update"}}}
+	merged.PostCreateCommands = []config.LifecycleHook{{"": {"echo user-postcreate"}}}
+	merged.PostStartCommands = []config.LifecycleHook{{"": {"echo feature-poststart"}}, {"": {"echo user-poststart"}}}
+	merged.PostAttachCommands = []config.LifecycleHook{{"": {"echo user-postattach"}}}
+	merged.WaitFor = "onCreateCommand"
+
+	hs := hookSetFromMerged(merged)
+
+	if len(hs.OnCreate) != 2 {
+		t.Errorf("OnCreate length = %d, want 2", len(hs.OnCreate))
+	}
+	if len(hs.UpdateContent) != 1 {
+		t.Errorf("UpdateContent length = %d, want 1", len(hs.UpdateContent))
+	}
+	if len(hs.PostCreate) != 1 {
+		t.Errorf("PostCreate length = %d, want 1", len(hs.PostCreate))
+	}
+	if len(hs.PostStart) != 2 {
+		t.Errorf("PostStart length = %d, want 2", len(hs.PostStart))
+	}
+	if len(hs.PostAttach) != 1 {
+		t.Errorf("PostAttach length = %d, want 1", len(hs.PostAttach))
+	}
+	if hs.WaitFor != "onCreateCommand" {
+		t.Errorf("WaitFor = %q, want onCreateCommand", hs.WaitFor)
+	}
+}
+
+func TestFeatureOnly_WithUserHook(t *testing.T) {
+	userHook := config.LifecycleHook{"": {"echo user"}}
+	merged := []config.LifecycleHook{
+		{"": {"echo feature1"}},
+		{"": {"echo feature2"}},
+		userHook,
+	}
+	got := featureOnly(merged, userHook)
+	if len(got) != 2 {
+		t.Fatalf("featureOnly length = %d, want 2", len(got))
+	}
+}
+
+func TestFeatureOnly_NoUserHook(t *testing.T) {
+	merged := []config.LifecycleHook{
+		{"": {"echo feature1"}},
+	}
+	got := featureOnly(merged, nil)
+	if len(got) != 1 {
+		t.Fatalf("featureOnly length = %d, want 1 (all entries are feature hooks)", len(got))
+	}
+}
+
+func TestFeatureOnly_Empty(t *testing.T) {
+	got := featureOnly(nil, config.LifecycleHook{"": {"echo user"}})
+	if len(got) != 0 {
+		t.Errorf("featureOnly(nil) should be empty, got %v", got)
+	}
+}
+
 // indexOfCmd returns the first index where the command string contains substr.
 func indexOfCmd(cmds []string, substr string) int {
 	for i, c := range cmds {

--- a/internal/engine/restart.go
+++ b/internal/engine/restart.go
@@ -286,16 +286,6 @@ func resolveConfigEnvFromStored(cfg *config.DevContainerConfig, storedEnv map[st
 func (e *Engine) runResumeHooks(ctx context.Context, ws *workspace.Workspace, cfg *config.DevContainerConfig, cc containerContext) error {
 	stored, _ := e.store.LoadResult(ws.ID)
 	hooks := hookSetWithStoredFeatures(cfg, stored)
-	return e.runResumeHooksWithSet(ctx, ws, cc, hooks)
-}
-
-// runResumeHooksWithSet runs resume hooks with a pre-built hookSet.
-func (e *Engine) runResumeHooksWithSet(ctx context.Context, ws *workspace.Workspace, cc containerContext, hooks *hookSet) error {
-	runner := e.newLifecycleRunner(ws, cc, nil)
-	// The runner needs remoteEnv for exec -e flags. Load from stored result
-	// if not already in the hookSet caller's context.
-	if stored, _ := e.store.LoadResult(ws.ID); stored != nil {
-		runner.remoteEnv = stored.RemoteEnv
-	}
+	runner := e.newLifecycleRunner(ws, cc, cfg.RemoteEnv)
 	return runner.runResumeHooks(ctx, hooks, cc.workspaceFolder)
 }

--- a/internal/engine/restart.go
+++ b/internal/engine/restart.go
@@ -248,6 +248,7 @@ func (e *Engine) restartRecreate(ctx context.Context, ws *workspace.Workspace, c
 		pluginResp:     pluginResp,
 		storedResult:   storedResult,
 		fromSnapshot:   hasSnapshot,
+		imageMetadata:  metadata,
 	})
 	if err != nil {
 		if upResult != nil {

--- a/internal/engine/restart.go
+++ b/internal/engine/restart.go
@@ -283,5 +283,5 @@ func resolveConfigEnvFromStored(cfg *config.DevContainerConfig, storedEnv map[st
 // (postStartCommand + postAttachCommand) for a container.
 func (e *Engine) runResumeHooks(ctx context.Context, ws *workspace.Workspace, cfg *config.DevContainerConfig, cc containerContext) error {
 	runner := e.newLifecycleRunner(ws, cc, cfg.RemoteEnv)
-	return runner.runResumeHooks(ctx, cfg, cc.workspaceFolder)
+	return runner.runResumeHooks(ctx, hookSetFromConfig(cfg), cc.workspaceFolder)
 }

--- a/internal/engine/restart.go
+++ b/internal/engine/restart.go
@@ -280,8 +280,21 @@ func resolveConfigEnvFromStored(cfg *config.DevContainerConfig, storedEnv map[st
 }
 
 // runResumeHooks executes only the resume-flow lifecycle hooks
-// (postStartCommand + postAttachCommand) for a container.
+// (postStartCommand + postAttachCommand) for a container, including stored
+// feature hooks if available.
 func (e *Engine) runResumeHooks(ctx context.Context, ws *workspace.Workspace, cfg *config.DevContainerConfig, cc containerContext) error {
-	runner := e.newLifecycleRunner(ws, cc, cfg.RemoteEnv)
-	return runner.runResumeHooks(ctx, hookSetFromConfig(cfg), cc.workspaceFolder)
+	stored, _ := e.store.LoadResult(ws.ID)
+	hooks := hookSetWithStoredFeatures(cfg, stored)
+	return e.runResumeHooksWithSet(ctx, ws, cc, hooks)
+}
+
+// runResumeHooksWithSet runs resume hooks with a pre-built hookSet.
+func (e *Engine) runResumeHooksWithSet(ctx context.Context, ws *workspace.Workspace, cc containerContext, hooks *hookSet) error {
+	runner := e.newLifecycleRunner(ws, cc, nil)
+	// The runner needs remoteEnv for exec -e flags. Load from stored result
+	// if not already in the hookSet caller's context.
+	if stored, _ := e.store.LoadResult(ws.ID); stored != nil {
+		runner.remoteEnv = stored.RemoteEnv
+	}
+	return runner.runResumeHooks(ctx, hooks, cc.workspaceFolder)
 }

--- a/internal/engine/restart.go
+++ b/internal/engine/restart.go
@@ -284,7 +284,10 @@ func resolveConfigEnvFromStored(cfg *config.DevContainerConfig, storedEnv map[st
 // (postStartCommand + postAttachCommand) for a container, including stored
 // feature hooks if available.
 func (e *Engine) runResumeHooks(ctx context.Context, ws *workspace.Workspace, cfg *config.DevContainerConfig, cc containerContext) error {
-	stored, _ := e.store.LoadResult(ws.ID)
+	stored, err := e.store.LoadResult(ws.ID)
+	if err != nil {
+		e.logger.Warn("failed to load stored result for resume hooks, feature hooks may be skipped", "error", err)
+	}
 	hooks := hookSetWithStoredFeatures(cfg, stored)
 	runner := e.newLifecycleRunner(ws, cc, cfg.RemoteEnv)
 	return runner.runResumeHooks(ctx, hooks, cc.workspaceFolder)

--- a/internal/engine/setup.go
+++ b/internal/engine/setup.go
@@ -22,10 +22,13 @@ import (
 //   - Chowning the workspace directory to the remote user
 //   - Running lifecycle hooks
 //
+// imageMetadata contains feature metadata for merging lifecycle hooks. When
+// non-nil, feature hooks are dispatched before user hooks at each stage.
+//
 // Returns the final merged environment produced by the EnvBuilder. Callers
 // should assign it to cfg.RemoteEnv for persistence; setupContainer itself
 // does not mutate cfg.RemoteEnv.
-func (e *Engine) setupContainer(ctx context.Context, ws *workspace.Workspace, cfg *config.DevContainerConfig, cc containerContext, envb *EnvBuilder) (map[string]string, error) {
+func (e *Engine) setupContainer(ctx context.Context, ws *workspace.Workspace, cfg *config.DevContainerConfig, cc containerContext, envb *EnvBuilder, imageMetadata []*config.ImageMetadata) (map[string]string, error) {
 	// Resolve ${containerEnv:VAR} in remoteEnv by probing the container environment.
 	// Also captures the container's base PATH for later merging.
 	var containerPATH string
@@ -76,9 +79,18 @@ func (e *Engine) setupContainer(ctx context.Context, ws *workspace.Workspace, cf
 	envb.SetProbed(probedEnv)
 	preHookEnv := envb.Build()
 
+	// Build hook set: merge feature hooks with user hooks when metadata is available.
+	var hooks *hookSet
+	if len(imageMetadata) > 0 {
+		merged := config.MergeConfiguration(cfg, imageMetadata)
+		hooks = hookSetFromMerged(merged)
+	} else {
+		hooks = hookSetFromConfig(cfg)
+	}
+
 	// Run lifecycle hooks with the pre-hook merged environment.
 	runner := e.newLifecycleRunner(ws, cc, preHookEnv)
-	hookErr := runner.runLifecycleHooks(ctx, hookSetFromConfig(cfg), cc.workspaceFolder)
+	hookErr := runner.runLifecycleHooks(ctx, hooks, cc.workspaceFolder)
 
 	// Post-hook environment probe: re-captures the environment to pick up
 	// any changes from lifecycle hooks (e.g. tools installed via mise, nvm).

--- a/internal/engine/setup.go
+++ b/internal/engine/setup.go
@@ -78,7 +78,7 @@ func (e *Engine) setupContainer(ctx context.Context, ws *workspace.Workspace, cf
 
 	// Run lifecycle hooks with the pre-hook merged environment.
 	runner := e.newLifecycleRunner(ws, cc, preHookEnv)
-	hookErr := runner.runLifecycleHooks(ctx, cfg, cc.workspaceFolder)
+	hookErr := runner.runLifecycleHooks(ctx, hookSetFromConfig(cfg), cc.workspaceFolder)
 
 	// Post-hook environment probe: re-captures the environment to pick up
 	// any changes from lifecycle hooks (e.g. tools installed via mise, nvm).

--- a/internal/engine/setup.go
+++ b/internal/engine/setup.go
@@ -22,13 +22,10 @@ import (
 //   - Chowning the workspace directory to the remote user
 //   - Running lifecycle hooks
 //
-// imageMetadata contains feature metadata for merging lifecycle hooks. When
-// non-nil, feature hooks are dispatched before user hooks at each stage.
-//
 // Returns the final merged environment produced by the EnvBuilder. Callers
 // should assign it to cfg.RemoteEnv for persistence; setupContainer itself
 // does not mutate cfg.RemoteEnv.
-func (e *Engine) setupContainer(ctx context.Context, ws *workspace.Workspace, cfg *config.DevContainerConfig, cc containerContext, envb *EnvBuilder, imageMetadata []*config.ImageMetadata) (map[string]string, error) {
+func (e *Engine) setupContainer(ctx context.Context, ws *workspace.Workspace, cfg *config.DevContainerConfig, cc containerContext, envb *EnvBuilder, hooks *hookSet) (map[string]string, error) {
 	// Resolve ${containerEnv:VAR} in remoteEnv by probing the container environment.
 	// Also captures the container's base PATH for later merging.
 	var containerPATH string
@@ -78,15 +75,6 @@ func (e *Engine) setupContainer(ctx context.Context, ws *workspace.Workspace, cf
 	probedEnv := e.probeUserEnv(ctx, cc, cfg.UserEnvProbe)
 	envb.SetProbed(probedEnv)
 	preHookEnv := envb.Build()
-
-	// Build hook set: merge feature hooks with user hooks when metadata is available.
-	var hooks *hookSet
-	if len(imageMetadata) > 0 {
-		merged := config.MergeConfiguration(cfg, imageMetadata)
-		hooks = hookSetFromMerged(merged)
-	} else {
-		hooks = hookSetFromConfig(cfg)
-	}
 
 	// Run lifecycle hooks with the pre-hook merged environment.
 	runner := e.newLifecycleRunner(ws, cc, preHookEnv)

--- a/internal/engine/snapshot.go
+++ b/internal/engine/snapshot.go
@@ -17,17 +17,25 @@ func snapshotImageName(workspaceID string) string {
 }
 
 // computeHookHash computes a stable hash of the create-time hook definitions
-// (onCreate, updateContent, postCreate). If the hooks change, the snapshot is stale.
-func computeHookHash(cfg *config.DevContainerConfig) string {
-	// Serialize the hook definitions to JSON for hashing.
+// (onCreate, updateContent, postCreate) including any feature hooks from the
+// stored result. If hooks change, the snapshot is stale.
+func computeHookHash(cfg *config.DevContainerConfig, stored *workspace.Result) string {
 	data := struct {
-		OnCreate      config.LifecycleHook `json:"onCreate,omitempty"`
-		UpdateContent config.LifecycleHook `json:"updateContent,omitempty"`
-		PostCreate    config.LifecycleHook `json:"postCreate,omitempty"`
+		OnCreate        config.LifecycleHook      `json:"onCreate,omitempty"`
+		UpdateContent   config.LifecycleHook      `json:"updateContent,omitempty"`
+		PostCreate      config.LifecycleHook      `json:"postCreate,omitempty"`
+		FeatureOnCreate []workspace.LifecycleHook `json:"featureOnCreate,omitempty"`
+		FeatureUpdate   []workspace.LifecycleHook `json:"featureUpdate,omitempty"`
+		FeaturePost     []workspace.LifecycleHook `json:"featurePost,omitempty"`
 	}{
 		OnCreate:      cfg.OnCreateCommand,
 		UpdateContent: cfg.UpdateContentCommand,
 		PostCreate:    cfg.PostCreateCommand,
+	}
+	if stored != nil {
+		data.FeatureOnCreate = stored.FeatureOnCreateCommands
+		data.FeatureUpdate = stored.FeatureUpdateContentCommands
+		data.FeaturePost = stored.FeaturePostCreateCommands
 	}
 
 	b, _ := json.Marshal(data)
@@ -68,7 +76,7 @@ func (e *Engine) commitSnapshot(ctx context.Context, ws *workspace.Workspace, cf
 	}
 
 	result.SnapshotImage = imageName
-	result.SnapshotHookHash = computeHookHash(cfg)
+	result.SnapshotHookHash = computeHookHash(cfg, result)
 	if err := e.store.SaveResult(ws.ID, result); err != nil {
 		e.logger.Warn("failed to save snapshot metadata", "error", err)
 	}
@@ -107,7 +115,7 @@ func (e *Engine) validSnapshot(ctx context.Context, ws *workspace.Workspace, cfg
 	}
 
 	// Check if hooks changed since snapshot was taken.
-	currentHash := computeHookHash(cfg)
+	currentHash := computeHookHash(cfg, result)
 	if currentHash != result.SnapshotHookHash {
 		e.logger.Debug("snapshot is stale (hook hash mismatch)", "stored", result.SnapshotHookHash, "current", currentHash)
 		return "", false

--- a/internal/engine/snapshot.go
+++ b/internal/engine/snapshot.go
@@ -44,16 +44,23 @@ func computeHookHash(cfg *config.DevContainerConfig, stored *workspace.Result) s
 }
 
 // hasCreateTimeHooks returns true if the config has any create-time hooks.
-func hasCreateTimeHooks(cfg *config.DevContainerConfig) bool {
-	return len(cfg.OnCreateCommand) > 0 ||
-		len(cfg.UpdateContentCommand) > 0 ||
-		len(cfg.PostCreateCommand) > 0
+func hasCreateTimeHooks(cfg *config.DevContainerConfig, stored *workspace.Result) bool {
+	if len(cfg.OnCreateCommand) > 0 || len(cfg.UpdateContentCommand) > 0 || len(cfg.PostCreateCommand) > 0 {
+		return true
+	}
+	if stored != nil {
+		return len(stored.FeatureOnCreateCommands) > 0 ||
+			len(stored.FeatureUpdateContentCommands) > 0 ||
+			len(stored.FeaturePostCreateCommands) > 0
+	}
+	return false
 }
 
 // commitSnapshot creates a snapshot image from the container and saves
 // the metadata in the workspace result.
 func (e *Engine) commitSnapshot(ctx context.Context, ws *workspace.Workspace, cfg *config.DevContainerConfig, containerID string) {
-	if !hasCreateTimeHooks(cfg) {
+	stored, _ := e.store.LoadResult(ws.ID)
+	if !hasCreateTimeHooks(cfg, stored) {
 		return
 	}
 

--- a/internal/engine/snapshot.go
+++ b/internal/engine/snapshot.go
@@ -59,8 +59,13 @@ func hasCreateTimeHooks(cfg *config.DevContainerConfig, stored *workspace.Result
 // commitSnapshot creates a snapshot image from the container and saves
 // the metadata in the workspace result.
 func (e *Engine) commitSnapshot(ctx context.Context, ws *workspace.Workspace, cfg *config.DevContainerConfig, containerID string) {
-	stored, _ := e.store.LoadResult(ws.ID)
-	if !hasCreateTimeHooks(cfg, stored) {
+	stored, err := e.store.LoadResult(ws.ID)
+	if err != nil {
+		e.logger.Warn("failed to load result for snapshot decision", "error", err)
+		if !hasCreateTimeHooks(cfg, nil) {
+			return
+		}
+	} else if !hasCreateTimeHooks(cfg, stored) {
 		return
 	}
 

--- a/internal/engine/snapshot_test.go
+++ b/internal/engine/snapshot_test.go
@@ -18,8 +18,8 @@ func TestComputeHookHash_Stable(t *testing.T) {
 	cfg.OnCreateCommand = config.LifecycleHook{"": {"npm install"}}
 	cfg.PostCreateCommand = config.LifecycleHook{"": {"echo done"}}
 
-	hash1 := computeHookHash(cfg)
-	hash2 := computeHookHash(cfg)
+	hash1 := computeHookHash(cfg, nil)
+	hash2 := computeHookHash(cfg, nil)
 
 	if hash1 != hash2 {
 		t.Errorf("hash not stable: %q != %q", hash1, hash2)
@@ -36,14 +36,32 @@ func TestComputeHookHash_ChangesWhenHooksChange(t *testing.T) {
 	cfg2 := &config.DevContainerConfig{}
 	cfg2.OnCreateCommand = config.LifecycleHook{"": {"yarn install"}}
 
-	if computeHookHash(cfg1) == computeHookHash(cfg2) {
+	if computeHookHash(cfg1, nil) == computeHookHash(cfg2, nil) {
 		t.Error("different hooks should produce different hashes")
+	}
+}
+
+func TestComputeHookHash_ChangesWithFeatureHooks(t *testing.T) {
+	cfg := &config.DevContainerConfig{}
+	cfg.OnCreateCommand = config.LifecycleHook{"": {"echo user"}}
+
+	hashNoFeatures := computeHookHash(cfg, nil)
+
+	stored := &workspace.Result{
+		FeatureOnCreateCommands: []workspace.LifecycleHook{
+			{"": {"echo feature-oncreate"}},
+		},
+	}
+	hashWithFeatures := computeHookHash(cfg, stored)
+
+	if hashNoFeatures == hashWithFeatures {
+		t.Error("hash should differ when feature hooks are added")
 	}
 }
 
 func TestComputeHookHash_EmptyHooks(t *testing.T) {
 	cfg := &config.DevContainerConfig{}
-	hash := computeHookHash(cfg)
+	hash := computeHookHash(cfg, nil)
 	if hash == "" {
 		t.Error("hash should not be empty even for empty hooks")
 	}
@@ -251,7 +269,7 @@ func TestValidSnapshot_Valid(t *testing.T) {
 	cfg := &config.DevContainerConfig{}
 	cfg.OnCreateCommand = config.LifecycleHook{"": {"npm install"}}
 
-	hash := computeHookHash(cfg)
+	hash := computeHookHash(cfg, nil)
 	mergedJSON, _ := json.Marshal(cfg)
 	if err := store.SaveResult(ws.ID, &workspace.Result{
 		ContainerID:      "container-1",
@@ -295,7 +313,7 @@ func TestValidSnapshot_StaleHash(t *testing.T) {
 		ContainerID:      "container-1",
 		MergedConfig:     mergedJSON,
 		SnapshotImage:    "crib-ws-stale-hash:snapshot",
-		SnapshotHookHash: computeHookHash(oldCfg),
+		SnapshotHookHash: computeHookHash(oldCfg, nil),
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -334,7 +352,7 @@ func TestValidSnapshot_MissingImage(t *testing.T) {
 		ContainerID:      "container-1",
 		MergedConfig:     mergedJSON,
 		SnapshotImage:    "crib-ws-missing-img:snapshot",
-		SnapshotHookHash: computeHookHash(cfg),
+		SnapshotHookHash: computeHookHash(cfg, nil),
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/engine/snapshot_test.go
+++ b/internal/engine/snapshot_test.go
@@ -70,7 +70,7 @@ func TestComputeHookHash_EmptyHooks(t *testing.T) {
 func TestHasCreateTimeHooks(t *testing.T) {
 	t.Run("no hooks", func(t *testing.T) {
 		cfg := &config.DevContainerConfig{}
-		if hasCreateTimeHooks(cfg) {
+		if hasCreateTimeHooks(cfg, nil) {
 			t.Error("expected false for no hooks")
 		}
 	})
@@ -78,7 +78,7 @@ func TestHasCreateTimeHooks(t *testing.T) {
 	t.Run("onCreate", func(t *testing.T) {
 		cfg := &config.DevContainerConfig{}
 		cfg.OnCreateCommand = config.LifecycleHook{"": {"echo hi"}}
-		if !hasCreateTimeHooks(cfg) {
+		if !hasCreateTimeHooks(cfg, nil) {
 			t.Error("expected true for onCreate")
 		}
 	})
@@ -86,7 +86,7 @@ func TestHasCreateTimeHooks(t *testing.T) {
 	t.Run("postCreate", func(t *testing.T) {
 		cfg := &config.DevContainerConfig{}
 		cfg.PostCreateCommand = config.LifecycleHook{"": {"echo hi"}}
-		if !hasCreateTimeHooks(cfg) {
+		if !hasCreateTimeHooks(cfg, nil) {
 			t.Error("expected true for postCreate")
 		}
 	})
@@ -94,7 +94,7 @@ func TestHasCreateTimeHooks(t *testing.T) {
 	t.Run("postStart only", func(t *testing.T) {
 		cfg := &config.DevContainerConfig{}
 		cfg.PostStartCommand = config.LifecycleHook{"": {"echo hi"}}
-		if hasCreateTimeHooks(cfg) {
+		if hasCreateTimeHooks(cfg, nil) {
 			t.Error("expected false for postStart only")
 		}
 	})

--- a/internal/engine/up_snapshot_test.go
+++ b/internal/engine/up_snapshot_test.go
@@ -123,7 +123,7 @@ func TestUpCreate_FromSnapshot_PreservesEnv(t *testing.T) {
 		ImageName:        "ruby:3.2",
 		RemoteUser:       "vscode",
 		SnapshotImage:    "crib-ws-up-snap:snapshot",
-		SnapshotHookHash: computeHookHash(&config.DevContainerConfig{}),
+		SnapshotHookHash: computeHookHash(&config.DevContainerConfig{}, nil),
 		RemoteEnv: map[string]string{
 			"PATH":      "/home/vscode/.bundle/bin:/home/vscode/.local/share/mise/installs/ruby/3.4.7/bin:/usr/local/bin:/usr/bin",
 			"RUBY_ROOT": "/home/vscode/.local/share/mise/installs/ruby/3.4.7",
@@ -220,7 +220,7 @@ func TestUpCreate_FromSnapshot_RunsResumeHooksOnly(t *testing.T) {
 		ImageName:        "ubuntu:22.04",
 		RemoteUser:       "vscode",
 		SnapshotImage:    "crib-ws-up-resume:snapshot",
-		SnapshotHookHash: computeHookHash(cfg),
+		SnapshotHookHash: computeHookHash(cfg, nil),
 		RemoteEnv:        map[string]string{"PATH": "/usr/local/bin:/usr/bin"},
 	}
 	if err := store.SaveResult(ws.ID, storedResult); err != nil {
@@ -308,7 +308,7 @@ func TestUpCreate_FromSnapshot_RecreateBypassesSnapshot(t *testing.T) {
 		ImageName:        "ubuntu:22.04",
 		RemoteUser:       "vscode",
 		SnapshotImage:    "crib-ws-up-recreate:snapshot",
-		SnapshotHookHash: computeHookHash(cfg),
+		SnapshotHookHash: computeHookHash(cfg, nil),
 		RemoteEnv:        map[string]string{"PATH": "/usr/local/bin:/usr/bin"},
 	}
 	if err := store.SaveResult(ws.ID, storedResult); err != nil {
@@ -426,7 +426,7 @@ func TestUpCreate_FromSnapshot_PluginCopiesExecuted(t *testing.T) {
 		ImageName:        "ubuntu:22.04",
 		RemoteUser:       "vscode",
 		SnapshotImage:    "crib-ws-up-copies:snapshot",
-		SnapshotHookHash: computeHookHash(cfg),
+		SnapshotHookHash: computeHookHash(cfg, nil),
 		RemoteEnv:        map[string]string{"PATH": "/usr/local/bin:/usr/bin"},
 	}
 	if err := store.SaveResult(ws.ID, storedResult); err != nil {
@@ -500,7 +500,7 @@ func TestUpCreate_FromSnapshot_PreservesImageName(t *testing.T) {
 		ImageName:        "crib-ws-up-img:features",
 		RemoteUser:       "vscode",
 		SnapshotImage:    "crib-ws-up-img:snapshot",
-		SnapshotHookHash: computeHookHash(cfg),
+		SnapshotHookHash: computeHookHash(cfg, nil),
 		RemoteEnv:        map[string]string{"PATH": "/usr/local/bin:/usr/bin"},
 	}
 	if err := store.SaveResult(ws.ID, storedResult); err != nil {
@@ -559,7 +559,7 @@ func TestUpCreate_FromSnapshot_PreservesFeatureEntrypoints(t *testing.T) {
 		RemoteUser:            "vscode",
 		HasFeatureEntrypoints: true,
 		SnapshotImage:         "crib-ws-up-feat:snapshot",
-		SnapshotHookHash:      computeHookHash(cfg),
+		SnapshotHookHash:      computeHookHash(cfg, nil),
 		RemoteEnv:             map[string]string{"PATH": "/usr/local/bin:/usr/bin"},
 	}
 	if err := store.SaveResult(ws.ID, storedResult); err != nil {
@@ -630,7 +630,7 @@ func TestUpCreate_FromSnapshot_ResolvesConfigEnv(t *testing.T) {
 		ImageName:        "go:1.22",
 		RemoteUser:       "vscode",
 		SnapshotImage:    "crib-ws-up-envres:snapshot",
-		SnapshotHookHash: computeHookHash(cfg),
+		SnapshotHookHash: computeHookHash(cfg, nil),
 		RemoteEnv: map[string]string{
 			"PATH":   "/go/bin:/usr/local/go/bin:/usr/local/bin:/usr/bin",
 			"GOPATH": "/go",

--- a/internal/feature/parse_test.go
+++ b/internal/feature/parse_test.go
@@ -127,6 +127,9 @@ func TestParseFeatureConfig(t *testing.T) {
 				if len(fc.OnCreateCommand) == 0 {
 					t.Error("expected onCreateCommand")
 				}
+				if len(fc.UpdateContentCommand) == 0 {
+					t.Error("expected updateContentCommand")
+				}
 				if len(fc.PostCreateCommand) == 0 {
 					t.Error("expected postCreateCommand")
 				}

--- a/internal/feature/testdata/full/devcontainer-feature.json
+++ b/internal/feature/testdata/full/devcontainer-feature.json
@@ -34,6 +34,7 @@
         "MY_VAR": "my_value"
     },
     "onCreateCommand": "echo on-create",
+    "updateContentCommand": "echo update-content",
     "postCreateCommand": "echo post-create",
     "postStartCommand": "echo post-start",
     "postAttachCommand": "echo post-attach"

--- a/internal/feature/types.go
+++ b/internal/feature/types.go
@@ -44,10 +44,11 @@ type FeatureConfig struct {
 	ContainerEnv  map[string]string        `json:"containerEnv,omitempty"`
 
 	// Lifecycle hooks.
-	OnCreateCommand   config.LifecycleHook `json:"onCreateCommand,omitempty"`
-	PostCreateCommand config.LifecycleHook `json:"postCreateCommand,omitempty"`
-	PostStartCommand  config.LifecycleHook `json:"postStartCommand,omitempty"`
-	PostAttachCommand config.LifecycleHook `json:"postAttachCommand,omitempty"`
+	OnCreateCommand      config.LifecycleHook `json:"onCreateCommand,omitempty"`
+	UpdateContentCommand config.LifecycleHook `json:"updateContentCommand,omitempty"`
+	PostCreateCommand    config.LifecycleHook `json:"postCreateCommand,omitempty"`
+	PostStartCommand     config.LifecycleHook `json:"postStartCommand,omitempty"`
+	PostAttachCommand    config.LifecycleHook `json:"postAttachCommand,omitempty"`
 }
 
 // FeatureOption describes a single option that a feature accepts.

--- a/internal/workspace/result.go
+++ b/internal/workspace/result.go
@@ -1,6 +1,14 @@
 package workspace
 
-import "encoding/json"
+import (
+	"encoding/json"
+)
+
+// LifecycleHook is a map of named command entries. String/array hooks use the
+// "" key; object hooks use named keys that run in parallel. This mirrors
+// config.LifecycleHook but is redeclared here to avoid a dependency on the
+// config package from workspace.
+type LifecycleHook map[string][]string
 
 // Result stores the outcome of a successful `crib up` run.
 type Result struct {
@@ -44,4 +52,14 @@ type Result struct {
 	// to detect changes inside compose files (volumes, ports, etc.) that are
 	// invisible to devcontainer.json config comparison.
 	ComposeFilesHash string `json:"composeFilesHash,omitempty"`
+
+	// Feature lifecycle hooks, stored so the resume/restart path can dispatch
+	// them without re-resolving features from OCI registries. These are the
+	// hooks declared in devcontainer-feature.json files, NOT the user's hooks
+	// from devcontainer.json. Per the spec, feature hooks run before user hooks.
+	FeatureOnCreateCommands      []LifecycleHook `json:"featureOnCreateCommands,omitempty"`
+	FeatureUpdateContentCommands []LifecycleHook `json:"featureUpdateContentCommands,omitempty"`
+	FeaturePostCreateCommands    []LifecycleHook `json:"featurePostCreateCommands,omitempty"`
+	FeaturePostStartCommands     []LifecycleHook `json:"featurePostStartCommands,omitempty"`
+	FeaturePostAttachCommands    []LifecycleHook `json:"featurePostAttachCommands,omitempty"`
 }

--- a/internal/workspace/result.go
+++ b/internal/workspace/result.go
@@ -1,8 +1,6 @@
 package workspace
 
-import (
-	"encoding/json"
-)
+import "encoding/json"
 
 // LifecycleHook is a map of named command entries. String/array hooks use the
 // "" key; object hooks use named keys that run in parallel. This mirrors

--- a/internal/workspace/store_test.go
+++ b/internal/workspace/store_test.go
@@ -153,6 +153,53 @@ func TestStore_SaveAndLoadResult(t *testing.T) {
 	}
 }
 
+func TestStore_SaveAndLoadResult_FeatureHooks(t *testing.T) {
+	store := NewStoreAt(t.TempDir())
+
+	result := &Result{
+		ContainerID:     "abc123",
+		ImageName:       "crib-ws:latest",
+		MergedConfig:    json.RawMessage(`{}`),
+		WorkspaceFolder: "/workspace",
+		FeatureOnCreateCommands: []LifecycleHook{
+			{"": {"echo feature1-oncreate"}},
+			{"": {"echo feature2-oncreate"}},
+		},
+		FeaturePostStartCommands: []LifecycleHook{
+			{"setup": {"echo feature-poststart"}},
+		},
+	}
+
+	if err := store.SaveResult("ws-hooks", result); err != nil {
+		t.Fatalf("SaveResult: %v", err)
+	}
+
+	loaded, err := store.LoadResult("ws-hooks")
+	if err != nil {
+		t.Fatalf("LoadResult: %v", err)
+	}
+
+	if len(loaded.FeatureOnCreateCommands) != 2 {
+		t.Fatalf("FeatureOnCreateCommands length = %d, want 2", len(loaded.FeatureOnCreateCommands))
+	}
+	if loaded.FeatureOnCreateCommands[0][""][0] != "echo feature1-oncreate" {
+		t.Errorf("FeatureOnCreateCommands[0] = %v, want echo feature1-oncreate", loaded.FeatureOnCreateCommands[0])
+	}
+	if len(loaded.FeaturePostStartCommands) != 1 {
+		t.Fatalf("FeaturePostStartCommands length = %d, want 1", len(loaded.FeaturePostStartCommands))
+	}
+	// Empty fields should not appear.
+	if len(loaded.FeatureUpdateContentCommands) != 0 {
+		t.Errorf("FeatureUpdateContentCommands should be empty, got %v", loaded.FeatureUpdateContentCommands)
+	}
+	if len(loaded.FeaturePostCreateCommands) != 0 {
+		t.Errorf("FeaturePostCreateCommands should be empty, got %v", loaded.FeaturePostCreateCommands)
+	}
+	if len(loaded.FeaturePostAttachCommands) != 0 {
+		t.Errorf("FeaturePostAttachCommands should be empty, got %v", loaded.FeaturePostAttachCommands)
+	}
+}
+
 func TestStore_LoadResult_NotFound(t *testing.T) {
 	store := NewStoreAt(t.TempDir())
 


### PR DESCRIPTION
## Summary

- **Dispatch feature lifecycle hooks**: Features can declare `onCreateCommand`,
  `updateContentCommand`, `postCreateCommand`, `postStartCommand`, and
  `postAttachCommand` in `devcontainer-feature.json`. These now execute before
  user-defined hooks at each stage, in feature installation order (per the spec).
  Feature hooks are stored in `result.json` so they persist across restarts
  without re-resolving features from OCI registries.
- **Parse feature `updateContentCommand`**: Previously the only feature lifecycle
  hook not recognized by the parser.
- **Spec reference doc**: Add `${env:VAR}` alias, add `entrypoint` to storable
  properties list.
- **Roadmap updates**: Remove resolved spec compliance items, add dotfiles plugin
  (from #17), add items from official CLI and DevPod architecture analysis
  (feature lockfile, structured log events, rich error context, workspace flock,
  compose-go library, userEnvProbe caching, shell persistence).

## Implementation

New `hookSet` struct holds merged lifecycle hook lists (feature hooks first, user
hook last). Three constructors:
- `hookSetFromConfig` - user hooks only (no features)
- `hookSetFromMerged` - from `MergeConfiguration` output (fresh build path)
- `hookSetWithStoredFeatures` - from stored result (resume/restart path)

Feature hooks are extracted and stored in `workspace.Result` during the fresh
setup path, then loaded on resume to avoid re-resolving features from OCI.

## Test plan

- [x] Unit tests for `hookSet` construction (`hookSetFromConfig`, `hookSetFromMerged`,
  `hookSetWithStoredFeatures`)
- [x] Unit tests for feature hook ordering (`TestRunLifecycleHooks_FeatureHooksBeforeUser`,
  `TestRunResumeHooks_FeatureHooksBeforeUser`)
- [x] Unit tests for `featureOnly`, `toWorkspaceHooks`, `prependStoredHooks`
- [x] Unit tests for `computeHookHash` with feature hooks
- [x] Unit tests for `hasCreateTimeHooks` with feature hooks
- [x] Integration test: local feature with `onCreateCommand` + `postStartCommand`,
  verifies hook execution, ordering (feature before user), result persistence,
  snapshot creation, and resume path dispatches stored feature hooks
- [x] All existing tests pass (`go test ./internal/... -short`)
- [x] Integration test passes (`go test ./internal/engine/ -run TestIntegrationFeatureLifecycleHooks`)