### PR TITLE
chore: housekeeping for v0.8.0

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -30,9 +30,9 @@ echo "✓ Lint passed"
 
 # Check cyclomatic complexity
 echo "Running gocyclo..."
-out=$(go tool gocyclo -over 40 -ignore '_test\.go$' .)
+out=$(go tool gocyclo -over 30 -ignore '_test\.go$' .)
 if [ -n "$out" ]; then
-    echo "Functions exceeding complexity threshold of 40:"
+    echo "Functions exceeding complexity threshold of 30:"
     echo "$out"
     exit 1
 fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -30,7 +30,7 @@ echo "✓ Lint passed"
 
 # Check cyclomatic complexity
 echo "Running gocyclo..."
-out=$(go tool gocyclo -over 40 .)
+out=$(go tool gocyclo -over 40 -ignore '_test\.go$' .)
 if [ -n "$out" ]; then
     echo "Functions exceeding complexity threshold of 40:"
     echo "$out"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,10 +1,8 @@
 name: Deploy docs
 
 on:
-  release:
-    types: [published]
   push:
-    branches: [docs-site, next]
+    branches: [docs-site, next, stable]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,11 +23,11 @@ jobs:
           GO_TEST_FLAGS: -json
       - name: Lint
         run: make lint
-      - name: Complexity gate (gocyclo -over 40)
+      - name: Complexity gate (gocyclo -over 30)
         run: |
-          out=$(go tool gocyclo -over 40 .)
+          out=$(go tool gocyclo -over 30 -ignore '_test\.go$' .)
           if [ -n "$out" ]; then
-            echo "Functions exceeding complexity threshold of 40:"
+            echo "Functions exceeding complexity threshold of 30:"
             echo "$out"
             exit 1
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cannot trigger).
 - Compose backend now captures stderr for diagnostics when a container is not
   found after `compose up`, instead of the opaque "container not found" error.
-- Integration tests warn when active crib workspaces are detected and refuse
-  to clean up non-test workspace IDs.
+- Compose override no longer produces duplicate mount destinations when the
+  user's compose files already define a volume for the same target path.
+  Fixes "duplicate mount destination" errors with podman-compose caused by
+  the compose-go long-form volume format not being deduplicated during merge.
+- `crib doctor --fix` no longer deletes containers belonging to a different
+  `CRIB_HOME`. Containers now carry a `crib.home` label recording which store
+  created them; doctor skips containers whose label doesn't match.
+- Integration and e2e tests no longer interfere with active workspaces.
+  `TestMain` warns about running crib containers, cleanup helpers reject
+  non-test workspace IDs, and the e2e doctor test no longer runs `--fix`
+  on an empty store.
 
 ## [0.7.1] - 2026-03-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and message) instead of raw strings. No user-visible change.
 - Logging consistency: config path change demoted from Info to Debug; removed
   explicit `slog.String()` wrappers in favor of implicit key-value args.
+- Compose override generation uses compose-go types instead of string
+  concatenation. Volume syntax changes to long form (functionally equivalent).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Docs website now deploys automatically after releases. The workflow triggers
   on `stable` branch push instead of the `release` event (which GITHUB_TOKEN
   cannot trigger).
+- Compose backend now captures stderr for diagnostics when a container is not
+  found after `compose up`, instead of the opaque "container not found" error.
+- Integration tests warn when active crib workspaces are detected and refuse
+  to clean up non-test workspace IDs.
 
 ## [0.7.1] - 2026-03-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   explicit `slog.String()` wrappers in favor of implicit key-value args.
 - Compose override generation uses compose-go types instead of string
   concatenation. Volume syntax changes to long form (functionally equivalent).
+- `LoadProject` now threads caller-supplied environment variables (e.g.
+  `localWorkspaceFolder`, `devcontainerId`) through to compose-go's loader
+  for `${VAR}` substitution. Previously accepted but silently ignored.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Workspace file lock prevents concurrent state-mutating commands (up, down,
+  rebuild, restart, remove) from racing on the same workspace.
+
+### Changed
+
+- Progress reporting uses typed events internally (`ProgressEvent` with phase
+  and message) instead of raw strings. No user-visible change.
+- Logging consistency: config path change demoted from Info to Debug; removed
+  explicit `slog.String()` wrappers in favor of implicit key-value args.
+
+### Fixed
+
+- Docs website now deploys automatically after releases. The workflow triggers
+  on `stable` branch push instead of the `release` event (which GITHUB_TOKEN
+  cannot trigger).
+
 ## [0.7.1] - 2026-03-25
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,8 @@ dockerfile/, workspace/}`. No cycles.
 - No agent injection. All container setup via `docker exec` from the host.
 - Docker and Podman through a single `OCIDriver` (not separate implementations).
 - Implicit workspace resolution from `cwd` (walk up to find `.devcontainer/`).
-- Container naming: `crib-{workspace-id}`, labels: `crib.workspace=<id>`.
+- Container naming: `crib-{workspace-id}`, labels: `crib.workspace=<id>`,
+  `crib.home=<store-base-dir>` (for multi-store isolation in tests/CI).
 - State stored in `~/.crib/workspaces/{id}/`.
 - Runtime detection: `CRIB_RUNTIME` env var > podman > docker.
 - Workspace state tracks `CribVersion` (refreshed on every access via
@@ -88,7 +89,8 @@ drivers are good for logic but miss real Docker/Podman behavior.
 - All packages under `internal/`; this is a binary, not a library.
 - CLI: `spf13/cobra`. Logging: `log/slog`.
 - Linting: golangci-lint v2 (errcheck, govet, staticcheck, unused, ineffassign).
-- Pre-commit hooks: gofmt + golangci-lint on staged Go files.
+- Pre-commit hooks: gofmt + golangci-lint + gocyclo (threshold 30, tests excluded)
+  on staged Go files.
 
 ## Key Reference Pages
 

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -21,6 +21,11 @@ var downCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		lock, err := store.Lock(ws.ID)
+		if err != nil {
+			return err
+		}
+		defer lock.Unlock() //nolint:errcheck // best-effort cleanup
 
 		u.Dim(versionString())
 

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -21,7 +21,7 @@ var downCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		lock, err := store.Lock(ws.ID)
+		lock, err := store.Lock(cmd.Context(), ws.ID)
 		if err != nil {
 			return err
 		}

--- a/cmd/rebuild.go
+++ b/cmd/rebuild.go
@@ -20,7 +20,7 @@ var rebuildCmd = &cobra.Command{
 		}
 		eng.SetOutput(os.Stdout, os.Stderr)
 		eng.SetVerbose(verboseFlag || debugFlag)
-		eng.SetProgress(func(msg string) { u.Dim("  " + msg) })
+		eng.SetProgress(func(ev engine.ProgressEvent) { u.Dim("  " + ev.Message) })
 		setupPlugins(eng, d)
 
 		ws, err := currentWorkspace(store, true)

--- a/cmd/rebuild.go
+++ b/cmd/rebuild.go
@@ -27,6 +27,11 @@ var rebuildCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		lock, err := store.Lock(ws.ID)
+		if err != nil {
+			return err
+		}
+		defer lock.Unlock() //nolint:errcheck // best-effort cleanup
 
 		u.Dim(versionString())
 		u.Header("Rebuilding workspace")

--- a/cmd/rebuild.go
+++ b/cmd/rebuild.go
@@ -27,7 +27,7 @@ var rebuildCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		lock, err := store.Lock(ws.ID)
+		lock, err := store.Lock(cmd.Context(), ws.ID)
 		if err != nil {
 			return err
 		}

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -26,7 +26,7 @@ var removeCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		lock, err := store.Lock(ws.ID)
+		lock, err := store.Lock(cmd.Context(), ws.ID)
 		if err != nil {
 			return err
 		}

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -26,6 +26,11 @@ var removeCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		lock, err := store.Lock(ws.ID)
+		if err != nil {
+			return err
+		}
+		defer lock.Unlock() //nolint:errcheck // best-effort cleanup
 
 		u.Dim(versionString())
 

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -37,7 +37,7 @@ args), restart will ask you to run 'crib rebuild' instead.`,
 		if err != nil {
 			return err
 		}
-		lock, err := store.Lock(ws.ID)
+		lock, err := store.Lock(cmd.Context(), ws.ID)
 		if err != nil {
 			return err
 		}

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -37,6 +37,11 @@ args), restart will ask you to run 'crib rebuild' instead.`,
 		if err != nil {
 			return err
 		}
+		lock, err := store.Lock(ws.ID)
+		if err != nil {
+			return err
+		}
+		defer lock.Unlock() //nolint:errcheck // best-effort cleanup
 
 		u.Dim(versionString())
 		u.Header("Restarting workspace")

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 
+	"github.com/fgrehm/crib/internal/engine"
 	"github.com/spf13/cobra"
 )
 
@@ -29,7 +30,7 @@ args), restart will ask you to run 'crib rebuild' instead.`,
 		}
 		eng.SetOutput(os.Stdout, os.Stderr)
 		eng.SetVerbose(verboseFlag || debugFlag)
-		eng.SetProgress(func(msg string) { u.Dim("  " + msg) })
+		eng.SetProgress(func(ev engine.ProgressEvent) { u.Dim("  " + ev.Message) })
 		setupPlugins(eng, d)
 
 		ws, err := currentWorkspace(store, false)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -248,7 +248,7 @@ func currentWorkspace(store *workspace.Store, create bool) (*workspace.Workspace
 		// Refresh fields that may have drifted from stored state.
 		var changed bool
 		if ws.DevContainerPath != rr.RelativeConfigPath {
-			logger.Info("devcontainer config path changed",
+			logger.Debug("devcontainer config path changed",
 				"old", ws.DevContainerPath, "new", rr.RelativeConfigPath)
 			ws.DevContainerPath = rr.RelativeConfigPath
 			changed = true

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -22,7 +22,7 @@ var upCmd = &cobra.Command{
 		}
 		eng.SetOutput(os.Stdout, os.Stderr)
 		eng.SetVerbose(verboseFlag || debugFlag)
-		eng.SetProgress(func(msg string) { u.Dim("  " + msg) })
+		eng.SetProgress(func(ev engine.ProgressEvent) { u.Dim("  " + ev.Message) })
 		setupPlugins(eng, d)
 
 		ws, err := currentWorkspace(store, true)

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -29,7 +29,7 @@ var upCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		lock, err := store.Lock(ws.ID)
+		lock, err := store.Lock(cmd.Context(), ws.ID)
 		if err != nil {
 			return err
 		}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -29,6 +29,11 @@ var upCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		lock, err := store.Lock(ws.ID)
+		if err != nil {
+			return err
+		}
+		defer lock.Unlock() //nolint:errcheck // best-effort cleanup
 
 		u.Dim(versionString())
 		u.Header("Starting workspace")

--- a/docs/ai-instructions/engine.instructions.md
+++ b/docs/ai-instructions/engine.instructions.md
@@ -22,6 +22,13 @@ compose differences. All post-creation/post-restart steps converge in a single
 Plugin dispatch, file copies, env wiring, lifecycle hooks, and result saving
 live in the shared orchestration layer, never inside the backend.
 
+## Workspace locking
+
+State-mutating commands (up, down, rebuild, restart, remove) acquire an exclusive
+file lock via `store.Lock(ctx, ws.ID)` before operating. The lock file lives at
+`~/.crib/workspaces/{id}/.lock`. Read-only commands (exec, run, shell, logs,
+status, list, doctor) do not lock. The lock respects context cancellation.
+
 ## Up() orchestration
 
 `Up()` in `engine.go` parses config, runs `initializeCommand`, creates a backend,
@@ -71,6 +78,12 @@ compose services are started, created, or restarted. The `composeBackend`
 methods (`start`, `createContainer`, `restart`) handle override generation
 internally. When a container is already running, `upExisting` skips
 regeneration (no backend call needed).
+
+Override generation uses compose-go types (`composetypes.ServiceConfig`,
+`composetypes.Project`) and `project.MarshalYAML()`. Volume targets from the
+user's compose files are loaded via `existingVolumeTargets()` to avoid
+duplicate mount destinations during merge (compose-go emits long-form volumes
+which podman-compose does not deduplicate against short-form).
 
 ## Persisted build artifacts
 

--- a/docs/ai-instructions/logging.instructions.md
+++ b/docs/ai-instructions/logging.instructions.md
@@ -19,7 +19,7 @@ applyTo: "internal/**,cmd/**"
 | Mechanism | Audience | Controlled by |
 |-----------|----------|---------------|
 | `internal/ui` (stdout) | User: results and errors | always visible; `cmd/` layer only |
-| Engine progress callback | User: operation status | always visible |
+| Engine progress callback (`ProgressEvent`) | User: operation status | always visible |
 | Engine stdout/stderr writers | User: subprocess output | `--verbose` |
 | `log/slog` (stderr) | Developer diagnostics | `--debug` |
 
@@ -30,3 +30,11 @@ detection).
 **`--verbose`** passes subprocess stdout through. Does not change the slog level.
 
 **`--debug`** sets slog to Debug and also implies verbose.
+
+## Progress events
+
+The engine emits `ProgressEvent` structs (defined in `progress.go`) with a
+`Phase` and `Message`. Phases: `PhaseBuild`, `PhaseCreate`, `PhaseHooks`,
+`PhaseSnapshot`, `PhaseRestart`, `PhasePlugins`. The cmd layer renders these
+via `u.Dim("  " + ev.Message)`. Use `e.reportProgress(phase, msg)` inside
+engine code; never call the progress callback directly.

--- a/docs/ai-instructions/logging.instructions.md
+++ b/docs/ai-instructions/logging.instructions.md
@@ -34,7 +34,7 @@ detection).
 ## Progress events
 
 The engine emits `ProgressEvent` structs (defined in `progress.go`) with a
-`Phase` and `Message`. Phases: `PhaseBuild`, `PhaseCreate`, `PhaseHooks`,
-`PhaseSnapshot`, `PhaseRestart`, `PhasePlugins`. The cmd layer renders these
+`Phase` and `Message`. Phases: `PhaseInit`, `PhaseBuild`, `PhaseCreate`,
+`PhasePlugins`, `PhaseHooks`, `PhaseRestart`. The cmd layer renders these
 via `u.Dim("  " + ev.Message)`. Use `e.reportProgress(phase, msg)` inside
 engine code; never call the progress callback directly.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -108,7 +108,9 @@ Mounting the host's `~/.claude/projects/<hash>/` directory at the container's ex
 
 #### Structured log events with progress tracking
 
-The official devcontainers CLI uses a typed log event system (`text`, `raw`, `start`, `stop`, `progress`) instead of plain text output. Lifecycle hooks emit `::step::` and `::endstep::` markers that the log handler converts to progress events, enabling rich terminal UI (spinners per hook step) without coupling hooks to the display layer. crib currently uses plain `slog` and a progress callback. A typed event system would decouple output formatting from execution and enable richer feedback during long-running operations.
+Foundation laid: the engine now emits typed `ProgressEvent` structs with `Phase` and `Message` fields, replacing raw string callbacks. The cmd layer renders events identically to before, but the structured data is available for richer UIs.
+
+Remaining work: the official devcontainers CLI goes further with a full event system (`text`, `raw`, `start`, `stop`, `progress`) and lifecycle hooks emit `::step::` and `::endstep::` markers that enable rich terminal UI (spinners per hook step). crib's typed events are the foundation for this, but the richer event taxonomy and per-hook-step tracking are not yet implemented.
 
 #### Rich error context
 
@@ -152,14 +154,6 @@ The spec describes a round-based priority system where `overrideFeatureInstallOr
 
 ### Housekeeping
 
-#### Workspace flock
-
-Concurrent `crib up` invocations on the same workspace can race (two processes building, creating containers, or writing `result.json` simultaneously). DevPod uses [`gofrs/flock`](https://github.com/gofrs/flock) for file-based workspace locking. Small effort, prevents a real (if uncommon) bug class. Lock file would live at `~/.crib/workspaces/{id}/lock`.
-
-#### Adopt compose-go library for Compose YAML parsing
-
-crib currently generates compose override YAML via string concatenation in `generateComposeOverride` (cyclomatic complexity 26) and shells out to `docker compose` for service inspection. The official [`compose-spec/compose-go/v2`](https://github.com/compose-spec/compose-go) library (used by DevPod) provides programmatic access to service definitions, environment files, build configs, and override generation. Would simplify `generateComposeOverride`, `resolveComposeDockerfileInfo`, and the Dockerfile content change detection item above.
-
 #### `userEnvProbe` session caching
 
 crib re-probes the container's user environment on every `crib up` (twice: pre-hook and post-hook). The official devcontainers CLI caches probe results in a container-side session file. Caching the pre-hook probe and only re-probing post-hook could save ~1s per start.
@@ -194,7 +188,7 @@ The name "crib" is close to [cribl.io](https://cribl.io/), which muddies search 
 
 #### Reduce cyclomatic complexity hotspots
 
-CI gates at gocyclo > 40 (the ratchet that prevents things from getting worse). Several engine functions exceed 15, the practical threshold for maintainability: `upCompose` (38), `syncRemoteUserUID` (29), `generateComposeOverride` (26), `Doctor` (23), `detectConfigChange` (22), `extractTar` (19), `upSingle` (18), `restartRecreateSingle` (18). These should be broken into focused helpers before they become harder to change.
+CI threshold lowered to 30 (from 40). `generateComposeOverride` dropped significantly after the compose-go refactor. Remaining hotspots are in the engine orchestration functions (`upCompose`, `syncRemoteUserUID`, `Doctor`, `detectConfigChange`). `upCompose` is the priority target for future decomposition.
 
 ## Not Planned
 

--- a/e2e/doctor_test.go
+++ b/e2e/doctor_test.go
@@ -47,7 +47,18 @@ func TestE2EDoctorFix(t *testing.T) {
 	projectDir := setupProject(t)
 	cribHome := t.TempDir()
 
-	// Doctor --fix on clean state should succeed.
+	// Bring up a workspace so doctor --fix has real state to inspect.
+	// Without a workspace in this store, doctor --fix would see containers
+	// from other CRIB_HOME instances as "dangling" and delete them.
+	mustRunCrib(t, projectDir, cribHome, "up")
+	t.Cleanup(func() {
+		cmd := cribCmd(projectDir, cribHome, "rm", "--force")
+		_ = cmd.Run()
+	})
+
+	// Doctor --fix should succeed with no issues for our workspace.
 	out := mustRunCrib(t, projectDir, cribHome, "doctor", "--fix")
-	_ = out // no-op fix is fine
+	if strings.Contains(strings.ToLower(out), "error") {
+		t.Errorf("doctor --fix: unexpected error in output: %s", out)
+	}
 }

--- a/examples/compose-app/.devcontainer/devcontainer.json
+++ b/examples/compose-app/.devcontainer/devcontainer.json
@@ -1,42 +1,15 @@
-// Compose example covering several recently fixed behaviours:
-//
-//   - Multi-service compose: both app and db start/stop/delete together.
-//   - ${localWorkspaceFolderBasename} in docker-compose.yml: crib passes
-//     devcontainer variables as env vars to docker compose, so ${PROJECT}
-//     resolves without "variable is not set" warnings.
-//   - ${containerEnv:VAR} in remoteEnv: resolved against the running
-//     container's environment after it starts.
-//   - remoteEnv in lifecycle hooks: postCreateCommand sees PROJECT_NAME
-//     and REDIS_URL because hooks now receive remoteEnv via -e flags.
-//   - remoteEnv in crib shell / crib exec: same vars are injected there too.
-//
-// Usage:
-//   cd examples/compose-app
-//   crib up
-//   crib shell                    # PROJECT_NAME and REDIS_URL are set
-//   crib exec -- node hello.js    # prints the resolved env vars
-//   crib stop                     # stops both app and db
-//   crib delete                   # removes both app and db
+// Multi-service compose example with variable chaining and remoteEnv.
 {
   "name": "compose-app",
   "dockerComposeFile": "docker-compose.yml",
   "service": "app",
   "runServices": ["app", "db"],
-
-  // ${localWorkspaceFolderBasename} is substituted by crib before the
-  // workspace folder is used, so this resolves to e.g. /workspaces/compose-app.
   "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
-
   "overrideCommand": true,
   "remoteUser": "root",
-
   "remoteEnv": {
-    // Pulled from the running container env - PROJECT was set in docker-compose.yml
-    // from ${localWorkspaceFolderBasename}, so this chains both substitutions.
     "PROJECT_NAME": "${containerEnv:PROJECT}",
-    // Plain value - shows remoteEnv reaches hooks and shell sessions.
     "REDIS_URL": "redis://db:6379"
   },
-
   "postCreateCommand": "echo '==> PROJECT_NAME='$PROJECT_NAME && echo '==> REDIS_URL='$REDIS_URL && node --version"
 }

--- a/examples/go-project/.devcontainer/devcontainer.json
+++ b/examples/go-project/.devcontainer/devcontainer.json
@@ -1,20 +1,11 @@
 // Go project example with development tools.
-// Usage:
-//   cd examples/go-project
-//   crib up
-//   crib exec -- bash
-//   crib stop
-//   crib delete
 {
   "name": "go-project",
   "image": "docker.io/library/golang:1.26-bookworm",
-
   "overrideCommand": true,
   "remoteUser": "root",
-
   "remoteEnv": {
     "CRIB_EXAMPLE": "go-project"
   },
-
   "postCreateCommand": "apt-get update && apt-get install -y git make curl && echo '==> Go dev environment ready. go version: ' && go version"
 }

--- a/examples/nodejs-project/.devcontainer/devcontainer.json
+++ b/examples/nodejs-project/.devcontainer/devcontainer.json
@@ -1,20 +1,11 @@
 // Node.js project example with development tools.
-// Usage:
-//   cd examples/nodejs-project
-//   crib up
-//   crib exec -- bash
-//   crib stop
-//   crib delete
 {
   "name": "nodejs-project",
   "image": "docker.io/library/node:22-bookworm",
-
   "overrideCommand": true,
   "remoteUser": "root",
-
   "remoteEnv": {
     "CRIB_EXAMPLE": "nodejs-project"
   },
-
   "postCreateCommand": "apt-get update && apt-get install -y git make curl && echo '==> Node.js dev environment ready. node: ' && node --version && npm --version"
 }

--- a/examples/python-dockerfile/.devcontainer/devcontainer.json
+++ b/examples/python-dockerfile/.devcontainer/devcontainer.json
@@ -1,23 +1,14 @@
 // Python project with custom Dockerfile.
-// Usage:
-//   cd examples/python-dockerfile
-//   crib up
-//   crib exec -- bash
-//   crib stop
-//   crib delete
 {
   "name": "python-dockerfile",
   "build": {
     "dockerfile": "Dockerfile",
     "context": "."
   },
-
   "overrideCommand": true,
   "remoteUser": "root",
-
   "remoteEnv": {
     "CRIB_EXAMPLE": "python-dockerfile"
   },
-
   "postCreateCommand": "echo '==> Python dev environment ready.' && python --version && pip list | grep -E 'pytest|black|flake8'"
 }

--- a/examples/ruby-project/.devcontainer/devcontainer.json
+++ b/examples/ruby-project/.devcontainer/devcontainer.json
@@ -1,22 +1,11 @@
 // Ruby project example with bundler cache testing.
-// Usage:
-//   cd examples/ruby-project
-//   crib up
-//   crib run -- rake --version     # should work without bundle exec
-//   crib run -- rspec --version    # should work without bundle exec
-//   crib run -- which rake         # should find it on PATH
-//   crib stop
-//   crib delete
 {
   "name": "ruby-project",
   "image": "docker.io/library/ruby:3.3-bookworm",
-
   "overrideCommand": true,
   "remoteUser": "root",
-
   "remoteEnv": {
     "CRIB_EXAMPLE": "ruby-project"
   },
-
   "postCreateCommand": "bundle install && echo '==> Installed gems:' && gem list --no-versions rake rspec && echo '==> rake at:' && which rake && echo '==> rspec at:' && which rspec"
 }

--- a/examples/rust-project/.devcontainer/devcontainer.json
+++ b/examples/rust-project/.devcontainer/devcontainer.json
@@ -1,15 +1,7 @@
 // Rust project with cargo and apt caching via .cribrc.
-// Usage:
-//   cd examples/rust-project
-//   crib up
-//   crib exec -- bash
-//   crib stop
-//   crib delete
 {
   "name": "rust-project",
   "image": "mcr.microsoft.com/devcontainers/rust:1",
-
   "remoteUser": "vscode",
-
   "postCreateCommand": "sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev && cargo fetch"
 }

--- a/examples/simple/.devcontainer/devcontainer.json
+++ b/examples/simple/.devcontainer/devcontainer.json
@@ -1,25 +1,11 @@
 // Simple crib example using a plain Debian image.
-// Usage:
-//   cd examples/simple
-//   crib up
-//   crib exec -- bash
-//   crib stop
-//   crib delete
 {
   "name": "simple",
   "image": "docker.io/library/debian:12-slim",
-
-  // Keep the container alive and override the default entrypoint.
   "overrideCommand": true,
-
-  // Run lifecycle commands as root (the default).
   "remoteUser": "root",
-
-  // Environment variables injected into every exec session.
   "remoteEnv": {
     "CRIB_EXAMPLE": "simple"
   },
-
-  // Runs once after the container is first created.
   "postCreateCommand": "echo '==> container ready. try: crib exec -- bash'"
 }

--- a/examples/with-local-features/.devcontainer/devcontainer.json
+++ b/examples/with-local-features/.devcontainer/devcontainer.json
@@ -1,26 +1,14 @@
 // Project demonstrating local devcontainer Features.
-// Features are defined as local folders with install.sh and devcontainer-feature.json.
-//
-// Usage:
-//   cd examples/with-local-features
-//   crib up
-//   crib exec -- node --version
-//   crib stop
-//   crib delete
 {
   "name": "with-local-features",
   "image": "docker.io/library/ubuntu:24.04",
-
   "features": {
     "./features/node": {}
   },
-
   "overrideCommand": true,
   "remoteUser": "root",
-
   "remoteEnv": {
     "CRIB_EXAMPLE": "with-local-features"
   },
-
   "postCreateCommand": "node --version"
 }

--- a/examples/with-remote-features/.devcontainer/devcontainer.json
+++ b/examples/with-remote-features/.devcontainer/devcontainer.json
@@ -1,24 +1,13 @@
 // Project demonstrating remote OCI devcontainer Features.
-// Features are pulled from ghcr.io and cached under ~/.crib/feature-cache/.
-//
-// Usage:
-//   cd examples/with-remote-features
-//   crib up
-//   crib exec -- go version
-//   crib stop
-//   crib delete
 {
   "name": "with-remote-features",
   "image": "docker.io/library/ubuntu:24.04",
-
   "features": {
     "ghcr.io/devcontainers/features/go:1": {},
     "ghcr.io/devcontainers/features/node:1": {},
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },
-
   "overrideCommand": true,
   "remoteUser": "root",
-
   "postCreateCommand": "go version && node --version && gh --version"
 }

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/term v0.2.1
 	github.com/compose-spec/compose-go/v2 v2.10.1
+	github.com/gofrs/flock v0.13.0
 	github.com/google/go-containerregistry v0.21.0
 	github.com/moby/buildkit v0.28.1
 	github.com/moby/patternmatcher v0.6.1
@@ -100,7 +101,6 @@ require (
 	github.com/go-xmlfmt/xmlfmt v1.1.3 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/godoc-lint/godoc-lint v0.11.2 // indirect
-	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golangci/asciicheck v0.5.0 // indirect
 	github.com/golangci/dupl v0.0.0-20250308024227-f665c8d69b32 // indirect

--- a/internal/compose/project.go
+++ b/internal/compose/project.go
@@ -27,17 +27,10 @@ type ServiceInfo struct {
 }
 
 // GetServiceInfo loads compose files and extracts configuration for the named service.
-// env provides extra environment variables for ${VAR} substitution in compose files.
+// env provides extra environment variables (KEY=VALUE) for ${VAR} substitution in
+// compose files (e.g. localWorkspaceFolder, devcontainerId).
 func GetServiceInfo(ctx context.Context, paths []string, serviceName string, env []string) (*ServiceInfo, error) {
-	// Merge extra env into env files parameter is not needed here since
-	// LoadProject takes envFiles. Instead, we temporarily set env vars.
-	// Actually, LoadProject uses currentEnv() which reads os.Environ().
-	// The engine passes devcontainer vars via extraEnv to compose CLI,
-	// but LoadProject reads the process env directly.
-	// For now, pass nil envFiles and rely on the caller to have set
-	// the needed env vars, or accept that some ${VAR} references may
-	// not resolve. This matches how compose CLI gets them via cmd.Env.
-	project, err := LoadProject(ctx, paths, nil)
+	project, err := LoadProject(ctx, paths, nil, env)
 	if err != nil {
 		return nil, fmt.Errorf("loading compose project: %w", err)
 	}
@@ -71,7 +64,9 @@ func (h *Helper) BuiltImageName(projectName, serviceName string) string {
 }
 
 // LoadProject loads a Docker Compose project from the given file paths and env files.
-func LoadProject(ctx context.Context, paths []string, envFiles []string) (*types.Project, error) {
+// extraEnv provides additional KEY=VALUE variables for ${VAR} substitution; they take
+// precedence over env file values but NOT over process environment variables.
+func LoadProject(ctx context.Context, paths []string, envFiles []string, extraEnv []string) (*types.Project, error) {
 	if len(paths) == 0 {
 		return nil, fmt.Errorf("no compose files specified")
 	}
@@ -90,15 +85,21 @@ func LoadProject(ctx context.Context, paths []string, envFiles []string) (*types
 		}
 	}
 
-	// Build environment from env files and current process env.
+	// Build environment: process env > extraEnv > env files.
 	env := currentEnv()
+	for _, pair := range extraEnv {
+		if k, v, ok := strings.Cut(pair, "="); ok {
+			if _, exists := env[k]; !exists {
+				env[k] = v
+			}
+		}
+	}
 	for _, ef := range envFiles {
 		parsed, err := dotenv.Read(ef)
 		if err != nil {
 			return nil, fmt.Errorf("reading env file %s: %w", ef, err)
 		}
 		for k, v := range parsed {
-			// Process env takes precedence over env file values.
 			if _, exists := env[k]; !exists {
 				env[k] = v
 			}

--- a/internal/compose/project_test.go
+++ b/internal/compose/project_test.go
@@ -13,7 +13,7 @@ func TestLoadProject(t *testing.T) {
 	composePath := filepath.Join(testdataDir, "simple-compose.yml")
 
 	ctx := context.Background()
-	project, err := LoadProject(ctx, []string{composePath}, nil)
+	project, err := LoadProject(ctx, []string{composePath}, nil, nil)
 	if err != nil {
 		t.Fatalf("LoadProject: %v", err)
 	}
@@ -35,7 +35,7 @@ func TestLoadProject(t *testing.T) {
 
 func TestLoadProject_NoFiles(t *testing.T) {
 	ctx := context.Background()
-	_, err := LoadProject(ctx, nil, nil)
+	_, err := LoadProject(ctx, nil, nil, nil)
 	if err == nil {
 		t.Error("expected error for no files, got nil")
 	}
@@ -97,6 +97,54 @@ func TestGetServiceInfo_NotFound(t *testing.T) {
 	_, err := GetServiceInfo(ctx, []string{composePath}, "nonexistent", nil)
 	if err == nil {
 		t.Error("expected error for nonexistent service, got nil")
+	}
+}
+
+func TestLoadProject_ExtraEnvSubstitution(t *testing.T) {
+	_, thisFile, _, _ := runtime.Caller(0)
+	testdataDir := filepath.Join(filepath.Dir(thisFile), "testdata")
+	composePath := filepath.Join(testdataDir, "env-compose.yml")
+
+	ctx := context.Background()
+	project, err := LoadProject(ctx, []string{composePath}, nil, []string{
+		"localWorkspaceFolder=/home/user/myproject",
+	})
+	if err != nil {
+		t.Fatalf("LoadProject: %v", err)
+	}
+
+	svc, err := project.GetService("app")
+	if err != nil {
+		t.Fatalf("GetService(app): %v", err)
+	}
+
+	if len(svc.Volumes) == 0 {
+		t.Fatal("expected at least one volume")
+	}
+	vol := svc.Volumes[0]
+	if vol.Source != "/home/user/myproject" {
+		t.Errorf("volume source = %q, want /home/user/myproject (env substitution failed)", vol.Source)
+	}
+	if vol.Target != "/workspaces/project" {
+		t.Errorf("volume target = %q, want /workspaces/project", vol.Target)
+	}
+}
+
+func TestGetServiceInfo_ExtraEnvSubstitution(t *testing.T) {
+	_, thisFile, _, _ := runtime.Caller(0)
+	testdataDir := filepath.Join(filepath.Dir(thisFile), "testdata")
+	composePath := filepath.Join(testdataDir, "env-compose.yml")
+
+	ctx := context.Background()
+	// Without env, the variable won't resolve (compose-go treats unset vars as empty).
+	info, err := GetServiceInfo(ctx, []string{composePath}, "app", []string{
+		"localWorkspaceFolder=/tmp/test-project",
+	})
+	if err != nil {
+		t.Fatalf("GetServiceInfo: %v", err)
+	}
+	if info.Image != "alpine:3.20" {
+		t.Errorf("Image = %q, want alpine:3.20", info.Image)
 	}
 }
 

--- a/internal/compose/testdata/env-compose.yml
+++ b/internal/compose/testdata/env-compose.yml
@@ -1,0 +1,5 @@
+services:
+  app:
+    image: alpine:3.20
+    volumes:
+      - ${localWorkspaceFolder}:/workspaces/project

--- a/internal/driver/oci/oci.go
+++ b/internal/driver/oci/oci.go
@@ -31,6 +31,11 @@ func (r Runtime) String() string {
 // LabelWorkspace is the container label key used for workspace discovery.
 const LabelWorkspace = "crib.workspace"
 
+// LabelHome is the container label key that records which CRIB_HOME (workspace
+// store) created the container. Used by doctor to avoid deleting containers
+// that belong to a different store (e.g. test isolation via CRIB_HOME).
+const LabelHome = "crib.home"
+
 // OCIDriver implements driver.Driver using docker or podman CLI commands.
 type OCIDriver struct {
 	helper  *Helper

--- a/internal/engine/backend_compose.go
+++ b/internal/engine/backend_compose.go
@@ -26,7 +26,7 @@ func (b *composeBackend) pluginUser(ctx context.Context) string {
 func (b *composeBackend) start(ctx context.Context, containerID string, pluginResp *plugin.PreContainerRunResponse) (string, error) {
 	allFiles := b.prepareOverride(ctx, pluginResp)
 
-	b.e.reportProgress("Starting services...")
+	b.e.reportProgress(PhaseCreate, "Starting services...")
 	if err := b.e.compose.Start(ctx, b.inv.projectName, allFiles, b.e.composeStdout(), b.e.composeStderr(), b.inv.env); err != nil {
 		return "", fmt.Errorf("starting compose services: %w", err)
 	}
@@ -65,20 +65,20 @@ func (b *composeBackend) createContainer(ctx context.Context, opts createOpts) (
 		if opts.imageName != "" {
 			others := removeService(services, b.cfg.Service)
 			if len(others) > 0 {
-				b.e.reportProgress("Building services...")
+				b.e.reportProgress(PhaseBuild, "Building services...")
 				if err := b.e.compose.Build(ctx, b.inv.projectName, allFiles, others, b.e.stdout, b.e.stderr, b.inv.env); err != nil {
 					return "", fmt.Errorf("building compose services: %w", err)
 				}
 			}
 		} else {
-			b.e.reportProgress("Building services...")
+			b.e.reportProgress(PhaseBuild, "Building services...")
 			if err := b.e.compose.Build(ctx, b.inv.projectName, allFiles, nil, b.e.stdout, b.e.stderr, b.inv.env); err != nil {
 				return "", fmt.Errorf("building compose services: %w", err)
 			}
 		}
 	}
 
-	b.e.reportProgress("Starting services...")
+	b.e.reportProgress(PhaseCreate, "Starting services...")
 	if err := b.e.compose.Up(ctx, b.inv.projectName, allFiles, services, b.e.composeStdout(), b.e.composeStderr(), b.inv.env); err != nil {
 		return "", fmt.Errorf("starting compose services: %w", err)
 	}
@@ -93,12 +93,12 @@ func (b *composeBackend) deleteExisting(ctx context.Context) error {
 func (b *composeBackend) restart(ctx context.Context, containerID string, pluginResp *plugin.PreContainerRunResponse) (string, error) {
 	allFiles := b.prepareOverride(ctx, pluginResp)
 
-	b.e.reportProgress("Stopping services...")
+	b.e.reportProgress(PhaseRestart, "Stopping services...")
 	if err := b.e.compose.Stop(ctx, b.inv.projectName, allFiles, b.e.composeStdout(), b.e.composeStderr(), b.inv.env); err != nil {
 		b.e.logger.Warn("failed to stop services, proceeding with start", "error", err)
 	}
 
-	b.e.reportProgress("Starting services...")
+	b.e.reportProgress(PhaseRestart, "Starting services...")
 	if err := b.e.compose.Start(ctx, b.inv.projectName, allFiles, b.e.composeStdout(), b.e.composeStderr(), b.inv.env); err != nil {
 		return "", fmt.Errorf("starting compose services: %w", err)
 	}

--- a/internal/engine/backend_compose.go
+++ b/internal/engine/backend_compose.go
@@ -1,9 +1,11 @@
 package engine
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/fgrehm/crib/internal/config"
 	"github.com/fgrehm/crib/internal/plugin"
@@ -26,12 +28,13 @@ func (b *composeBackend) pluginUser(ctx context.Context) string {
 func (b *composeBackend) start(ctx context.Context, containerID string, pluginResp *plugin.PreContainerRunResponse) (string, error) {
 	allFiles := b.prepareOverride(ctx, pluginResp)
 
+	var stderrBuf bytes.Buffer
 	b.e.reportProgress(PhaseCreate, "Starting services...")
-	if err := b.e.compose.Start(ctx, b.inv.projectName, allFiles, b.e.composeStdout(), b.e.composeStderr(), b.inv.env); err != nil {
+	if err := b.e.compose.Start(ctx, b.inv.projectName, allFiles, b.e.composeStdout(), b.e.composeStderrTee(&stderrBuf), b.inv.env); err != nil {
 		return "", fmt.Errorf("starting compose services: %w", err)
 	}
 
-	return b.findRunningContainer(ctx, "after start")
+	return b.findRunningContainer(ctx, "after start", stderrBuf.String())
 }
 
 func (b *composeBackend) buildImage(ctx context.Context) (*buildResult, error) {
@@ -78,12 +81,13 @@ func (b *composeBackend) createContainer(ctx context.Context, opts createOpts) (
 		}
 	}
 
+	var stderrBuf bytes.Buffer
 	b.e.reportProgress(PhaseCreate, "Starting services...")
-	if err := b.e.compose.Up(ctx, b.inv.projectName, allFiles, services, b.e.composeStdout(), b.e.composeStderr(), b.inv.env); err != nil {
+	if err := b.e.compose.Up(ctx, b.inv.projectName, allFiles, services, b.e.composeStdout(), b.e.composeStderrTee(&stderrBuf), b.inv.env); err != nil {
 		return "", fmt.Errorf("starting compose services: %w", err)
 	}
 
-	return b.findRunningContainer(ctx, "after up")
+	return b.findRunningContainer(ctx, "after up", stderrBuf.String())
 }
 
 func (b *composeBackend) deleteExisting(ctx context.Context) error {
@@ -98,12 +102,13 @@ func (b *composeBackend) restart(ctx context.Context, containerID string, plugin
 		b.e.logger.Warn("failed to stop services, proceeding with start", "error", err)
 	}
 
+	var stderrBuf bytes.Buffer
 	b.e.reportProgress(PhaseRestart, "Starting services...")
-	if err := b.e.compose.Start(ctx, b.inv.projectName, allFiles, b.e.composeStdout(), b.e.composeStderr(), b.inv.env); err != nil {
+	if err := b.e.compose.Start(ctx, b.inv.projectName, allFiles, b.e.composeStdout(), b.e.composeStderrTee(&stderrBuf), b.inv.env); err != nil {
 		return "", fmt.Errorf("starting compose services: %w", err)
 	}
 
-	return b.findRunningContainer(ctx, "after restart")
+	return b.findRunningContainer(ctx, "after restart", stderrBuf.String())
 }
 
 func (b *composeBackend) canResumeFromStored() bool {
@@ -134,10 +139,15 @@ func (b *composeBackend) prepareOverride(ctx context.Context, pluginResp *plugin
 }
 
 // findRunningContainer locates the primary service container and verifies
-// it is running.
-func (b *composeBackend) findRunningContainer(ctx context.Context, stage string) (string, error) {
+// it is running. composeOutput is included in the error message when the
+// container cannot be found, providing diagnostics that would otherwise be
+// lost when compose stderr is discarded in non-verbose mode.
+func (b *composeBackend) findRunningContainer(ctx context.Context, stage, composeOutput string) (string, error) {
 	container, err := b.e.findComposeContainer(ctx, b.ws.ID, b.inv, stage)
 	if err != nil {
+		if hint := strings.TrimSpace(composeOutput); hint != "" {
+			return "", fmt.Errorf("%w\ncompose output:\n%s", err, hint)
+		}
 		return "", err
 	}
 	if err := b.e.ensureContainerRunning(ctx, b.ws.ID, container); err != nil {

--- a/internal/engine/backend_single.go
+++ b/internal/engine/backend_single.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/fgrehm/crib/internal/config"
+	ocidriver "github.com/fgrehm/crib/internal/driver/oci"
 	"github.com/fgrehm/crib/internal/plugin"
 	"github.com/fgrehm/crib/internal/workspace"
 )
@@ -37,6 +38,7 @@ func (b *singleBackend) createContainer(ctx context.Context, opts createOpts) (s
 	if err != nil {
 		return "", err
 	}
+	runOpts.Labels[ocidriver.LabelHome] = b.e.store.BaseDir()
 
 	subCtx := &config.SubstitutionContext{
 		DevContainerID:           b.ws.ID,

--- a/internal/engine/backend_single.go
+++ b/internal/engine/backend_single.go
@@ -55,7 +55,7 @@ func (b *singleBackend) createContainer(ctx context.Context, opts createOpts) (s
 		runOpts.ExtraArgs = append(runOpts.ExtraArgs, opts.pluginResp.RunArgs...)
 	}
 
-	b.e.reportProgress("Creating container...")
+	b.e.reportProgress(PhaseCreate, "Creating container...")
 	if err := b.e.driver.RunContainer(ctx, b.ws.ID, runOpts); err != nil {
 		return "", fmt.Errorf("creating container: %w", err)
 	}

--- a/internal/engine/backend_single_test.go
+++ b/internal/engine/backend_single_test.go
@@ -29,7 +29,7 @@ func TestSingleBackend_CanResumeFromStored_ReturnsFalse(t *testing.T) {
 
 func TestSingleBackend_Start_CallsDriverStart(t *testing.T) {
 	drv := &mockDriver{}
-	eng := &Engine{driver: drv, logger: slog.Default(), progress: func(string) {}}
+	eng := &Engine{driver: drv, logger: slog.Default(), progress: func(ProgressEvent) {}}
 
 	b := &singleBackend{
 		e:  eng,
@@ -47,7 +47,7 @@ func TestSingleBackend_Start_CallsDriverStart(t *testing.T) {
 
 func TestSingleBackend_Restart_CallsDriverRestart(t *testing.T) {
 	drv := &mockDriver{}
-	eng := &Engine{driver: drv, logger: slog.Default(), progress: func(string) {}}
+	eng := &Engine{driver: drv, logger: slog.Default(), progress: func(ProgressEvent) {}}
 
 	b := &singleBackend{
 		e:  eng,
@@ -77,7 +77,7 @@ func TestSingleBackend_CreateContainer_MergesPluginResponse(t *testing.T) {
 		logger:   slog.Default(),
 		stdout:   io.Discard,
 		stderr:   io.Discard,
-		progress: func(string) {},
+		progress: func(ProgressEvent) {},
 	}
 
 	cfg := &config.DevContainerConfig{}
@@ -162,7 +162,7 @@ func TestSingleBackend_CreateContainer_AppliesFeatureMetadata(t *testing.T) {
 		logger:   slog.Default(),
 		stdout:   io.Discard,
 		stderr:   io.Discard,
-		progress: func(string) {},
+		progress: func(ProgressEvent) {},
 	}
 
 	cfg := &config.DevContainerConfig{}
@@ -242,7 +242,7 @@ func TestSingleBackend_DeleteExisting_WithContainer(t *testing.T) {
 
 func TestSingleBackend_Start_IgnoresPluginResp(t *testing.T) {
 	drv := &mockDriver{}
-	eng := &Engine{driver: drv, logger: slog.Default(), progress: func(string) {}}
+	eng := &Engine{driver: drv, logger: slog.Default(), progress: func(ProgressEvent) {}}
 
 	b := &singleBackend{
 		e:  eng,
@@ -277,7 +277,7 @@ func TestSingleBackend_CreateContainer_FeatureEntrypoints(t *testing.T) {
 		logger:   slog.Default(),
 		stdout:   io.Discard,
 		stderr:   io.Discard,
-		progress: func(string) {},
+		progress: func(ProgressEvent) {},
 	}
 
 	cfg := &config.DevContainerConfig{}
@@ -318,7 +318,7 @@ func TestSingleBackend_CreateContainer_FeatureEntrypoints(t *testing.T) {
 
 func TestSingleBackend_Restart_IgnoresPluginResp(t *testing.T) {
 	drv := &mockDriver{}
-	eng := &Engine{driver: drv, logger: slog.Default(), progress: func(string) {}}
+	eng := &Engine{driver: drv, logger: slog.Default(), progress: func(ProgressEvent) {}}
 
 	b := &singleBackend{
 		e:  eng,
@@ -354,7 +354,7 @@ func TestSingleBackend_CreateContainer_FindsNewContainer(t *testing.T) {
 		logger:   slog.Default(),
 		stdout:   io.Discard,
 		stderr:   io.Discard,
-		progress: func(string) {},
+		progress: func(ProgressEvent) {},
 	}
 
 	cfg := &config.DevContainerConfig{}
@@ -398,7 +398,7 @@ func TestSingleBackend_CreateContainer_ProgressReported(t *testing.T) {
 		logger:   slog.Default(),
 		stdout:   io.Discard,
 		stderr:   io.Discard,
-		progress: func(msg string) { progressMessages = append(progressMessages, msg) },
+		progress: func(ev ProgressEvent) { progressMessages = append(progressMessages, ev.Message) },
 	}
 
 	cfg := &config.DevContainerConfig{}

--- a/internal/engine/build.go
+++ b/internal/engine/build.go
@@ -183,7 +183,7 @@ func (e *Engine) doBuild(ctx context.Context, ws *workspace.Workspace, cfg *conf
 
 	// Check if image already exists.
 	if _, inspErr := e.driver.InspectImage(ctx, imageName); inspErr == nil {
-		e.reportProgress("Image cached, skipping build")
+		e.reportProgress(PhaseBuild, "Image cached, skipping build")
 		return &buildResult{
 			imageName:      imageName,
 			imageMetadata:  metadata,
@@ -219,7 +219,7 @@ func (e *Engine) doBuild(ctx context.Context, ws *workspace.Workspace, cfg *conf
 	// Clean up previous build image if hash changed.
 	e.cleanupPreviousBuildImage(ctx, ws.ID, imageName)
 
-	e.reportProgress("Building image...")
+	e.reportProgress(PhaseBuild, "Building image...")
 	err = e.driver.BuildImage(ctx, ws.ID, &driver.BuildOptions{
 		PrebuildHash: hash,
 		Image:        imageName,

--- a/internal/engine/compose.go
+++ b/internal/engine/compose.go
@@ -251,7 +251,11 @@ func (e *Engine) generateComposeOverride(ws *workspace.Workspace, cfg *config.De
 		return "", fmt.Errorf("marshalling compose override: %w", err)
 	}
 
-	overridePath := filepath.Join(e.store.WorkspaceDir(ws.ID), "compose-override.yml")
+	wsDir := e.store.WorkspaceDir(ws.ID)
+	if err := os.MkdirAll(wsDir, 0o755); err != nil {
+		return "", fmt.Errorf("creating workspace directory: %w", err)
+	}
+	overridePath := filepath.Join(wsDir, "compose-override.yml")
 	if err := os.WriteFile(overridePath, yamlBytes, 0o644); err != nil {
 		return "", fmt.Errorf("writing compose override: %w", err)
 	}

--- a/internal/engine/compose.go
+++ b/internal/engine/compose.go
@@ -236,37 +236,8 @@ func (e *Engine) generateComposeOverride(ws *workspace.Workspace, cfg *config.De
 	svc.CapAdd = featOv.CapAdd
 	svc.SecurityOpt = featOv.SecurityOpt
 
-	// Container environment (config + features + plugins).
-	env := composetypes.MappingWithEquals{}
-	for k, v := range cfg.ContainerEnv {
-		env[k] = &v
-	}
-	for k, v := range featOv.Env {
-		env[k] = &v
-	}
-	if pluginResp != nil {
-		for k, v := range pluginResp.Env {
-			env[k] = &v
-		}
-	}
-	if len(env) > 0 {
-		svc.Environment = env
-	}
-
-	// Volumes: workspace mount + feature mounts + plugin mounts.
-	if cfg.WorkspaceMount == "" {
-		svc.Volumes = append(svc.Volumes, composetypes.ServiceVolumeConfig{
-			Type: "bind", Source: ws.Source, Target: workspaceFolder,
-		})
-	}
-	for _, m := range featOv.Mounts {
-		svc.Volumes = append(svc.Volumes, toComposeVolume(m))
-	}
-	if pluginResp != nil {
-		for _, m := range pluginResp.Mounts {
-			svc.Volumes = append(svc.Volumes, toComposeVolume(m))
-		}
-	}
+	svc.Environment = buildOverrideEnv(cfg, featOv, pluginResp)
+	svc.Volumes = buildOverrideVolumes(ws, cfg, workspaceFolder, featOv, pluginResp)
 
 	// Auto-inject userns_mode for rootless Podman.
 	isPodman := e.isRootlessPodman() && !composeFilesContainUserns(composeFiles)
@@ -278,18 +249,7 @@ func (e *Engine) generateComposeOverride(ws *workspace.Workspace, cfg *config.De
 		Services: composetypes.Services{serviceName: svc},
 	}
 
-	// Top-level named volume declarations (compose rejects unknown names).
-	namedVols := composetypes.Volumes{}
-	seen := make(map[string]bool)
-	for _, v := range svc.Volumes {
-		if v.Type == "volume" && !seen[v.Source] {
-			seen[v.Source] = true
-			namedVols[v.Source] = composetypes.VolumeConfig{Name: v.Source}
-		}
-	}
-	if len(namedVols) > 0 {
-		project.Volumes = namedVols
-	}
+	project.Volumes = collectNamedVolumes(svc.Volumes)
 
 	// Disable podman-compose pod creation (incompatible with --userns).
 	if isPodman {
@@ -314,6 +274,62 @@ func (e *Engine) generateComposeOverride(ws *workspace.Workspace, cfg *config.De
 	}
 
 	return overridePath, nil
+}
+
+// buildOverrideEnv merges environment variables from config, features, and
+// plugins into a single MappingWithEquals for the compose override.
+func buildOverrideEnv(cfg *config.DevContainerConfig, featOv featureOverrides, pluginResp *plugin.PreContainerRunResponse) composetypes.MappingWithEquals {
+	env := composetypes.MappingWithEquals{}
+	for k, v := range cfg.ContainerEnv {
+		env[k] = &v
+	}
+	for k, v := range featOv.Env {
+		env[k] = &v
+	}
+	if pluginResp != nil {
+		for k, v := range pluginResp.Env {
+			env[k] = &v
+		}
+	}
+	if len(env) == 0 {
+		return nil
+	}
+	return env
+}
+
+// buildOverrideVolumes assembles the service volume list from the workspace
+// bind mount, feature mounts, and plugin mounts.
+func buildOverrideVolumes(ws *workspace.Workspace, cfg *config.DevContainerConfig, workspaceFolder string, featOv featureOverrides, pluginResp *plugin.PreContainerRunResponse) []composetypes.ServiceVolumeConfig {
+	var vols []composetypes.ServiceVolumeConfig
+	if cfg.WorkspaceMount == "" {
+		vols = append(vols, composetypes.ServiceVolumeConfig{
+			Type: "bind", Source: ws.Source, Target: workspaceFolder,
+		})
+	}
+	for _, m := range featOv.Mounts {
+		vols = append(vols, toComposeVolume(m))
+	}
+	if pluginResp != nil {
+		for _, m := range pluginResp.Mounts {
+			vols = append(vols, toComposeVolume(m))
+		}
+	}
+	return vols
+}
+
+// collectNamedVolumes returns top-level volume declarations for any "volume"
+// type mounts. Compose rejects unknown volume references without these.
+func collectNamedVolumes(vols []composetypes.ServiceVolumeConfig) composetypes.Volumes {
+	named := composetypes.Volumes{}
+	for _, v := range vols {
+		if v.Type == "volume" {
+			named[v.Source] = composetypes.VolumeConfig{Name: v.Source}
+		}
+	}
+	if len(named) == 0 {
+		return nil
+	}
+	return named
 }
 
 // toComposeVolume converts a crib config.Mount to a compose ServiceVolumeConfig.

--- a/internal/engine/compose.go
+++ b/internal/engine/compose.go
@@ -143,32 +143,19 @@ type featureOverrides struct {
 func collectFeatureOverrides(metadata []*config.ImageMetadata, subCtx *config.SubstitutionContext) featureOverrides {
 	sub := func(s string) string { return config.SubstituteString(subCtx, s) }
 
-	var ov featureOverrides
+	ov := featureOverrides{Env: make(map[string]string)}
 	for _, m := range metadata {
-		if m.Privileged != nil && *m.Privileged {
+		if !ov.Privileged && m.Privileged != nil && *m.Privileged {
 			ov.Privileged = true
-			break
 		}
-	}
-	for _, m := range metadata {
-		if m.Init != nil && *m.Init {
+		if !ov.Init && m.Init != nil && *m.Init {
 			ov.Init = true
-			break
 		}
-	}
-	for _, m := range metadata {
 		ov.CapAdd = append(ov.CapAdd, m.CapAdd...)
 		ov.SecurityOpt = append(ov.SecurityOpt, m.SecurityOpt...)
-	}
-
-	ov.Env = make(map[string]string)
-	for _, m := range metadata {
 		for k, v := range m.ContainerEnv {
 			ov.Env[k] = sub(v)
 		}
-	}
-
-	for _, m := range metadata {
 		for _, mount := range m.Mounts {
 			mount.Source = sub(mount.Source)
 			mount.Target = sub(mount.Target)
@@ -206,7 +193,7 @@ func (e *Engine) generateComposeOverride(ws *workspace.Workspace, cfg *config.De
 
 	// Override entrypoint/command to keep the container alive.
 	overrideCommand := cfg.OverrideCommand == nil || *cfg.OverrideCommand
-	sleepCmd := `echo Container started; trap "exit 0" 15; exec "$@"; sleep infinity`
+	sleepCmd := sleepScript
 	if overrideCommand {
 		if hasFeatureEntrypoints {
 			// Feature entrypoints are baked into the image. Don't
@@ -264,11 +251,7 @@ func (e *Engine) generateComposeOverride(ws *workspace.Workspace, cfg *config.De
 		return "", fmt.Errorf("marshalling compose override: %w", err)
 	}
 
-	wsDir := e.store.WorkspaceDir(ws.ID)
-	if err := os.MkdirAll(wsDir, 0o755); err != nil {
-		return "", fmt.Errorf("creating workspace directory: %w", err)
-	}
-	overridePath := filepath.Join(wsDir, "compose-override.yml")
+	overridePath := filepath.Join(e.store.WorkspaceDir(ws.ID), "compose-override.yml")
 	if err := os.WriteFile(overridePath, yamlBytes, 0o644); err != nil {
 		return "", fmt.Errorf("writing compose override: %w", err)
 	}

--- a/internal/engine/compose.go
+++ b/internal/engine/compose.go
@@ -33,7 +33,7 @@ func (e *Engine) buildComposeFeatures(ctx context.Context, ws *workspace.Workspa
 	var baseImage string
 	if svcInfo.HasBuild {
 		// Build-based service: run compose build first to produce the base image.
-		e.reportProgress("Building service...")
+		e.reportProgress(PhaseBuild, "Building service...")
 		if err := e.compose.Build(ctx, inv.projectName, inv.files, []string{serviceName}, e.stdout, e.stderr, inv.env); err != nil {
 			return nil, fmt.Errorf("building compose service: %w", err)
 		}

--- a/internal/engine/compose.go
+++ b/internal/engine/compose.go
@@ -225,7 +225,13 @@ func (e *Engine) generateComposeOverride(ws *workspace.Workspace, cfg *config.De
 	svc.SecurityOpt = featOv.SecurityOpt
 
 	svc.Environment = buildOverrideEnv(cfg, featOv, pluginResp)
-	svc.Volumes = buildOverrideVolumes(ws, cfg, workspaceFolder, featOv, pluginResp)
+
+	// Load existing volume targets from the user's compose files so we
+	// don't produce duplicate mount destinations in the override. Compose
+	// deduplicates short-form volumes by target during merge, but not
+	// when the override uses long-form (compose-go's output format).
+	existingTargets := e.existingVolumeTargets(composeFiles, serviceName)
+	svc.Volumes = buildOverrideVolumes(ws, cfg, workspaceFolder, featOv, pluginResp, existingTargets)
 
 	// Auto-inject userns_mode for rootless Podman.
 	isPodman := e.isRootlessPodman() && !composeFilesContainUserns(composeFiles)
@@ -286,20 +292,27 @@ func buildOverrideEnv(cfg *config.DevContainerConfig, featOv featureOverrides, p
 }
 
 // buildOverrideVolumes assembles the service volume list from the workspace
-// bind mount, feature mounts, and plugin mounts.
-func buildOverrideVolumes(ws *workspace.Workspace, cfg *config.DevContainerConfig, workspaceFolder string, featOv featureOverrides, pluginResp *plugin.PreContainerRunResponse) []composetypes.ServiceVolumeConfig {
+// bind mount, feature mounts, and plugin mounts. existingTargets contains
+// volume targets already defined in the user's compose files; mounts for
+// those targets are skipped to avoid "duplicate mount destination" errors
+// when compose merges the files.
+func buildOverrideVolumes(ws *workspace.Workspace, cfg *config.DevContainerConfig, workspaceFolder string, featOv featureOverrides, pluginResp *plugin.PreContainerRunResponse, existingTargets map[string]bool) []composetypes.ServiceVolumeConfig {
 	var vols []composetypes.ServiceVolumeConfig
-	if cfg.WorkspaceMount == "" {
+	if cfg.WorkspaceMount == "" && !existingTargets[workspaceFolder] {
 		vols = append(vols, composetypes.ServiceVolumeConfig{
 			Type: "bind", Source: ws.Source, Target: workspaceFolder,
 		})
 	}
 	for _, m := range featOv.Mounts {
-		vols = append(vols, toComposeVolume(m))
+		if !existingTargets[m.Target] {
+			vols = append(vols, toComposeVolume(m))
+		}
 	}
 	if pluginResp != nil {
 		for _, m := range pluginResp.Mounts {
-			vols = append(vols, toComposeVolume(m))
+			if !existingTargets[m.Target] {
+				vols = append(vols, toComposeVolume(m))
+			}
 		}
 	}
 	return vols
@@ -318,6 +331,32 @@ func collectNamedVolumes(vols []composetypes.ServiceVolumeConfig) composetypes.V
 		return nil
 	}
 	return named
+}
+
+// existingVolumeTargets loads the user's compose files and returns the set of
+// volume target paths already defined for the given service. Returns nil on
+// any error (best-effort; the override will include all mounts and compose
+// may report a duplicate if one exists).
+func (e *Engine) existingVolumeTargets(composeFiles []string, service string) map[string]bool {
+	if len(composeFiles) == 0 {
+		return nil
+	}
+	project, err := composehelper.LoadProject(context.Background(), composeFiles, nil)
+	if err != nil {
+		e.logger.Debug("failed to load compose files for volume dedup", "error", err)
+		return nil
+	}
+	svc, err := project.GetService(service)
+	if err != nil {
+		return nil
+	}
+	targets := make(map[string]bool, len(svc.Volumes))
+	for _, v := range svc.Volumes {
+		if v.Target != "" {
+			targets[v.Target] = true
+		}
+	}
+	return targets
 }
 
 // toComposeVolume converts a crib config.Mount to a compose ServiceVolumeConfig.

--- a/internal/engine/compose.go
+++ b/internal/engine/compose.go
@@ -175,6 +175,7 @@ func (e *Engine) generateComposeOverride(ws *workspace.Workspace, cfg *config.De
 	svc := composetypes.ServiceConfig{
 		Labels: composetypes.Labels{
 			ocidriver.LabelWorkspace: ws.ID,
+			ocidriver.LabelHome:      e.store.BaseDir(),
 		},
 	}
 

--- a/internal/engine/compose.go
+++ b/internal/engine/compose.go
@@ -9,6 +9,8 @@ import (
 	"slices"
 	"strings"
 
+	composetypes "github.com/compose-spec/compose-go/v2/types"
+
 	composehelper "github.com/fgrehm/crib/internal/compose"
 	"github.com/fgrehm/crib/internal/config"
 	"github.com/fgrehm/crib/internal/dockerfile"
@@ -125,28 +127,72 @@ func (e *Engine) resolveComposeDockerfileInfo(svcInfo *composehelper.ServiceInfo
 	return baseImage, user
 }
 
-// generateComposeOverride creates a temporary compose override file that adds
-// crib-specific labels and configuration to the target service.
-// pluginResp may be nil; when non-nil, plugin mounts and env are included.
+// featureOverrides holds capabilities and runtime configuration declared by
+// DevContainer Features, collected from image metadata.
+type featureOverrides struct {
+	Privileged  bool
+	Init        bool
+	CapAdd      []string
+	SecurityOpt []string
+	Env         map[string]string
+	Mounts      []config.Mount
+}
+
+// collectFeatureOverrides gathers feature-declared capabilities, env, and
+// mounts from image metadata, applying variable substitution to values.
+func collectFeatureOverrides(metadata []*config.ImageMetadata, subCtx *config.SubstitutionContext) featureOverrides {
+	sub := func(s string) string { return config.SubstituteString(subCtx, s) }
+
+	var ov featureOverrides
+	for _, m := range metadata {
+		if m.Privileged != nil && *m.Privileged {
+			ov.Privileged = true
+			break
+		}
+	}
+	for _, m := range metadata {
+		if m.Init != nil && *m.Init {
+			ov.Init = true
+			break
+		}
+	}
+	for _, m := range metadata {
+		ov.CapAdd = append(ov.CapAdd, m.CapAdd...)
+		ov.SecurityOpt = append(ov.SecurityOpt, m.SecurityOpt...)
+	}
+
+	ov.Env = make(map[string]string)
+	for _, m := range metadata {
+		for k, v := range m.ContainerEnv {
+			ov.Env[k] = sub(v)
+		}
+	}
+
+	for _, m := range metadata {
+		for _, mount := range m.Mounts {
+			mount.Source = sub(mount.Source)
+			mount.Target = sub(mount.Target)
+			ov.Mounts = append(ov.Mounts, mount)
+		}
+	}
+	return ov
+}
+
 // generateComposeOverride creates a compose override file with crib-specific
-// configuration (labels, entrypoint, env, mounts, etc.). featureMetadata is
-// optional; when non-nil, feature-declared capabilities (privileged, init,
-// capAdd, entrypoints) are included in the override.
+// configuration (labels, entrypoint, env, mounts, etc.) using compose-go types.
+// featureMetadata is optional; when non-nil, feature-declared capabilities
+// (privileged, init, capAdd, entrypoints) are included in the override.
 func (e *Engine) generateComposeOverride(ws *workspace.Workspace, cfg *config.DevContainerConfig, workspaceFolder string, composeFiles []string, featureImage string, pluginResp *plugin.PreContainerRunResponse, featureMetadata ...*config.ImageMetadata) (string, error) {
 	serviceName := cfg.Service
 
-	// Build the override YAML.
-	var b strings.Builder
-	b.WriteString("services:\n")
-	fmt.Fprintf(&b, "  %s:\n", serviceName)
+	svc := composetypes.ServiceConfig{
+		Labels: composetypes.Labels{
+			ocidriver.LabelWorkspace: ws.ID,
+		},
+	}
 
-	// Add workspace label for container discovery.
-	b.WriteString("    labels:\n")
-	fmt.Fprintf(&b, "      %s: %q\n", ocidriver.LabelWorkspace, ws.ID)
-
-	// Override image if a feature image was built.
 	if featureImage != "" {
-		fmt.Fprintf(&b, "    image: %s\n", featureImage)
+		svc.Image = featureImage
 	}
 
 	// Check if features declare entrypoints (baked into image ENTRYPOINT).
@@ -160,170 +206,125 @@ func (e *Engine) generateComposeOverride(ws *workspace.Workspace, cfg *config.De
 
 	// Override entrypoint/command to keep the container alive.
 	overrideCommand := cfg.OverrideCommand == nil || *cfg.OverrideCommand
+	sleepCmd := `echo Container started; trap "exit 0" 15; exec "$@"; sleep infinity`
 	if overrideCommand {
 		if hasFeatureEntrypoints {
 			// Feature entrypoints are baked into the image. Don't
 			// override entrypoint; only set command as a full command
 			// so the feature entrypoint can exec into it.
-			b.WriteString("    command:\n")
-			b.WriteString("      - /bin/sh\n")
-			b.WriteString("      - -c\n")
-			b.WriteString("      - 'echo Container started; trap \"exit 0\" 15; exec \"$@\"; sleep infinity'\n")
+			svc.Command = composetypes.ShellCommand{"/bin/sh", "-c", sleepCmd}
 		} else {
-			b.WriteString("    entrypoint: /bin/sh\n")
-			b.WriteString("    command:\n")
-			b.WriteString("      - -c\n")
-			b.WriteString("      - 'echo Container started; trap \"exit 0\" 15; exec \"$@\"; sleep infinity'\n")
+			svc.Entrypoint = composetypes.ShellCommand{"/bin/sh"}
+			svc.Command = composetypes.ShellCommand{"-c", sleepCmd}
 		}
 	}
 
-	// Apply feature capabilities and collect mounts/env with variable substitution.
+	// Collect feature capabilities, env, and mounts.
 	subCtx := &config.SubstitutionContext{
 		DevContainerID:           ws.ID,
 		LocalWorkspaceFolder:     ws.Source,
 		ContainerWorkspaceFolder: workspaceFolder,
 		Env:                      envMap(),
 	}
-	featureEnv, featureMounts := writeFeatureOverrides(&b, featureMetadata, subCtx)
+	featOv := collectFeatureOverrides(featureMetadata, subCtx)
 
-	// Container environment (config + plugins + features).
-	hasConfigEnv := len(cfg.ContainerEnv) > 0
-	hasPluginEnv := pluginResp != nil && len(pluginResp.Env) > 0
-	hasFeatureEnv := len(featureEnv) > 0
-	if hasConfigEnv || hasPluginEnv || hasFeatureEnv {
-		b.WriteString("    environment:\n")
-		for k, v := range cfg.ContainerEnv {
-			fmt.Fprintf(&b, "      %s: %q\n", k, v)
-		}
-		for k, v := range featureEnv {
-			fmt.Fprintf(&b, "      %s: %q\n", k, v)
-		}
-		if hasPluginEnv {
-			for k, v := range pluginResp.Env {
-				fmt.Fprintf(&b, "      %s: %q\n", k, v)
-			}
+	svc.Privileged = featOv.Privileged
+	if featOv.Init {
+		initTrue := true
+		svc.Init = &initTrue
+	}
+	svc.CapAdd = featOv.CapAdd
+	svc.SecurityOpt = featOv.SecurityOpt
+
+	// Container environment (config + features + plugins).
+	env := composetypes.MappingWithEquals{}
+	for k, v := range cfg.ContainerEnv {
+		env[k] = &v
+	}
+	for k, v := range featOv.Env {
+		env[k] = &v
+	}
+	if pluginResp != nil {
+		for k, v := range pluginResp.Env {
+			env[k] = &v
 		}
 	}
-
-	// Volumes: workspace mount + plugin mounts + feature mounts.
-	useDefaultWorkspaceMount := cfg.WorkspaceMount == ""
-	hasPluginMounts := pluginResp != nil && len(pluginResp.Mounts) > 0
-	hasFeatureMounts := len(featureMounts) > 0
-	if useDefaultWorkspaceMount || hasPluginMounts || hasFeatureMounts {
-		b.WriteString("    volumes:\n")
-		if useDefaultWorkspaceMount {
-			fmt.Fprintf(&b, "      - %s:%s\n", ws.Source, workspaceFolder)
-		}
-		for _, m := range featureMounts {
-			fmt.Fprintf(&b, "      - %s:%s\n", m.Source, m.Target)
-		}
-		if hasPluginMounts {
-			for _, m := range pluginResp.Mounts {
-				fmt.Fprintf(&b, "      - %s:%s\n", m.Source, m.Target)
-			}
-		}
+	if len(env) > 0 {
+		svc.Environment = env
 	}
 
-	// Auto-inject userns_mode: "keep-id" for rootless Podman to fix bind mount
-	// permissions. Skip if the user already set userns_mode in their compose files.
-	// Also disable podman-compose pod creation (x-podman.in_pod) because
-	// --userns and --pod are incompatible in Podman.
-	if e.isRootlessPodman() && !composeFilesContainUserns(composeFiles) {
-		b.WriteString("    userns_mode: \"keep-id\"\n")
-		b.WriteString("x-podman:\n")
-		b.WriteString("  in_pod: false\n")
+	// Volumes: workspace mount + feature mounts + plugin mounts.
+	if cfg.WorkspaceMount == "" {
+		svc.Volumes = append(svc.Volumes, composetypes.ServiceVolumeConfig{
+			Type: "bind", Source: ws.Source, Target: workspaceFolder,
+		})
 	}
-
-	// Top-level volumes: declarations for named volumes (e.g. package cache, features).
-	// Without this, compose rejects unknown volume references in the service.
-	namedVolSeen := make(map[string]bool)
-	var namedVolNames []string
-	for _, m := range featureMounts {
-		if m.Type == "volume" && !namedVolSeen[m.Source] {
-			namedVolSeen[m.Source] = true
-			namedVolNames = append(namedVolNames, m.Source)
-		}
+	for _, m := range featOv.Mounts {
+		svc.Volumes = append(svc.Volumes, toComposeVolume(m))
 	}
-	if hasPluginMounts {
+	if pluginResp != nil {
 		for _, m := range pluginResp.Mounts {
-			if m.Type == "volume" && !namedVolSeen[m.Source] {
-				namedVolSeen[m.Source] = true
-				namedVolNames = append(namedVolNames, m.Source)
-			}
-		}
-	}
-	if len(namedVolNames) > 0 {
-		b.WriteString("volumes:\n")
-		for _, name := range namedVolNames {
-			fmt.Fprintf(&b, "  %s:\n    name: %s\n", name, name)
+			svc.Volumes = append(svc.Volumes, toComposeVolume(m))
 		}
 	}
 
-	// Persist the override in the workspace state directory so it survives
-	// for troubleshooting. The file is overwritten on every compose up.
+	// Auto-inject userns_mode for rootless Podman.
+	isPodman := e.isRootlessPodman() && !composeFilesContainUserns(composeFiles)
+	if isPodman {
+		svc.UserNSMode = "keep-id"
+	}
+
+	project := &composetypes.Project{
+		Services: composetypes.Services{serviceName: svc},
+	}
+
+	// Top-level named volume declarations (compose rejects unknown names).
+	namedVols := composetypes.Volumes{}
+	seen := make(map[string]bool)
+	for _, v := range svc.Volumes {
+		if v.Type == "volume" && !seen[v.Source] {
+			seen[v.Source] = true
+			namedVols[v.Source] = composetypes.VolumeConfig{Name: v.Source}
+		}
+	}
+	if len(namedVols) > 0 {
+		project.Volumes = namedVols
+	}
+
+	// Disable podman-compose pod creation (incompatible with --userns).
+	if isPodman {
+		project.Extensions = composetypes.Extensions{
+			"x-podman": map[string]any{"in_pod": false},
+		}
+	}
+
+	// Marshal and persist.
+	yamlBytes, err := project.MarshalYAML()
+	if err != nil {
+		return "", fmt.Errorf("marshalling compose override: %w", err)
+	}
+
 	wsDir := e.store.WorkspaceDir(ws.ID)
 	if err := os.MkdirAll(wsDir, 0o755); err != nil {
 		return "", fmt.Errorf("creating workspace directory: %w", err)
 	}
 	overridePath := filepath.Join(wsDir, "compose-override.yml")
-	if err := os.WriteFile(overridePath, []byte(b.String()), 0o644); err != nil {
+	if err := os.WriteFile(overridePath, yamlBytes, 0o644); err != nil {
 		return "", fmt.Errorf("writing compose override: %w", err)
 	}
 
 	return overridePath, nil
 }
 
-// writeFeatureOverrides writes feature capabilities (privileged, init, cap_add,
-// security_opt) to the compose override YAML and returns collected feature env
-// and mounts with variable substitution applied.
-func writeFeatureOverrides(b *strings.Builder, metadata []*config.ImageMetadata, subCtx *config.SubstitutionContext) (env map[string]string, mounts []config.Mount) {
-	sub := func(s string) string { return config.SubstituteString(subCtx, s) }
-
-	for _, m := range metadata {
-		if m.Privileged != nil && *m.Privileged {
-			b.WriteString("    privileged: true\n")
-			break
-		}
+// toComposeVolume converts a crib config.Mount to a compose ServiceVolumeConfig.
+func toComposeVolume(m config.Mount) composetypes.ServiceVolumeConfig {
+	typ := m.Type
+	if typ == "" {
+		typ = "bind"
 	}
-	for _, m := range metadata {
-		if m.Init != nil && *m.Init {
-			b.WriteString("    init: true\n")
-			break
-		}
+	return composetypes.ServiceVolumeConfig{
+		Type: typ, Source: m.Source, Target: m.Target,
 	}
-	var capAdds, secOpts []string
-	for _, m := range metadata {
-		capAdds = append(capAdds, m.CapAdd...)
-		secOpts = append(secOpts, m.SecurityOpt...)
-	}
-	if len(capAdds) > 0 {
-		b.WriteString("    cap_add:\n")
-		for _, c := range capAdds {
-			fmt.Fprintf(b, "      - %s\n", c)
-		}
-	}
-	if len(secOpts) > 0 {
-		b.WriteString("    security_opt:\n")
-		for _, s := range secOpts {
-			fmt.Fprintf(b, "      - %s\n", s)
-		}
-	}
-
-	env = make(map[string]string)
-	for _, m := range metadata {
-		for k, v := range m.ContainerEnv {
-			env[k] = sub(v)
-		}
-	}
-
-	for _, m := range metadata {
-		for _, mount := range m.Mounts {
-			mount.Source = sub(mount.Source)
-			mount.Target = sub(mount.Target)
-			mounts = append(mounts, mount)
-		}
-	}
-	return env, mounts
 }
 
 // composeDown wraps compose.Down, including a temporary x-podman override when

--- a/internal/engine/compose.go
+++ b/internal/engine/compose.go
@@ -140,8 +140,14 @@ type featureOverrides struct {
 
 // collectFeatureOverrides gathers feature-declared capabilities, env, and
 // mounts from image metadata, applying variable substitution to values.
+// If subCtx is nil, no substitution is performed.
 func collectFeatureOverrides(metadata []*config.ImageMetadata, subCtx *config.SubstitutionContext) featureOverrides {
-	sub := func(s string) string { return config.SubstituteString(subCtx, s) }
+	sub := func(s string) string {
+		if subCtx == nil {
+			return s
+		}
+		return config.SubstituteString(subCtx, s)
+	}
 
 	ov := featureOverrides{Env: make(map[string]string)}
 	for _, m := range metadata {
@@ -230,7 +236,8 @@ func (e *Engine) generateComposeOverride(ws *workspace.Workspace, cfg *config.De
 	// don't produce duplicate mount destinations in the override. Compose
 	// deduplicates short-form volumes by target during merge, but not
 	// when the override uses long-form (compose-go's output format).
-	existingTargets := e.existingVolumeTargets(composeFiles, serviceName)
+	composeEnv := devcontainerEnv(ws.ID, ws.Source, workspaceFolder)
+	existingTargets := e.existingVolumeTargets(composeFiles, serviceName, composeEnv)
 	svc.Volumes = buildOverrideVolumes(ws, cfg, workspaceFolder, featOv, pluginResp, existingTargets)
 
 	// Auto-inject userns_mode for rootless Podman.
@@ -337,11 +344,11 @@ func collectNamedVolumes(vols []composetypes.ServiceVolumeConfig) composetypes.V
 // volume target paths already defined for the given service. Returns nil on
 // any error (best-effort; the override will include all mounts and compose
 // may report a duplicate if one exists).
-func (e *Engine) existingVolumeTargets(composeFiles []string, service string) map[string]bool {
+func (e *Engine) existingVolumeTargets(composeFiles []string, service string, extraEnv []string) map[string]bool {
 	if len(composeFiles) == 0 {
 		return nil
 	}
-	project, err := composehelper.LoadProject(context.Background(), composeFiles, nil, nil)
+	project, err := composehelper.LoadProject(context.Background(), composeFiles, nil, extraEnv)
 	if err != nil {
 		e.logger.Debug("failed to load compose files for volume dedup", "error", err)
 		return nil

--- a/internal/engine/compose.go
+++ b/internal/engine/compose.go
@@ -341,7 +341,7 @@ func (e *Engine) existingVolumeTargets(composeFiles []string, service string) ma
 	if len(composeFiles) == 0 {
 		return nil
 	}
-	project, err := composehelper.LoadProject(context.Background(), composeFiles, nil)
+	project, err := composehelper.LoadProject(context.Background(), composeFiles, nil, nil)
 	if err != nil {
 		e.logger.Debug("failed to load compose files for volume dedup", "error", err)
 		return nil
@@ -389,12 +389,21 @@ func (e *Engine) writePodmanDownOverride(composeFiles []string) (string, bool) {
 	if !e.isRootlessPodman() || composeFilesContainUserns(composeFiles) {
 		return "", false
 	}
+	project := &composetypes.Project{
+		Extensions: composetypes.Extensions{
+			"x-podman": map[string]any{"in_pod": false},
+		},
+	}
+	yamlBytes, err := project.MarshalYAML()
+	if err != nil {
+		return "", false
+	}
 	f, err := os.CreateTemp("", "crib-podman-down-override-*.yml")
 	if err != nil {
 		return "", false
 	}
 	path := f.Name()
-	if _, err := f.WriteString("x-podman:\n  in_pod: false\n"); err != nil {
+	if _, err := f.Write(yamlBytes); err != nil {
 		_ = f.Close()
 		_ = os.Remove(path)
 		return "", false

--- a/internal/engine/compose_integration_test.go
+++ b/internal/engine/compose_integration_test.go
@@ -76,6 +76,7 @@ func writeComposeDevcontainer(t *testing.T, projectDir, wsID string) *workspace.
 // cleanupCompose tears down containers/networks and removes labeled images.
 func cleanupCompose(t *testing.T, e *Engine, d *oci.OCIDriver, ws *workspace.Workspace) {
 	t.Helper()
+	requireTestWorkspace(t, ws.ID)
 	ctx := context.Background()
 	_ = e.Down(ctx, ws)
 	cleanupWorkspaceImages(t, d, ws.ID)

--- a/internal/engine/compose_test.go
+++ b/internal/engine/compose_test.go
@@ -736,6 +736,116 @@ func TestCollectFeatureOverrides_ExcludesFeatureContainerEnv(t *testing.T) {
 	}
 }
 
+// Regression: podman-compose does not deduplicate volumes when the user's
+// compose file uses short-form (source:target) and the override uses
+// long-form (type/source/target from compose-go). generateComposeOverride
+// must skip volumes whose target already exists in the user's compose files.
+func TestGenerateComposeOverride_DeduplicatesPluginMountAgainstUserVolumes(t *testing.T) {
+	projectDir := t.TempDir()
+	devDir := filepath.Join(projectDir, ".devcontainer")
+	if err := os.MkdirAll(devDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// User's compose file already mounts to /home/vscode/.claude.
+	composeContent := `services:
+  app:
+    image: alpine:3.20
+    volumes:
+      - ../../data/claude:/home/vscode/.claude
+      - ../../data/ssh:/home/vscode/.ssh
+`
+	composeFile := filepath.Join(devDir, "compose.yml")
+	if err := os.WriteFile(composeFile, []byte(composeContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ws := &workspace.Workspace{ID: "test-ws", Source: projectDir}
+	e := newComposeTestEngine(t, "docker", ws)
+	e.logger = slog.Default()
+
+	cfg := &config.DevContainerConfig{}
+	cfg.Service = "app"
+
+	// Plugin wants to mount to the same target (/home/vscode/.claude) and
+	// a non-conflicting target (/home/vscode/.crib_history).
+	pluginResp := &plugin.PreContainerRunResponse{
+		Mounts: []config.Mount{
+			{Type: "bind", Source: "/crib/state/claude", Target: "/home/vscode/.claude"},
+			{Type: "bind", Source: "/crib/state/history", Target: "/home/vscode/.crib_history"},
+		},
+	}
+
+	path, err := e.generateComposeOverride(ws, cfg, "/workspaces/project", []string{composeFile}, "", pluginResp)
+	if err != nil {
+		t.Fatalf("generateComposeOverride: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading override: %v", err)
+	}
+	content := string(data)
+
+	// The conflicting mount (/home/vscode/.claude) must be skipped.
+	if strings.Contains(content, "/crib/state/claude") {
+		t.Errorf("override should not contain plugin mount for /home/vscode/.claude (already in user compose):\n%s", content)
+	}
+
+	// The non-conflicting mount must still be present.
+	if !strings.Contains(content, "/crib/state/history") || !strings.Contains(content, "/home/vscode/.crib_history") {
+		t.Errorf("override should contain non-conflicting plugin mount:\n%s", content)
+	}
+}
+
+// Verify that the default workspace mount is skipped when the user's compose
+// file already provides a volume for the workspace folder.
+func TestGenerateComposeOverride_DeduplicatesWorkspaceMount(t *testing.T) {
+	projectDir := t.TempDir()
+	devDir := filepath.Join(projectDir, ".devcontainer")
+	if err := os.MkdirAll(devDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// User's compose file already mounts the workspace folder.
+	composeContent := `services:
+  app:
+    image: alpine:3.20
+    volumes:
+      - ../..:/workspaces:cached
+`
+	composeFile := filepath.Join(devDir, "compose.yml")
+	if err := os.WriteFile(composeFile, []byte(composeContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ws := &workspace.Workspace{ID: "test-ws", Source: projectDir}
+	e := newComposeTestEngine(t, "docker", ws)
+	e.logger = slog.Default()
+
+	cfg := &config.DevContainerConfig{}
+	cfg.Service = "app"
+	// WorkspaceMount is empty, so crib would normally add a default mount
+	// to /workspaces. The user's compose file already provides it.
+
+	path, err := e.generateComposeOverride(ws, cfg, "/workspaces", []string{composeFile}, "", nil)
+	if err != nil {
+		t.Fatalf("generateComposeOverride: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading override: %v", err)
+	}
+	content := string(data)
+
+	// The override should not add a workspace mount since the user's
+	// compose file already has one for /workspaces.
+	if strings.Contains(content, "target: /workspaces") {
+		t.Errorf("override should not duplicate workspace mount:\n%s", content)
+	}
+}
+
 func TestWritePodmanDownOverride_RootlessPodman(t *testing.T) {
 	origGetuid := getuid
 	t.Cleanup(func() { getuid = origGetuid })

--- a/internal/engine/compose_test.go
+++ b/internal/engine/compose_test.go
@@ -51,10 +51,10 @@ func TestGenerateComposeOverride_RootlessPodmanInjectsUserns(t *testing.T) {
 		t.Fatalf("reading override: %v", err)
 	}
 
-	if !strings.Contains(string(data), `userns_mode: "keep-id"`) {
-		t.Errorf("expected userns_mode: \"keep-id\" in override, got:\n%s", data)
+	if !strings.Contains(string(data), "userns_mode: keep-id") {
+		t.Errorf("expected userns_mode in override, got:\n%s", data)
 	}
-	if !strings.Contains(string(data), "x-podman:\n  in_pod: false") {
+	if !strings.Contains(string(data), "x-podman:") || !strings.Contains(string(data), "in_pod: false") {
 		t.Errorf("expected x-podman in_pod: false in override, got:\n%s", data)
 	}
 }
@@ -223,15 +223,15 @@ func TestGenerateComposeOverride_PluginMounts(t *testing.T) {
 	}
 	content := string(data)
 
-	// Workspace mount should still be present.
-	if !strings.Contains(content, "/tmp/project:/workspaces/project") {
+	// Workspace mount should still be present (long form).
+	if !strings.Contains(content, "source: /tmp/project") || !strings.Contains(content, "target: /workspaces/project") {
 		t.Errorf("expected workspace mount, got:\n%s", content)
 	}
 	// Plugin mounts should be present.
-	if !strings.Contains(content, "/host/history:/home/vscode/.crib_history") {
+	if !strings.Contains(content, "source: /host/history") || !strings.Contains(content, "target: /home/vscode/.crib_history") {
 		t.Errorf("expected plugin history mount, got:\n%s", content)
 	}
-	if !strings.Contains(content, "/host/ssh:/tmp/ssh-agent.sock") {
+	if !strings.Contains(content, "source: /host/ssh") || !strings.Contains(content, "target: /tmp/ssh-agent.sock") {
 		t.Errorf("expected plugin ssh mount, got:\n%s", content)
 	}
 }
@@ -586,8 +586,8 @@ func TestGenerateComposeOverride_NoFeatureEntrypointSetsEntrypoint(t *testing.T)
 	content := string(data)
 
 	// Without feature entrypoints: should set entrypoint and command.
-	if !strings.Contains(content, "entrypoint: /bin/sh") {
-		t.Errorf("expected entrypoint: /bin/sh, got:\n%s", content)
+	if !strings.Contains(content, "entrypoint:") || !strings.Contains(content, "/bin/sh") {
+		t.Errorf("expected entrypoint with /bin/sh, got:\n%s", content)
 	}
 }
 
@@ -620,12 +620,12 @@ func TestGenerateComposeOverride_FeatureMounts(t *testing.T) {
 	content := string(data)
 
 	// Variable substitution should resolve ${devcontainerId}.
-	if !strings.Contains(content, "dind-var-lib-docker-test-ws:/var/lib/docker") {
+	if !strings.Contains(content, "source: dind-var-lib-docker-test-ws") || !strings.Contains(content, "target: /var/lib/docker") {
 		t.Errorf("expected substituted feature mount, got:\n%s", content)
 	}
 
 	// Named volume should get a top-level declaration.
-	if !strings.Contains(content, "  dind-var-lib-docker-test-ws:\n    name: dind-var-lib-docker-test-ws") {
+	if !strings.Contains(content, "dind-var-lib-docker-test-ws:") || !strings.Contains(content, "name: dind-var-lib-docker-test-ws") {
 		t.Errorf("expected top-level named volume declaration, got:\n%s", content)
 	}
 }
@@ -663,7 +663,7 @@ func TestGenerateComposeOverride_FeatureEnv(t *testing.T) {
 		t.Errorf("expected DOCKER_HOST in environment, got:\n%s", content)
 	}
 	// Variable substitution should resolve ${devcontainerId} in env values.
-	if !strings.Contains(content, `"test-ws"`) {
+	if !strings.Contains(content, "WS_ID: test-ws") {
 		t.Errorf("expected substituted WS_ID value, got:\n%s", content)
 	}
 }
@@ -712,9 +712,9 @@ func TestGenerateComposeOverride_FeatureEnvMergedWithConfigAndPlugin(t *testing.
 
 // Regression: feature containerEnv (e.g. PATH=/nvm/bin:${PATH}) is baked into
 // the image via Dockerfile ENV. featureToMetadata must exclude it so
-// writeFeatureOverrides doesn't write it into the compose environment section,
+// collectFeatureOverrides doesn't include it in the compose environment section,
 // which would override the image's correctly-expanded values.
-func TestWriteFeatureOverrides_ExcludesFeatureContainerEnv(t *testing.T) {
+func TestCollectFeatureOverrides_ExcludesFeatureContainerEnv(t *testing.T) {
 	f := &feature.FeatureSet{
 		Config: &feature.FeatureConfig{
 			ID: "node",
@@ -726,16 +726,13 @@ func TestWriteFeatureOverrides_ExcludesFeatureContainerEnv(t *testing.T) {
 	}
 
 	metadata := []*config.ImageMetadata{featureToMetadata(f)}
+	ov := collectFeatureOverrides(metadata, nil)
 
-	var b strings.Builder
-	env, _ := writeFeatureOverrides(&b, metadata, nil)
-
-	if len(env) != 0 {
-		t.Errorf("feature containerEnv should not appear in compose env, got %v", env)
+	if len(ov.Env) != 0 {
+		t.Errorf("feature containerEnv should not appear in compose env, got %v", ov.Env)
 	}
-	// Other metadata (capAdd) should still be written.
-	if !strings.Contains(b.String(), "SYS_PTRACE") {
-		t.Errorf("expected SYS_PTRACE in compose override, got:\n%s", b.String())
+	if len(ov.CapAdd) != 1 || ov.CapAdd[0] != "SYS_PTRACE" {
+		t.Errorf("expected SYS_PTRACE in CapAdd, got %v", ov.CapAdd)
 	}
 }
 

--- a/internal/engine/doctor.go
+++ b/internal/engine/doctor.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	ocidriver "github.com/fgrehm/crib/internal/driver/oci"
 )
 
 // DoctorIssue describes a single problem found by Doctor.
@@ -87,9 +89,17 @@ func (e *Engine) Doctor(ctx context.Context, fix bool) (*DoctorResult, error) {
 		if err != nil {
 			e.logger.Warn("failed to list containers for doctor check", "error", err)
 		} else {
+			storeDir := e.store.BaseDir()
 			for _, c := range containers {
 				wsID := c.Config.Labels["crib.workspace"]
 				if wsID == "" {
+					continue
+				}
+				// Skip containers that belong to a different CRIB_HOME.
+				// Without this check, running doctor --fix with an isolated
+				// store (e.g. tests using CRIB_HOME=tmpdir) would delete
+				// containers from the user's real store.
+				if home := c.Config.Labels[ocidriver.LabelHome]; home != "" && home != storeDir {
 					continue
 				}
 				if !e.store.Exists(wsID) {

--- a/internal/engine/doctor_test.go
+++ b/internal/engine/doctor_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/fgrehm/crib/internal/config"
 	"github.com/fgrehm/crib/internal/driver"
+	ocidriver "github.com/fgrehm/crib/internal/driver/oci"
 	"github.com/fgrehm/crib/internal/workspace"
 )
 
@@ -307,6 +308,161 @@ func TestDoctor_StalePluginData_Fix(t *testing.T) {
 	parentPluginDir := filepath.Join(storeDir, "ws-stale-fix", "plugins")
 	if _, err := os.Stat(parentPluginDir); !os.IsNotExist(err) {
 		t.Error("stale plugin directory should be removed with --fix")
+	}
+}
+
+func TestDoctor_DanglingContainer_SkippedWhenDifferentCribHome(t *testing.T) {
+	store := workspace.NewStoreAt(t.TempDir())
+
+	mockDrv := &doctorMockDriver{
+		containers: []driver.ContainerDetails{
+			{
+				ID: "container-other-store",
+				Config: driver.ContainerConfig{
+					Labels: map[string]string{
+						"crib.workspace":    "some-workspace",
+						ocidriver.LabelHome: "/some/other/store",
+					},
+				},
+			},
+		},
+	}
+
+	eng := &Engine{
+		driver: mockDrv,
+		store:  store,
+		logger: slog.Default(),
+		stdout: io.Discard,
+		stderr: io.Discard,
+	}
+
+	result, err := eng.Doctor(context.Background(), false)
+	if err != nil {
+		t.Fatalf("Doctor: %v", err)
+	}
+
+	for _, issue := range result.Issues {
+		if issue.Check == "dangling-container" {
+			t.Errorf("should skip container from different crib.home, got issue: %s", issue.Description)
+		}
+	}
+}
+
+func TestDoctor_DanglingContainer_FlaggedWhenSameCribHome(t *testing.T) {
+	store := workspace.NewStoreAt(t.TempDir())
+
+	mockDrv := &doctorMockDriver{
+		containers: []driver.ContainerDetails{
+			{
+				ID: "container-same-store",
+				Config: driver.ContainerConfig{
+					Labels: map[string]string{
+						"crib.workspace":    "nonexistent-ws",
+						ocidriver.LabelHome: store.BaseDir(),
+					},
+				},
+			},
+		},
+	}
+
+	eng := &Engine{
+		driver: mockDrv,
+		store:  store,
+		logger: slog.Default(),
+		stdout: io.Discard,
+		stderr: io.Discard,
+	}
+
+	result, err := eng.Doctor(context.Background(), false)
+	if err != nil {
+		t.Fatalf("Doctor: %v", err)
+	}
+
+	found := false
+	for _, issue := range result.Issues {
+		if issue.Check == "dangling-container" && issue.WorkspaceID == "nonexistent-ws" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected dangling-container issue for container matching crib.home")
+	}
+}
+
+func TestDoctor_DanglingContainer_FlaggedWhenNoHomeLabel(t *testing.T) {
+	store := workspace.NewStoreAt(t.TempDir())
+
+	// Pre-v0.8.0 containers have no crib.home label. They should still be
+	// flagged as dangling (the guard only skips when home is present AND different).
+	mockDrv := &doctorMockDriver{
+		containers: []driver.ContainerDetails{
+			{
+				ID: "container-legacy",
+				Config: driver.ContainerConfig{
+					Labels: map[string]string{
+						"crib.workspace": "orphan-ws",
+					},
+				},
+			},
+		},
+	}
+
+	eng := &Engine{
+		driver: mockDrv,
+		store:  store,
+		logger: slog.Default(),
+		stdout: io.Discard,
+		stderr: io.Discard,
+	}
+
+	result, err := eng.Doctor(context.Background(), false)
+	if err != nil {
+		t.Fatalf("Doctor: %v", err)
+	}
+
+	found := false
+	for _, issue := range result.Issues {
+		if issue.Check == "dangling-container" && issue.WorkspaceID == "orphan-ws" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected dangling-container for container without crib.home label")
+	}
+}
+
+func TestDoctor_Fix_SkipsContainerFromDifferentStore(t *testing.T) {
+	store := workspace.NewStoreAt(t.TempDir())
+
+	mockDrv := &doctorMockDriver{
+		containers: []driver.ContainerDetails{
+			{
+				ID: "container-protected",
+				Config: driver.ContainerConfig{
+					Labels: map[string]string{
+						"crib.workspace":    "other-ws",
+						ocidriver.LabelHome: "/different/store",
+					},
+				},
+			},
+		},
+	}
+
+	eng := &Engine{
+		driver: mockDrv,
+		store:  store,
+		logger: slog.Default(),
+		stdout: io.Discard,
+		stderr: io.Discard,
+	}
+
+	_, err := eng.Doctor(context.Background(), true)
+	if err != nil {
+		t.Fatalf("Doctor --fix: %v", err)
+	}
+
+	if len(mockDrv.deleted) != 0 {
+		t.Errorf("should not delete container from different store, deleted: %v", mockDrv.deleted)
 	}
 }
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -60,7 +60,7 @@ type Engine struct {
 	stdout           io.Writer
 	stderr           io.Writer
 	verbose          bool
-	progress         func(string)
+	progress         func(ProgressEvent)
 }
 
 // New creates an Engine with the given dependencies.
@@ -108,11 +108,22 @@ func (e *Engine) composeStderr() io.Writer {
 	return io.Discard
 }
 
-// SetProgress sets a callback for user-facing progress messages.
-func (e *Engine) SetProgress(fn func(string)) {
+// SetProgress sets a callback for user-facing progress events.
+func (e *Engine) SetProgress(fn func(ProgressEvent)) {
 	e.progress = fn
 	if e.plugins != nil {
-		e.plugins.SetProgress(fn)
+		e.plugins.SetProgress(progressToString(fn))
+	}
+}
+
+// progressToString adapts a ProgressEvent callback to a plain string callback
+// for use by the plugin manager (which lives in a separate package).
+func progressToString(fn func(ProgressEvent)) func(string) {
+	if fn == nil {
+		return nil
+	}
+	return func(msg string) {
+		fn(ProgressEvent{Phase: PhasePlugins, Message: msg})
 	}
 }
 
@@ -120,7 +131,7 @@ func (e *Engine) SetProgress(fn func(string)) {
 func (e *Engine) SetPlugins(m *plugin.Manager) {
 	e.plugins = m
 	if e.progress != nil {
-		m.SetProgress(e.progress)
+		m.SetProgress(progressToString(e.progress))
 	}
 }
 
@@ -135,11 +146,11 @@ func (e *Engine) SetBuildCacheMounts(mounts []string) {
 	e.buildCacheMounts = mounts
 }
 
-// reportProgress sends a message to the progress callback (if set)
-// and logs it at debug level.
-func (e *Engine) reportProgress(msg string) {
+// reportProgress sends a progress event to the callback (if set)
+// and logs the message at debug level.
+func (e *Engine) reportProgress(phase ProgressPhase, msg string) {
 	if e.progress != nil {
-		e.progress(msg)
+		e.progress(ProgressEvent{Phase: phase, Message: msg})
 	}
 	e.logger.Debug(msg)
 }
@@ -186,7 +197,7 @@ func (e *Engine) Up(ctx context.Context, ws *workspace.Workspace, opts UpOptions
 		return nil, fmt.Errorf("initializeCommand: %w", err)
 	}
 	if cfg.WaitFor == "initializeCommand" {
-		e.reportProgress("Container ready.")
+		e.reportProgress(PhaseInit, "Container ready.")
 	}
 
 	// Compose guards.
@@ -213,7 +224,7 @@ func (e *Engine) Up(ctx context.Context, ws *workspace.Workspace, opts UpOptions
 
 	// Remove existing container if recreating.
 	if container != nil && opts.Recreate {
-		e.reportProgress("Removing container...")
+		e.reportProgress(PhaseCreate, "Removing container...")
 		if err := e.store.ClearHookMarkers(ws.ID); err != nil {
 			e.logger.Warn("failed to clear hook markers", "error", err)
 		}
@@ -250,14 +261,14 @@ func (e *Engine) upExisting(ctx context.Context, ws *workspace.Workspace, cfg *c
 	}
 
 	if !container.State.IsRunning() {
-		e.reportProgress("Starting container...")
+		e.reportProgress(PhaseCreate, "Starting container...")
 		newID, err := b.start(ctx, container.ID, pluginResp)
 		if err != nil {
 			return nil, err
 		}
 		cc.containerID = newID
 	} else {
-		e.reportProgress("Container already running")
+		e.reportProgress(PhaseCreate, "Container already running")
 	}
 
 	return e.finalize(ctx, ws, cfg, finalizeOpts{

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -130,6 +130,7 @@ func (e *Engine) SetProgress(fn func(ProgressEvent)) {
 
 // progressToString adapts a ProgressEvent callback to a plain string callback
 // for use by the plugin manager (which lives in a separate package).
+// TODO: remove once plugin package migrates to ProgressEvent.
 func progressToString(fn func(ProgressEvent)) func(string) {
 	if fn == nil {
 		return nil

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -106,6 +107,17 @@ func (e *Engine) composeStderr() io.Writer {
 		return e.stderr
 	}
 	return io.Discard
+}
+
+// composeStderrTee returns a writer that always captures compose stderr into
+// buf, and also forwards to the engine's stderr in verbose mode. Use this
+// when the caller needs the output for error diagnostics even in non-verbose
+// mode (e.g., "container not found after up").
+func (e *Engine) composeStderrTee(buf *bytes.Buffer) io.Writer {
+	if e.verbose {
+		return io.MultiWriter(buf, e.stderr)
+	}
+	return buf
 }
 
 // SetProgress sets a callback for user-facing progress events.

--- a/internal/engine/finalize_test.go
+++ b/internal/engine/finalize_test.go
@@ -35,7 +35,7 @@ func TestFinalize_FreshSetup_RunsPluginCopiesAndChown(t *testing.T) {
 		logger:   slog.Default(),
 		stdout:   io.Discard,
 		stderr:   io.Discard,
-		progress: func(string) {},
+		progress: func(ProgressEvent) {},
 	}
 
 	cfg := &config.DevContainerConfig{}
@@ -108,7 +108,7 @@ func TestFinalize_FreshSetup_CallsSetupContainerAndCommitsSnapshot(t *testing.T)
 		logger:   slog.Default(),
 		stdout:   io.Discard,
 		stderr:   io.Discard,
-		progress: func(string) {},
+		progress: func(ProgressEvent) {},
 	}
 
 	cfg := &config.DevContainerConfig{}
@@ -161,7 +161,7 @@ func TestFinalize_FromSnapshot_RestoresStoredEnvAndRunsResumeHooks(t *testing.T)
 		logger:   slog.Default(),
 		stdout:   io.Discard,
 		stderr:   io.Discard,
-		progress: func(string) {},
+		progress: func(ProgressEvent) {},
 	}
 
 	cfg := &config.DevContainerConfig{}
@@ -255,7 +255,7 @@ func TestFinalize_FromSnapshot_SkipsSetupContainerAndSnapshot(t *testing.T) {
 		logger:   slog.Default(),
 		stdout:   io.Discard,
 		stderr:   io.Discard,
-		progress: func(string) {},
+		progress: func(ProgressEvent) {},
 	}
 
 	cfg := &config.DevContainerConfig{}
@@ -303,7 +303,7 @@ func TestFinalize_SkipVolumeChown(t *testing.T) {
 		logger:   slog.Default(),
 		stdout:   io.Discard,
 		stderr:   io.Discard,
-		progress: func(string) {},
+		progress: func(ProgressEvent) {},
 	}
 
 	cfg := &config.DevContainerConfig{}
@@ -361,7 +361,7 @@ func TestFinalize_EarlySave_BeforeLifecycleHooks(t *testing.T) {
 		logger:   slog.Default(),
 		stdout:   io.Discard,
 		stderr:   io.Discard,
-		progress: func(string) {},
+		progress: func(ProgressEvent) {},
 	}
 
 	cfg := &config.DevContainerConfig{}
@@ -418,7 +418,7 @@ func TestFinalize_PreservesPathPrepend_FreshSetup(t *testing.T) {
 		logger:   slog.Default(),
 		stdout:   io.Discard,
 		stderr:   io.Discard,
-		progress: func(string) {},
+		progress: func(ProgressEvent) {},
 	}
 
 	cfg := &config.DevContainerConfig{}
@@ -475,7 +475,7 @@ func TestFinalize_PreservesPathPrepend_FromSnapshot(t *testing.T) {
 		logger:   slog.Default(),
 		stdout:   io.Discard,
 		stderr:   io.Discard,
-		progress: func(string) {},
+		progress: func(ProgressEvent) {},
 	}
 
 	cfg := &config.DevContainerConfig{}
@@ -541,7 +541,7 @@ func TestFinalize_RemoteUserSkippedWhenPreset(t *testing.T) {
 		logger:   slog.Default(),
 		stdout:   io.Discard,
 		stderr:   io.Discard,
-		progress: func(string) {},
+		progress: func(ProgressEvent) {},
 	}
 
 	cfg := &config.DevContainerConfig{}

--- a/internal/engine/initialize.go
+++ b/internal/engine/initialize.go
@@ -3,7 +3,6 @@ package engine
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"os/exec"
 
 	"github.com/fgrehm/crib/internal/config"
@@ -19,7 +18,7 @@ func (e *Engine) runInitializeCommand(ctx context.Context, ws *workspace.Workspa
 		return nil
 	}
 
-	e.reportProgress("Running initializeCommand...")
+	e.reportProgress(PhaseInit, "Running initializeCommand...")
 
 	return dispatchHook(ctx, cfg.InitializeCommand, func(ctx context.Context, hookName string, cmdParts []string) error {
 		return e.execInitCmd(ctx, ws, "initializeCommand", hookName, cmdParts)
@@ -50,7 +49,7 @@ func (e *Engine) execInitCmd(ctx context.Context, ws *workspace.Workspace, hookS
 	cmd.Stdout = e.stdout
 	cmd.Stderr = e.stderr
 
-	e.logger.Debug("executing host command", slog.String("hook", label), slog.String("cmd", cmd.String()))
+	e.logger.Debug("executing host command", "hook", label, "cmd", cmd.String())
 
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("lifecycle hook %q failed: %w", label, err)

--- a/internal/engine/integration_test.go
+++ b/internal/engine/integration_test.go
@@ -19,6 +19,47 @@ import (
 	"github.com/fgrehm/crib/internal/workspace"
 )
 
+const testWorkspacePrefix = "test-"
+
+// TestMain warns if non-test crib containers are running, which can lead to
+// interference (stale compose state, network conflicts, etc.).
+func TestMain(m *testing.M) {
+	// Check for active workspaces before running integration tests. We can't
+	// call testing.Short() before flag.Parse(), so check the flag directly.
+	short := false
+	for _, arg := range os.Args[1:] {
+		if arg == "-test.short" || arg == "-test.short=true" {
+			short = true
+			break
+		}
+	}
+	if !short {
+		d, err := oci.NewOCIDriver(slog.Default())
+		if err == nil {
+			containers, _ := d.ListContainers(context.Background())
+			for _, c := range containers {
+				wsID := c.Config.Labels[oci.LabelWorkspace]
+				if wsID != "" && !strings.HasPrefix(wsID, testWorkspacePrefix) {
+					fmt.Fprintf(os.Stderr, "\n⚠ WARNING: active crib workspace %q (container %s) detected.\n", wsID, c.ID[:12])
+					fmt.Fprintf(os.Stderr, "  Integration tests may interfere with running workspaces.\n")
+					fmt.Fprintf(os.Stderr, "  Consider running 'crib down' first.\n\n")
+					break
+				}
+			}
+		}
+	}
+	os.Exit(m.Run())
+}
+
+// requireTestWorkspace fatals if the workspace ID does not start with the test
+// prefix. Prevents test cleanup from accidentally removing real workspaces.
+func requireTestWorkspace(t *testing.T, wsID string) {
+	t.Helper()
+	if !strings.HasPrefix(wsID, testWorkspacePrefix) {
+		t.Fatalf("refusing to operate on non-test workspace %q (must start with %q)", wsID, testWorkspacePrefix)
+	}
+}
+
 func newTestEngine(t *testing.T) (*Engine, *oci.OCIDriver, *workspace.Store) {
 	t.Helper()
 	d, err := oci.NewOCIDriver(slog.Default())
@@ -36,6 +77,7 @@ func newTestEngine(t *testing.T) (*Engine, *oci.OCIDriver, *workspace.Store) {
 // test teardown. Prevents crib-test-* images from accumulating on disk.
 func cleanupWorkspaceImages(t *testing.T, d driver.Driver, wsID string) {
 	t.Helper()
+	requireTestWorkspace(t, wsID)
 	ctx := context.Background()
 	images, err := d.ListImages(ctx, oci.WorkspaceLabel(wsID))
 	if err != nil {

--- a/internal/engine/lifecycle.go
+++ b/internal/engine/lifecycle.go
@@ -25,7 +25,7 @@ type lifecycleRunner struct {
 	logger      *slog.Logger
 	stdout      io.Writer
 	stderr      io.Writer
-	progress    func(string)
+	progress    func(ProgressEvent)
 	verbose     bool
 }
 
@@ -142,10 +142,10 @@ func (r *lifecycleRunner) runLifecycleHooks(ctx context.Context, hooks *hookSet,
 	return nil
 }
 
-// signalReadyAt emits a "Container ready." progress message when stage matches waitFor.
+// signalReadyAt emits a "Container ready." progress event when stage matches waitFor.
 func (r *lifecycleRunner) signalReadyAt(stage, waitFor string) {
 	if stage == waitFor && r.progress != nil {
-		r.progress("Container ready.")
+		r.progress(ProgressEvent{Phase: PhaseHooks, Message: "Container ready.", Done: true})
 	}
 }
 
@@ -219,7 +219,7 @@ func (r *lifecycleRunner) runHook(ctx context.Context, name string, hook config.
 	}
 
 	if r.progress != nil {
-		r.progress("Running " + name + "...")
+		r.progress(ProgressEvent{Phase: PhaseHooks, Message: "Running " + name + "..."})
 	}
 	r.logger.Debug("running lifecycle hook", "hook", name)
 

--- a/internal/engine/lifecycle.go
+++ b/internal/engine/lifecycle.go
@@ -145,7 +145,7 @@ func (r *lifecycleRunner) runLifecycleHooks(ctx context.Context, hooks *hookSet,
 // signalReadyAt emits a "Container ready." progress event when stage matches waitFor.
 func (r *lifecycleRunner) signalReadyAt(stage, waitFor string) {
 	if stage == waitFor && r.progress != nil {
-		r.progress(ProgressEvent{Phase: PhaseHooks, Message: "Container ready.", Done: true})
+		r.progress(ProgressEvent{Phase: PhaseHooks, Message: "Container ready."})
 	}
 }
 

--- a/internal/engine/lifecycle_test.go
+++ b/internal/engine/lifecycle_test.go
@@ -212,7 +212,7 @@ func TestRunHook_ProgressCallback(t *testing.T) {
 	var messages []string
 	mock := &mockDriver{}
 	r, _, _ := newTestRunner(t, mock)
-	r.progress = func(msg string) { messages = append(messages, msg) }
+	r.progress = func(ev ProgressEvent) { messages = append(messages, ev.Message) }
 
 	hook := config.LifecycleHook{"": {"echo hi"}}
 	if err := r.runHook(context.Background(), "postStartCommand", hook, ""); err != nil {
@@ -228,7 +228,7 @@ func TestRunHook_NoProgressWhenEmpty(t *testing.T) {
 	var messages []string
 	mock := &mockDriver{}
 	r, _, _ := newTestRunner(t, mock)
-	r.progress = func(msg string) { messages = append(messages, msg) }
+	r.progress = func(ev ProgressEvent) { messages = append(messages, ev.Message) }
 
 	if err := r.runHook(context.Background(), "postStartCommand", config.LifecycleHook{}, ""); err != nil {
 		t.Fatalf("runHook: %v", err)
@@ -242,7 +242,7 @@ func TestRunHook_NoProgressWhenEmpty(t *testing.T) {
 
 func TestSignalReadyAt_Match(t *testing.T) {
 	var got []string
-	r := &lifecycleRunner{progress: func(msg string) { got = append(got, msg) }}
+	r := &lifecycleRunner{progress: func(ev ProgressEvent) { got = append(got, ev.Message) }}
 	r.signalReadyAt("updateContentCommand", "updateContentCommand")
 
 	if len(got) != 1 || got[0] != "Container ready." {
@@ -252,7 +252,7 @@ func TestSignalReadyAt_Match(t *testing.T) {
 
 func TestSignalReadyAt_NoMatch(t *testing.T) {
 	var got []string
-	r := &lifecycleRunner{progress: func(msg string) { got = append(got, msg) }}
+	r := &lifecycleRunner{progress: func(ev ProgressEvent) { got = append(got, ev.Message) }}
 	r.signalReadyAt("onCreateCommand", "updateContentCommand")
 
 	if len(got) != 0 {
@@ -268,9 +268,9 @@ func TestSignalReadyAt_NilProgress(t *testing.T) {
 
 // --- runLifecycleHooks waitFor tests ---
 
-// collectProgress returns a progress callback that appends to a slice.
-func collectProgress(msgs *[]string) func(string) {
-	return func(msg string) { *msgs = append(*msgs, msg) }
+// collectProgress returns a progress callback that appends messages to a slice.
+func collectProgress(msgs *[]string) func(ProgressEvent) {
+	return func(ev ProgressEvent) { *msgs = append(*msgs, ev.Message) }
 }
 
 // indexOfMsg returns the first index where pred matches, or -1.

--- a/internal/engine/progress.go
+++ b/internal/engine/progress.go
@@ -1,0 +1,21 @@
+package engine
+
+// ProgressPhase identifies a stage of the devcontainer lifecycle.
+type ProgressPhase string
+
+const (
+	PhaseInit     ProgressPhase = "init"
+	PhaseBuild    ProgressPhase = "build"
+	PhaseCreate   ProgressPhase = "create"
+	PhasePlugins  ProgressPhase = "plugins"
+	PhaseHooks    ProgressPhase = "hooks"
+	PhaseSnapshot ProgressPhase = "snapshot"
+	PhaseRestart  ProgressPhase = "restart"
+)
+
+// ProgressEvent carries a structured progress update from the engine.
+type ProgressEvent struct {
+	Phase   ProgressPhase
+	Message string
+	Done    bool // true when this event marks the end of its phase
+}

--- a/internal/engine/progress.go
+++ b/internal/engine/progress.go
@@ -4,18 +4,16 @@ package engine
 type ProgressPhase string
 
 const (
-	PhaseInit     ProgressPhase = "init"
-	PhaseBuild    ProgressPhase = "build"
-	PhaseCreate   ProgressPhase = "create"
-	PhasePlugins  ProgressPhase = "plugins"
-	PhaseHooks    ProgressPhase = "hooks"
-	PhaseSnapshot ProgressPhase = "snapshot"
-	PhaseRestart  ProgressPhase = "restart"
+	PhaseInit    ProgressPhase = "init"
+	PhaseBuild   ProgressPhase = "build"
+	PhaseCreate  ProgressPhase = "create"
+	PhasePlugins ProgressPhase = "plugins"
+	PhaseHooks   ProgressPhase = "hooks"
+	PhaseRestart ProgressPhase = "restart"
 )
 
 // ProgressEvent carries a structured progress update from the engine.
 type ProgressEvent struct {
 	Phase   ProgressPhase
 	Message string
-	Done    bool // true when this event marks the end of its phase
 }

--- a/internal/engine/progress_test.go
+++ b/internal/engine/progress_test.go
@@ -1,0 +1,194 @@
+package engine
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/fgrehm/crib/internal/plugin"
+	"github.com/fgrehm/crib/internal/workspace"
+)
+
+func TestSetProgress_ReportProgressCallsCallback(t *testing.T) {
+	store := workspace.NewStoreAt(t.TempDir())
+	eng := &Engine{
+		driver: &mockDriver{responses: map[string]string{}},
+		store:  store,
+		logger: slog.Default(),
+		stdout: io.Discard,
+		stderr: io.Discard,
+	}
+
+	var mu sync.Mutex
+	var events []ProgressEvent
+	eng.SetProgress(func(ev ProgressEvent) {
+		mu.Lock()
+		events = append(events, ev)
+		mu.Unlock()
+	})
+
+	eng.reportProgress(PhaseBuild, "Building image...")
+	eng.reportProgress(PhaseHooks, "Running onCreateCommand...")
+
+	if len(events) != 2 {
+		t.Fatalf("got %d events, want 2", len(events))
+	}
+	if events[0].Phase != PhaseBuild || events[0].Message != "Building image..." {
+		t.Errorf("event[0] = %+v, want PhaseBuild/Building image...", events[0])
+	}
+	if events[1].Phase != PhaseHooks || events[1].Message != "Running onCreateCommand..." {
+		t.Errorf("event[1] = %+v, want PhaseHooks/Running onCreateCommand...", events[1])
+	}
+}
+
+func TestReportProgress_NilCallback(t *testing.T) {
+	eng := &Engine{
+		driver: &mockDriver{responses: map[string]string{}},
+		store:  workspace.NewStoreAt(t.TempDir()),
+		logger: slog.Default(),
+		stdout: io.Discard,
+		stderr: io.Discard,
+	}
+	// No SetProgress call. reportProgress should not panic.
+	eng.reportProgress(PhaseBuild, "should not panic")
+}
+
+func TestProgressToString_WrapsInPhasePlugins(t *testing.T) {
+	var got ProgressEvent
+	adapter := progressToString(func(ev ProgressEvent) {
+		got = ev
+	})
+
+	adapter("Running plugin: ssh")
+
+	if got.Phase != PhasePlugins {
+		t.Errorf("phase = %q, want %q", got.Phase, PhasePlugins)
+	}
+	if got.Message != "Running plugin: ssh" {
+		t.Errorf("message = %q, want 'Running plugin: ssh'", got.Message)
+	}
+}
+
+func TestProgressToString_NilInput(t *testing.T) {
+	adapter := progressToString(nil)
+	if adapter != nil {
+		t.Error("progressToString(nil) should return nil")
+	}
+}
+
+func TestSetProgress_WiresPluginManager(t *testing.T) {
+	store := workspace.NewStoreAt(t.TempDir())
+	eng := &Engine{
+		driver: &mockDriver{responses: map[string]string{}},
+		store:  store,
+		logger: slog.Default(),
+		stdout: io.Discard,
+		stderr: io.Discard,
+	}
+
+	mgr := plugin.NewManager(slog.Default())
+	eng.SetPlugins(mgr)
+
+	var events []ProgressEvent
+	eng.SetProgress(func(ev ProgressEvent) {
+		events = append(events, ev)
+	})
+
+	// The manager's progress callback should now be wired.
+	// Trigger it via the engine's reportProgress (direct) and verify.
+	eng.reportProgress(PhaseBuild, "direct event")
+
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1", len(events))
+	}
+	if events[0].Phase != PhaseBuild {
+		t.Errorf("phase = %q, want PhaseBuild", events[0].Phase)
+	}
+}
+
+func TestSetPlugins_WiresExistingProgress(t *testing.T) {
+	store := workspace.NewStoreAt(t.TempDir())
+	eng := &Engine{
+		driver: &mockDriver{responses: map[string]string{}},
+		store:  store,
+		logger: slog.Default(),
+		stdout: io.Discard,
+		stderr: io.Discard,
+	}
+
+	var events []ProgressEvent
+	// Set progress FIRST, then plugins.
+	eng.SetProgress(func(ev ProgressEvent) {
+		events = append(events, ev)
+	})
+
+	mgr := plugin.NewManager(slog.Default())
+	eng.SetPlugins(mgr)
+
+	// Direct engine progress should still work.
+	eng.reportProgress(PhaseCreate, "Creating container...")
+
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1", len(events))
+	}
+}
+
+func TestComposeStderrTee_VerboseMode(t *testing.T) {
+	var stderr bytes.Buffer
+	eng := &Engine{
+		driver:  &mockDriver{responses: map[string]string{}},
+		store:   workspace.NewStoreAt(t.TempDir()),
+		logger:  slog.Default(),
+		stdout:  io.Discard,
+		stderr:  &stderr,
+		verbose: true,
+	}
+
+	var buf bytes.Buffer
+	w := eng.composeStderrTee(&buf)
+
+	msg := []byte("compose warning: something happened\n")
+	n, err := w.Write(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != len(msg) {
+		t.Errorf("wrote %d bytes, want %d", n, len(msg))
+	}
+
+	// In verbose mode, output goes to both the buffer and stderr.
+	if buf.String() != string(msg) {
+		t.Errorf("buffer = %q, want %q", buf.String(), string(msg))
+	}
+	if stderr.String() != string(msg) {
+		t.Errorf("stderr = %q, want %q", stderr.String(), string(msg))
+	}
+}
+
+func TestComposeStderrTee_NonVerboseMode(t *testing.T) {
+	var stderr bytes.Buffer
+	eng := &Engine{
+		driver:  &mockDriver{responses: map[string]string{}},
+		store:   workspace.NewStoreAt(t.TempDir()),
+		logger:  slog.Default(),
+		stdout:  io.Discard,
+		stderr:  &stderr,
+		verbose: false,
+	}
+
+	var buf bytes.Buffer
+	w := eng.composeStderrTee(&buf)
+
+	msg := []byte("compose error: container failed\n")
+	w.Write(msg)
+
+	// In non-verbose mode, output goes only to the buffer.
+	if buf.String() != string(msg) {
+		t.Errorf("buffer = %q, want %q", buf.String(), string(msg))
+	}
+	if stderr.String() != "" {
+		t.Errorf("stderr should be empty in non-verbose mode, got %q", stderr.String())
+	}
+}

--- a/internal/engine/restart.go
+++ b/internal/engine/restart.go
@@ -100,7 +100,7 @@ func (e *Engine) Restart(ctx context.Context, ws *workspace.Workspace) (*Restart
 		return nil, fmt.Errorf("config changes require a full rebuild (image, Dockerfile, or features changed); run 'crib rebuild' instead")
 
 	case changeSafe:
-		e.reportProgress("Config changes detected, recreating container...")
+		e.reportProgress(PhaseRestart, "Config changes detected, recreating container...")
 		result, err := e.restartRecreate(ctx, ws, cfg, workspaceFolder, b, storedResult)
 		if result != nil {
 			result.Recreated = true
@@ -109,7 +109,7 @@ func (e *Engine) Restart(ctx context.Context, ws *workspace.Workspace) (*Restart
 
 	default:
 		// No changes -- simple restart.
-		e.reportProgress("Restarting container...")
+		e.reportProgress(PhaseRestart, "Restarting container...")
 		return e.restartSimple(ctx, ws, cfg, workspaceFolder, b, storedResult)
 	}
 }
@@ -199,7 +199,7 @@ func (e *Engine) restartRecreate(ctx context.Context, ws *workspace.Workspace, c
 
 	// If no image available, rebuild.
 	if imageName == "" && len(cfg.DockerComposeFile) == 0 {
-		e.reportProgress("No cached image found, rebuilding...")
+		e.reportProgress(PhaseBuild, "No cached image found, rebuilding...")
 	}
 	if imageName == "" {
 		buildRes, err := b.buildImage(ctx)

--- a/internal/engine/restart_test.go
+++ b/internal/engine/restart_test.go
@@ -345,7 +345,7 @@ func TestRestartRecreateSingle_RunsPlugins(t *testing.T) {
 		logger:      slog.Default(),
 		stdout:      io.Discard,
 		stderr:      io.Discard,
-		progress:    func(string) {},
+		progress:    func(ProgressEvent) {},
 	}
 
 	cfg := &config.DevContainerConfig{}
@@ -429,7 +429,7 @@ func TestRestartRecreateSingle_NoPlugins(t *testing.T) {
 		logger:   slog.Default(),
 		stdout:   io.Discard,
 		stderr:   io.Discard,
-		progress: func(string) {},
+		progress: func(ProgressEvent) {},
 	}
 
 	cfg := &config.DevContainerConfig{}
@@ -473,7 +473,7 @@ func TestRunResumeHooks_PropagatesVerbose(t *testing.T) {
 		logger:   slog.Default(),
 		stdout:   io.Discard,
 		stderr:   io.Discard,
-		progress: func(string) {},
+		progress: func(ProgressEvent) {},
 		verbose:  true,
 	}
 
@@ -541,7 +541,7 @@ func TestRestartSimple_NonCompose_UsesStoredRemoteUser(t *testing.T) {
 		logger:      slog.Default(),
 		stdout:      io.Discard,
 		stderr:      io.Discard,
-		progress:    func(string) {},
+		progress:    func(ProgressEvent) {},
 	}
 
 	// Config has no RemoteUser — the stored result's RemoteUser should be used.
@@ -592,7 +592,7 @@ func TestRestartSimple_NonCompose_PreservesImageName(t *testing.T) {
 		logger:      slog.Default(),
 		stdout:      io.Discard,
 		stderr:      io.Discard,
-		progress:    func(string) {},
+		progress:    func(ProgressEvent) {},
 	}
 
 	cfg := &config.DevContainerConfig{}
@@ -654,7 +654,7 @@ func TestRestartSimple_NonCompose_PreservesPathPrepend(t *testing.T) {
 		logger:      slog.Default(),
 		stdout:      io.Discard,
 		stderr:      io.Discard,
-		progress:    func(string) {},
+		progress:    func(ProgressEvent) {},
 	}
 
 	cfg := &config.DevContainerConfig{}
@@ -739,7 +739,7 @@ func TestRestartSimple_NonCompose_PreservesProbedEnv(t *testing.T) {
 		logger:      slog.Default(),
 		stdout:      io.Discard,
 		stderr:      io.Discard,
-		progress:    func(string) {},
+		progress:    func(ProgressEvent) {},
 	}
 
 	cfg := &config.DevContainerConfig{}
@@ -823,7 +823,7 @@ func TestRestartRecreateSingle_WithSnapshot_PreservesProbedEnv(t *testing.T) {
 		logger:      slog.Default(),
 		stdout:      io.Discard,
 		stderr:      io.Discard,
-		progress:    func(string) {},
+		progress:    func(ProgressEvent) {},
 	}
 
 	cfg := &config.DevContainerConfig{}
@@ -895,7 +895,7 @@ func TestRestartSimple_NonCompose_ConfigEnvOverridesStored(t *testing.T) {
 		logger:      slog.Default(),
 		stdout:      io.Discard,
 		stderr:      io.Discard,
-		progress:    func(string) {},
+		progress:    func(ProgressEvent) {},
 	}
 
 	cfg := &config.DevContainerConfig{}
@@ -979,7 +979,7 @@ func TestRestartSimple_NonCompose_PluginEnvMerged(t *testing.T) {
 		logger:      slog.Default(),
 		stdout:      io.Discard,
 		stderr:      io.Discard,
-		progress:    func(string) {},
+		progress:    func(ProgressEvent) {},
 	}
 
 	cfg := &config.DevContainerConfig{}
@@ -1064,7 +1064,7 @@ func TestRestartSimple_NonCompose_PluginEnvDoesNotOverrideConfig(t *testing.T) {
 		logger:      slog.Default(),
 		stdout:      io.Discard,
 		stderr:      io.Discard,
-		progress:    func(string) {},
+		progress:    func(ProgressEvent) {},
 	}
 
 	cfg := &config.DevContainerConfig{}
@@ -1117,7 +1117,7 @@ func TestRestartRecreateSingle_PreservesFeatureEntrypoints(t *testing.T) {
 		logger:      slog.Default(),
 		stdout:      io.Discard,
 		stderr:      io.Discard,
-		progress:    func(string) {},
+		progress:    func(ProgressEvent) {},
 	}
 
 	cfg := &config.DevContainerConfig{}
@@ -1187,7 +1187,7 @@ func TestRestartRecreateSingle_ResolvedConfigEnv(t *testing.T) {
 		logger:      slog.Default(),
 		stdout:      io.Discard,
 		stderr:      io.Discard,
-		progress:    func(string) {},
+		progress:    func(ProgressEvent) {},
 	}
 
 	cfg := &config.DevContainerConfig{}

--- a/internal/engine/single.go
+++ b/internal/engine/single.go
@@ -109,35 +109,22 @@ func (e *Engine) buildRunOptions(cfg *config.DevContainerConfig, imageName, proj
 }
 
 // applyFeatureMetadata merges feature-declared runtime capabilities into the
-// run options. These are capabilities like privileged, init, capAdd that
-// features declare in devcontainer-feature.json but can only be applied at
-// container creation time (not in the Dockerfile).
+// run options using collectFeatureOverrides for the metadata extraction.
 // subCtx is used to substitute variables (e.g. ${devcontainerId}) in mount
 // sources and containerEnv values. If nil, no substitution is performed.
 func applyFeatureMetadata(opts *driver.RunOptions, metadata []*config.ImageMetadata, subCtx *config.SubstitutionContext) {
-	sub := func(s string) string {
-		if subCtx == nil {
-			return s
-		}
-		return config.SubstituteString(subCtx, s)
+	ov := collectFeatureOverrides(metadata, subCtx)
+	if ov.Privileged {
+		opts.Privileged = true
 	}
-	for _, m := range metadata {
-		if m.Privileged != nil && *m.Privileged {
-			opts.Privileged = true
-		}
-		if m.Init != nil && *m.Init {
-			opts.Init = true
-		}
-		opts.CapAdd = append(opts.CapAdd, m.CapAdd...)
-		opts.SecurityOpt = append(opts.SecurityOpt, m.SecurityOpt...)
-		for _, mount := range m.Mounts {
-			mount.Source = sub(mount.Source)
-			mount.Target = sub(mount.Target)
-			opts.Mounts = append(opts.Mounts, mount)
-		}
-		for k, v := range m.ContainerEnv {
-			opts.Env = append(opts.Env, k+"="+sub(v))
-		}
+	if ov.Init {
+		opts.Init = true
+	}
+	opts.CapAdd = append(opts.CapAdd, ov.CapAdd...)
+	opts.SecurityOpt = append(opts.SecurityOpt, ov.SecurityOpt...)
+	opts.Mounts = append(opts.Mounts, ov.Mounts...)
+	for k, v := range ov.Env {
+		opts.Env = append(opts.Env, k+"="+v)
 	}
 }
 

--- a/internal/engine/single.go
+++ b/internal/engine/single.go
@@ -19,13 +19,16 @@ import (
 // defaultEntrypoint is used when overrideCommand is not explicitly false.
 const defaultEntrypoint = "/bin/sh"
 
+// sleepScript is the shell command that keeps the container alive.
+const sleepScript = `echo Container started; trap "exit 0" 15; exec "$@"; sleep infinity`
+
 // defaultCmd keeps the container alive when overrideCommand is not false.
 // These are arguments to defaultEntrypoint ("/bin/sh").
-var defaultCmd = []string{"-c", "echo Container started; trap \"exit 0\" 15; exec \"$@\"; sleep infinity"}
+var defaultCmd = []string{"-c", sleepScript}
 
 // featureCmd is used when features set an ENTRYPOINT in the image.
 // The feature entrypoint chains via exec "$@", so CMD must be a full command.
-var featureCmd = []string{"/bin/sh", "-c", "echo Container started; trap \"exit 0\" 15; exec \"$@\"; sleep infinity"}
+var featureCmd = []string{"/bin/sh", "-c", sleepScript}
 
 // buildRunOptions constructs RunOptions from the devcontainer config.
 // hasFeatureEntrypoints indicates the image has feature-declared entrypoints

--- a/internal/engine/single_test.go
+++ b/internal/engine/single_test.go
@@ -640,7 +640,7 @@ func TestUpExisting_PreservesPathPrepend(t *testing.T) {
 		logger:      slog.Default(),
 		stdout:      io.Discard,
 		stderr:      io.Discard,
-		progress:    func(string) {},
+		progress:    func(ProgressEvent) {},
 	}
 
 	cfg := &config.DevContainerConfig{}
@@ -701,7 +701,7 @@ func TestUpExisting_PassesRemoteUserToPlugins(t *testing.T) {
 		logger:      slog.Default(),
 		stdout:      io.Discard,
 		stderr:      io.Discard,
-		progress:    func(string) {},
+		progress:    func(ProgressEvent) {},
 	}
 
 	cfg := &config.DevContainerConfig{}
@@ -754,7 +754,7 @@ func TestUpExisting_FallsBackToContainerUser(t *testing.T) {
 		logger:      slog.Default(),
 		stdout:      io.Discard,
 		stderr:      io.Discard,
-		progress:    func(string) {},
+		progress:    func(ProgressEvent) {},
 	}
 
 	// No RemoteUser, only ContainerUser.

--- a/internal/engine/up_snapshot_test.go
+++ b/internal/engine/up_snapshot_test.go
@@ -154,7 +154,7 @@ func TestUpCreate_FromSnapshot_PreservesEnv(t *testing.T) {
 		logger:      slog.Default(),
 		stdout:      io.Discard,
 		stderr:      io.Discard,
-		progress:    func(string) {},
+		progress:    func(ProgressEvent) {},
 	}
 
 	cfg := &config.DevContainerConfig{}
@@ -239,7 +239,7 @@ func TestUpCreate_FromSnapshot_RunsResumeHooksOnly(t *testing.T) {
 		logger:      slog.Default(),
 		stdout:      io.Discard,
 		stderr:      io.Discard,
-		progress:    func(string) {},
+		progress:    func(ProgressEvent) {},
 	}
 
 	b := eng.newBackend(ws, cfg, "/workspaces/project")
@@ -327,7 +327,7 @@ func TestUpCreate_FromSnapshot_RecreateBypassesSnapshot(t *testing.T) {
 		logger:      slog.Default(),
 		stdout:      io.Discard,
 		stderr:      io.Discard,
-		progress:    func(string) {},
+		progress:    func(ProgressEvent) {},
 	}
 
 	// With Recreate=true, the snapshot should be bypassed. This will fail
@@ -390,7 +390,7 @@ func TestUpCreate_FromSnapshot_StaleSnapshotFallsThrough(t *testing.T) {
 		logger:      slog.Default(),
 		stdout:      io.Discard,
 		stderr:      io.Discard,
-		progress:    func(string) {},
+		progress:    func(ProgressEvent) {},
 	}
 
 	cfg := &config.DevContainerConfig{}
@@ -462,7 +462,7 @@ func TestUpCreate_FromSnapshot_PluginCopiesExecuted(t *testing.T) {
 		logger:      slog.Default(),
 		stdout:      io.Discard,
 		stderr:      io.Discard,
-		progress:    func(string) {},
+		progress:    func(ProgressEvent) {},
 	}
 
 	b := eng.newBackend(ws, cfg, "/workspaces/project")
@@ -519,7 +519,7 @@ func TestUpCreate_FromSnapshot_PreservesImageName(t *testing.T) {
 		logger:      slog.Default(),
 		stdout:      io.Discard,
 		stderr:      io.Discard,
-		progress:    func(string) {},
+		progress:    func(ProgressEvent) {},
 	}
 
 	b := eng.newBackend(ws, cfg, "/workspaces/project")
@@ -578,7 +578,7 @@ func TestUpCreate_FromSnapshot_PreservesFeatureEntrypoints(t *testing.T) {
 		logger:      slog.Default(),
 		stdout:      io.Discard,
 		stderr:      io.Discard,
-		progress:    func(string) {},
+		progress:    func(ProgressEvent) {},
 	}
 
 	b := eng.newBackend(ws, cfg, "/workspaces/project")
@@ -652,7 +652,7 @@ func TestUpCreate_FromSnapshot_ResolvesConfigEnv(t *testing.T) {
 		logger:      slog.Default(),
 		stdout:      io.Discard,
 		stderr:      io.Discard,
-		progress:    func(string) {},
+		progress:    func(ProgressEvent) {},
 	}
 
 	b := eng.newBackend(ws, cfg, "/workspaces/project")

--- a/internal/workspace/store.go
+++ b/internal/workspace/store.go
@@ -53,7 +53,7 @@ func NewStoreAt(baseDir string) *Store {
 
 // Save writes a workspace config to disk.
 func (s *Store) Save(ws *Workspace) error {
-	dir := s.workspaceDir(ws.ID)
+	dir := s.WorkspaceDir(ws.ID)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("creating workspace directory: %w", err)
 	}
@@ -73,7 +73,7 @@ func (s *Store) Save(ws *Workspace) error {
 
 // Load reads a workspace config from disk.
 func (s *Store) Load(id string) (*Workspace, error) {
-	path := filepath.Join(s.workspaceDir(id), workspaceConfigFile)
+	path := filepath.Join(s.WorkspaceDir(id), workspaceConfigFile)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -92,7 +92,7 @@ func (s *Store) Load(id string) (*Workspace, error) {
 
 // Delete removes a workspace directory from disk.
 func (s *Store) Delete(id string) error {
-	dir := s.workspaceDir(id)
+	dir := s.WorkspaceDir(id)
 	if err := os.RemoveAll(dir); err != nil {
 		return fmt.Errorf("deleting workspace: %w", err)
 	}
@@ -125,14 +125,14 @@ func (s *Store) List() ([]string, error) {
 
 // Exists checks if a workspace exists on disk.
 func (s *Store) Exists(id string) bool {
-	path := filepath.Join(s.workspaceDir(id), workspaceConfigFile)
+	path := filepath.Join(s.WorkspaceDir(id), workspaceConfigFile)
 	_, err := os.Stat(path)
 	return err == nil
 }
 
 // SaveResult writes a build result to disk.
 func (s *Store) SaveResult(id string, result *Result) error {
-	dir := s.workspaceDir(id)
+	dir := s.WorkspaceDir(id)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("creating workspace directory: %w", err)
 	}
@@ -152,7 +152,7 @@ func (s *Store) SaveResult(id string, result *Result) error {
 
 // LoadResult reads a build result from disk. Returns nil, nil if not found.
 func (s *Store) LoadResult(id string) (*Result, error) {
-	path := filepath.Join(s.workspaceDir(id), workspaceResultFile)
+	path := filepath.Join(s.WorkspaceDir(id), workspaceResultFile)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -171,7 +171,7 @@ func (s *Store) LoadResult(id string) (*Result, error) {
 
 // MarkHookDone records that a lifecycle hook has been executed for a workspace.
 func (s *Store) MarkHookDone(id, hookName string) error {
-	dir := filepath.Join(s.workspaceDir(id), "hooks")
+	dir := filepath.Join(s.WorkspaceDir(id), "hooks")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("creating hooks directory: %w", err)
 	}
@@ -184,7 +184,7 @@ func (s *Store) MarkHookDone(id, hookName string) error {
 
 // IsHookDone checks whether a lifecycle hook has already been executed.
 func (s *Store) IsHookDone(id, hookName string) bool {
-	path := filepath.Join(s.workspaceDir(id), "hooks", hookName+".done")
+	path := filepath.Join(s.WorkspaceDir(id), "hooks", hookName+".done")
 	_, err := os.Stat(path)
 	return err == nil
 }
@@ -192,7 +192,7 @@ func (s *Store) IsHookDone(id, hookName string) bool {
 // ClearHookMarkers removes all lifecycle hook markers for a workspace,
 // allowing hooks to run again (used on recreate).
 func (s *Store) ClearHookMarkers(id string) error {
-	dir := filepath.Join(s.workspaceDir(id), "hooks")
+	dir := filepath.Join(s.WorkspaceDir(id), "hooks")
 	if err := os.RemoveAll(dir); err != nil {
 		return fmt.Errorf("clearing hook markers: %w", err)
 	}
@@ -210,7 +210,7 @@ func (l *Lock) Unlock() error { return l.fl.Unlock() }
 // defer lock.Unlock() to release it. The lock respects context cancellation
 // so Ctrl+C works while waiting for a competing process.
 func (s *Store) Lock(ctx context.Context, id string) (*Lock, error) {
-	dir := s.workspaceDir(id)
+	dir := s.WorkspaceDir(id)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return nil, fmt.Errorf("creating workspace directory: %w", err)
 	}
@@ -220,10 +220,8 @@ func (s *Store) Lock(ctx context.Context, id string) (*Lock, error) {
 		return nil, fmt.Errorf("acquiring workspace lock: %w", err)
 	}
 	if !locked {
-		if ctx.Err() != nil {
-			return nil, ctx.Err()
-		}
-		return nil, fmt.Errorf("workspace %q is locked by another crib process", id)
+		// TryLockContext only returns locked=false on context cancellation.
+		return nil, fmt.Errorf("workspace %q is locked by another crib process: %w", id, ctx.Err())
 	}
 	return &Lock{fl: fl}, nil
 }
@@ -234,9 +232,4 @@ func (s *Store) BaseDir() string { return s.baseDir }
 // WorkspaceDir returns the on-disk directory for a workspace.
 func (s *Store) WorkspaceDir(id string) string {
 	return filepath.Join(s.baseDir, id)
-}
-
-// workspaceDir is an internal alias kept for backward compatibility within the package.
-func (s *Store) workspaceDir(id string) string {
-	return s.WorkspaceDir(id)
 }

--- a/internal/workspace/store.go
+++ b/internal/workspace/store.go
@@ -1,11 +1,13 @@
 package workspace
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/gofrs/flock"
 )
@@ -197,19 +199,30 @@ func (s *Store) ClearHookMarkers(id string) error {
 	return nil
 }
 
+// Lock is a workspace file lock. Call Unlock to release it.
+type Lock struct{ fl *flock.Flock }
+
+// Unlock releases the workspace lock.
+func (l *Lock) Unlock() error { return l.fl.Unlock() }
+
 // Lock acquires an exclusive file lock for a workspace, preventing concurrent
 // mutations (up, down, rebuild, restart, remove) from racing. The caller must
-// defer lock.Unlock() to release it.
-func (s *Store) Lock(id string) (*flock.Flock, error) {
+// defer lock.Unlock() to release it. The lock respects context cancellation
+// so Ctrl+C works while waiting for a competing process.
+func (s *Store) Lock(ctx context.Context, id string) (*Lock, error) {
 	dir := s.workspaceDir(id)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return nil, fmt.Errorf("creating workspace directory: %w", err)
 	}
 	fl := flock.New(filepath.Join(dir, ".lock"))
-	if err := fl.Lock(); err != nil {
+	locked, err := fl.TryLockContext(ctx, 200*time.Millisecond)
+	if err != nil {
 		return nil, fmt.Errorf("acquiring workspace lock: %w", err)
 	}
-	return fl, nil
+	if !locked {
+		return nil, fmt.Errorf("workspace %q is locked by another crib process", id)
+	}
+	return &Lock{fl: fl}, nil
 }
 
 // WorkspaceDir returns the on-disk directory for a workspace.

--- a/internal/workspace/store.go
+++ b/internal/workspace/store.go
@@ -228,6 +228,9 @@ func (s *Store) Lock(ctx context.Context, id string) (*Lock, error) {
 	return &Lock{fl: fl}, nil
 }
 
+// BaseDir returns the store's base directory (e.g. ~/.crib/workspaces).
+func (s *Store) BaseDir() string { return s.baseDir }
+
 // WorkspaceDir returns the on-disk directory for a workspace.
 func (s *Store) WorkspaceDir(id string) string {
 	return filepath.Join(s.baseDir, id)

--- a/internal/workspace/store.go
+++ b/internal/workspace/store.go
@@ -220,6 +220,9 @@ func (s *Store) Lock(ctx context.Context, id string) (*Lock, error) {
 		return nil, fmt.Errorf("acquiring workspace lock: %w", err)
 	}
 	if !locked {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
 		return nil, fmt.Errorf("workspace %q is locked by another crib process", id)
 	}
 	return &Lock{fl: fl}, nil

--- a/internal/workspace/store.go
+++ b/internal/workspace/store.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/gofrs/flock"
 )
 
 const (
@@ -193,6 +195,21 @@ func (s *Store) ClearHookMarkers(id string) error {
 		return fmt.Errorf("clearing hook markers: %w", err)
 	}
 	return nil
+}
+
+// Lock acquires an exclusive file lock for a workspace, preventing concurrent
+// mutations (up, down, rebuild, restart, remove) from racing. The caller must
+// defer lock.Unlock() to release it.
+func (s *Store) Lock(id string) (*flock.Flock, error) {
+	dir := s.workspaceDir(id)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("creating workspace directory: %w", err)
+	}
+	fl := flock.New(filepath.Join(dir, ".lock"))
+	if err := fl.Lock(); err != nil {
+		return nil, fmt.Errorf("acquiring workspace lock: %w", err)
+	}
+	return fl, nil
 }
 
 // WorkspaceDir returns the on-disk directory for a workspace.

--- a/internal/workspace/store_test.go
+++ b/internal/workspace/store_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"testing"
 	"time"
+
+	"github.com/gofrs/flock"
 )
 
 func TestStore_SaveAndLoad(t *testing.T) {
@@ -197,6 +199,62 @@ func TestStore_SaveAndLoadResult_FeatureHooks(t *testing.T) {
 	}
 	if len(loaded.FeaturePostAttachCommands) != 0 {
 		t.Errorf("FeaturePostAttachCommands should be empty, got %v", loaded.FeaturePostAttachCommands)
+	}
+}
+
+func TestStore_Lock(t *testing.T) {
+	store := NewStoreAt(t.TempDir())
+
+	// Lock should succeed and create the workspace directory.
+	fl, err := store.Lock("locktest")
+	if err != nil {
+		t.Fatalf("Lock: %v", err)
+	}
+
+	// A second TryLock on the same workspace should fail (held by us).
+	fl2 := flock.New(fl.Path())
+	locked, err := fl2.TryLock()
+	if err != nil {
+		t.Fatalf("TryLock: %v", err)
+	}
+	if locked {
+		t.Error("TryLock should fail while lock is held")
+		fl2.Unlock()
+	}
+
+	// Unlock, then TryLock should succeed.
+	if err := fl.Unlock(); err != nil {
+		t.Fatalf("Unlock: %v", err)
+	}
+	locked, err = fl2.TryLock()
+	if err != nil {
+		t.Fatalf("TryLock after unlock: %v", err)
+	}
+	if !locked {
+		t.Error("TryLock should succeed after unlock")
+	}
+	fl2.Unlock()
+}
+
+func TestStore_Lock_DeleteCleansUp(t *testing.T) {
+	store := NewStoreAt(t.TempDir())
+
+	// Create a workspace and lock it.
+	if err := store.Save(&Workspace{ID: "cleanup", Source: "/tmp"}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	fl, err := store.Lock("cleanup")
+	if err != nil {
+		t.Fatalf("Lock: %v", err)
+	}
+	fl.Unlock()
+
+	// Delete removes the entire workspace dir including the lock file.
+	if err := store.Delete("cleanup"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if store.Exists("cleanup") {
+		t.Error("workspace should not exist after delete")
 	}
 }
 

--- a/internal/workspace/store_test.go
+++ b/internal/workspace/store_test.go
@@ -1,12 +1,11 @@
 package workspace
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"testing"
 	"time"
-
-	"github.com/gofrs/flock"
 )
 
 func TestStore_SaveAndLoad(t *testing.T) {
@@ -204,50 +203,47 @@ func TestStore_SaveAndLoadResult_FeatureHooks(t *testing.T) {
 
 func TestStore_Lock(t *testing.T) {
 	store := NewStoreAt(t.TempDir())
+	ctx := context.Background()
 
 	// Lock should succeed and create the workspace directory.
-	fl, err := store.Lock("locktest")
+	lock, err := store.Lock(ctx, "locktest")
 	if err != nil {
 		t.Fatalf("Lock: %v", err)
 	}
 
-	// A second TryLock on the same workspace should fail (held by us).
-	fl2 := flock.New(fl.Path())
-	locked, err := fl2.TryLock()
-	if err != nil {
-		t.Fatalf("TryLock: %v", err)
-	}
-	if locked {
-		t.Error("TryLock should fail while lock is held")
-		fl2.Unlock()
+	// A second Lock with an already-cancelled context should fail immediately
+	// because the lock is held.
+	cancelledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	_, err = store.Lock(cancelledCtx, "locktest")
+	if err == nil {
+		t.Error("Lock should fail when workspace is already locked and context is cancelled")
 	}
 
-	// Unlock, then TryLock should succeed.
-	if err := fl.Unlock(); err != nil {
+	// Unlock, then Lock should succeed.
+	if err := lock.Unlock(); err != nil {
 		t.Fatalf("Unlock: %v", err)
 	}
-	locked, err = fl2.TryLock()
+	lock2, err := store.Lock(ctx, "locktest")
 	if err != nil {
-		t.Fatalf("TryLock after unlock: %v", err)
+		t.Fatalf("Lock after unlock: %v", err)
 	}
-	if !locked {
-		t.Error("TryLock should succeed after unlock")
-	}
-	fl2.Unlock()
+	lock2.Unlock()
 }
 
 func TestStore_Lock_DeleteCleansUp(t *testing.T) {
 	store := NewStoreAt(t.TempDir())
+	ctx := context.Background()
 
 	// Create a workspace and lock it.
 	if err := store.Save(&Workspace{ID: "cleanup", Source: "/tmp"}); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
-	fl, err := store.Lock("cleanup")
+	lock, err := store.Lock(ctx, "cleanup")
 	if err != nil {
 		t.Fatalf("Lock: %v", err)
 	}
-	fl.Unlock()
+	lock.Unlock()
 
 	// Delete removes the entire workspace dir including the lock file.
 	if err := store.Delete("cleanup"); err != nil {


### PR DESCRIPTION
## Summary

Accumulated housekeeping before moving on to new features:

- **Workspace flock**: State-mutating commands (`up`, `down`, `rebuild`, `restart`, `remove`) now acquire an exclusive file lock via `gofrs/flock`, preventing concurrent operations on the same workspace from racing
- **Compose-go types**: `generateComposeOverride` and `writePodmanDownOverride` use compose-go `types.Project` + `MarshalYAML()` instead of string concatenation. `LoadProject` threads env vars for proper `${localWorkspaceFolder}` substitution
- **Typed progress events**: Engine emits `ProgressEvent` structs with `Phase` and `Message` instead of raw strings (no user-visible change)
- **Logging consistency**: Config path log demoted to Debug, removed explicit `slog.String()` wrappers
- **CI fix**: Docs workflow triggers on `stable` branch push (GITHUB_TOKEN release events don't trigger other workflows)
- **Doctor scoping**: `crib doctor --fix` checks `crib.home` label to avoid deleting containers from a different `CRIB_HOME`
- **Compose diagnostics**: Captures stderr when container not found after `compose up`
- **Volume dedup**: Compose override no longer duplicates mounts already in user's compose files
- **Test safety**: Integration tests guard against interfering with active workspaces
- **Example cleanup**: Stripped boilerplate comments from all example devcontainer.json files
- **Gocyclo threshold**: Lowered from 40 to 30 (test files excluded)

## Test plan

- [x] `make lint` passes (gocyclo at 30)
- [x] `make test` passes
- [x] `make test-integration` (exercises compose override path end-to-end)
- [x] Manual: `compose-override.yml` output verified for compose-app example, round-tripped through `podman compose config`

### New test coverage

- Doctor unit tests: runtime check, compose check, orphaned workspaces, stale plugins, healthy system, and `crib.home` scoping (same store flagged, different store skipped, legacy containers without label)
- Progress wiring: `SetProgress`/`reportProgress` callback, `progressToString` adapter, `SetPlugins` order independence
- `composeStderrTee`: verbose mode (MultiWriter) vs non-verbose (buffer only)
- Volume dedup regression test
- Workspace lock: acquire, context-cancel contention, unlock + reacquire