### PR TITLE
refactor(engine): compose dedup, typed errors, port log bump

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install gotestfmt
         run: go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
       - name: Unit tests
-        run: set -euo pipefail && make test 2>&1 | tee /tmp/gotest.log | gotestfmt
+        run: set -euo pipefail && make test | tee /tmp/gotest.log | gotestfmt
         env:
           GO_TEST_FLAGS: -json
       - name: Lint
@@ -59,12 +59,12 @@ jobs:
           podman system service -t 0 &
           sleep 2
       - name: Integration tests
-        run: set -euo pipefail && make test-integration 2>&1 | tee /tmp/gotest.log | gotestfmt
+        run: set -euo pipefail && make test-integration | tee /tmp/gotest.log | gotestfmt
         env:
           CRIB_RUNTIME: podman
           GO_TEST_FLAGS: -json
       - name: E2E tests
-        run: set -euo pipefail && make test-e2e 2>&1 | tee /tmp/gotest.log | gotestfmt
+        run: set -euo pipefail && make test-e2e | tee /tmp/gotest.log | gotestfmt
         env:
           CRIB_RUNTIME: podman
           GO_TEST_FLAGS: -json
@@ -85,12 +85,12 @@ jobs:
       - name: Verify Docker is available
         run: docker info
       - name: Integration tests
-        run: set -euo pipefail && make test-integration 2>&1 | tee /tmp/gotest.log | gotestfmt
+        run: set -euo pipefail && make test-integration | tee /tmp/gotest.log | gotestfmt
         env:
           CRIB_RUNTIME: docker
           GO_TEST_FLAGS: -json
       - name: E2E tests
-        run: set -euo pipefail && make test-e2e 2>&1 | tee /tmp/gotest.log | gotestfmt
+        run: set -euo pipefail && make test-e2e | tee /tmp/gotest.log | gotestfmt
         env:
           CRIB_RUNTIME: docker
           GO_TEST_FLAGS: -json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `crib down`, `crib stop`, and `crib remove` now return a clear error
+  immediately when a compose workspace is detected but compose is not
+  installed, instead of silently falling through to single-container
+  cleanup.
+- Invalid port numbers in container inspect output are now logged at
+  `WARN` level instead of `DEBUG`, making them visible in `crib status`
+  output without `--debug`.
 - Docs website now deploys automatically on `stable` branch push.
 - Compose backend captures stderr for diagnostics when container is not found
   after `compose up`.

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 
 	"github.com/charmbracelet/x/term"
+	"github.com/fgrehm/crib/internal/engine"
 	"github.com/spf13/cobra"
 )
 
@@ -37,10 +38,10 @@ Use -- to separate crib flags from the container command:
 			return fmt.Errorf("finding container: %w", err)
 		}
 		if status.Container == nil {
-			return errNoContainer
+			return &engine.ErrNoContainer{WorkspaceID: ws.ID}
 		}
 		if !status.Container.State.IsRunning() {
-			return errContainerStopped
+			return &engine.ErrContainerStopped{WorkspaceID: ws.ID, ContainerID: status.Container.ID}
 		}
 		container := status.Container
 

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -9,7 +9,6 @@ import (
 	"syscall"
 
 	"github.com/charmbracelet/x/term"
-	"github.com/fgrehm/crib/internal/engine"
 	"github.com/spf13/cobra"
 )
 
@@ -33,17 +32,10 @@ Use -- to separate crib flags from the container command:
 			return err
 		}
 
-		status, err := eng.Status(cmd.Context(), ws)
+		container, err := eng.RequireRunningContainer(cmd.Context(), ws)
 		if err != nil {
-			return fmt.Errorf("finding container: %w", err)
+			return err
 		}
-		if status.Container == nil {
-			return &engine.ErrNoContainer{WorkspaceID: ws.ID}
-		}
-		if !status.Container.State.IsRunning() {
-			return &engine.ErrContainerStopped{WorkspaceID: ws.ID, ContainerID: status.Container.ID}
-		}
-		container := status.Container
 
 		shellArgs := args
 		if len(shellArgs) == 0 {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,13 +27,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// errNoContainer is returned when a command requires a running container but
-// none exists for the workspace. Used by exec, run, and shell.
-var errNoContainer = fmt.Errorf("no container found (run 'crib up' first)")
-
-// errContainerStopped is returned when the container exists but is not running.
-var errContainerStopped = fmt.Errorf("container is stopped (run 'crib up' to start it)")
-
 // noArgs rejects any positional arguments with a clear error message.
 // Prefer this over cobra.NoArgs, whose error says "unknown command" which is
 // misleading when the extra token is not a subcommand.

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/fgrehm/crib/internal/engine"
 	"github.com/fgrehm/crib/internal/plugin"
 	"github.com/spf13/cobra"
 )
@@ -42,10 +43,10 @@ Use -- to separate crib flags from the container command:
 			return fmt.Errorf("finding container: %w", err)
 		}
 		if status.Container == nil {
-			return errNoContainer
+			return &engine.ErrNoContainer{WorkspaceID: ws.ID}
 		}
 		if !status.Container.State.IsRunning() {
-			return errContainerStopped
+			return &engine.ErrContainerStopped{WorkspaceID: ws.ID, ContainerID: status.Container.ID}
 		}
 		container := status.Container
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/fgrehm/crib/internal/engine"
 	"github.com/fgrehm/crib/internal/plugin"
 	"github.com/spf13/cobra"
 )
@@ -38,17 +37,10 @@ Use -- to separate crib flags from the container command:
 			return err
 		}
 
-		status, err := eng.Status(cmd.Context(), ws)
+		container, err := eng.RequireRunningContainer(cmd.Context(), ws)
 		if err != nil {
-			return fmt.Errorf("finding container: %w", err)
+			return err
 		}
-		if status.Container == nil {
-			return &engine.ErrNoContainer{WorkspaceID: ws.ID}
-		}
-		if !status.Container.State.IsRunning() {
-			return &engine.ErrContainerStopped{WorkspaceID: ws.ID, ContainerID: status.Container.ID}
-		}
-		container := status.Container
 
 		// Detect the user's shell in the container (same logic as crib shell).
 		var buf bytes.Buffer

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/fgrehm/crib/internal/engine"
 	"github.com/spf13/cobra"
 )
 
@@ -39,17 +38,10 @@ Working directory is set to the workspace folder if available.`,
 			return err
 		}
 
-		status, err := eng.Status(cmd.Context(), ws)
+		container, err := eng.RequireRunningContainer(cmd.Context(), ws)
 		if err != nil {
-			return fmt.Errorf("finding container: %w", err)
+			return err
 		}
-		if status.Container == nil {
-			return &engine.ErrNoContainer{WorkspaceID: ws.ID}
-		}
-		if !status.Container.State.IsRunning() {
-			return &engine.ErrContainerStopped{WorkspaceID: ws.ID, ContainerID: status.Container.ID}
-		}
-		container := status.Container
 
 		// Detect which shell is available in the container
 		var buf bytes.Buffer

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/fgrehm/crib/internal/engine"
 	"github.com/spf13/cobra"
 )
 
@@ -43,10 +44,10 @@ Working directory is set to the workspace folder if available.`,
 			return fmt.Errorf("finding container: %w", err)
 		}
 		if status.Container == nil {
-			return errNoContainer
+			return &engine.ErrNoContainer{WorkspaceID: ws.ID}
 		}
 		if !status.Container.State.IsRunning() {
-			return errContainerStopped
+			return &engine.ErrContainerStopped{WorkspaceID: ws.ID, ContainerID: status.Container.ID}
 		}
 		container := status.Container
 

--- a/internal/driver/oci/container.go
+++ b/internal/driver/oci/container.go
@@ -285,7 +285,7 @@ func (ic *inspectContainer) toContainerDetails() driver.ContainerDetails {
 		for _, b := range bindings {
 			hostPort, err := strconv.Atoi(b.HostPort)
 			if err != nil {
-				slog.Debug("invalid host port in container inspect", "value", b.HostPort, "error", err)
+				slog.Warn("invalid host port in container inspect", "value", b.HostPort, "error", err)
 			}
 			d.Ports = append(d.Ports, driver.PortBinding{
 				ContainerPort: port,
@@ -308,7 +308,7 @@ func parseContainerPort(s string) (int, string) {
 	}
 	port, err := strconv.Atoi(portStr)
 	if err != nil {
-		slog.Debug("invalid container port in inspect output", "value", portStr, "error", err)
+		slog.Warn("invalid container port in inspect output", "value", portStr, "error", err)
 	}
 	return port, proto
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -208,7 +208,7 @@ func (e *Engine) Up(ctx context.Context, ws *workspace.Workspace, opts UpOptions
 	// Compose guards - fail before any side effects.
 	if len(cfg.DockerComposeFile) > 0 {
 		if e.compose == nil {
-			return nil, fmt.Errorf("compose is not available (install docker compose or podman compose)")
+			return nil, &ErrComposeNotAvailable{}
 		}
 		if cfg.Service == "" {
 			return nil, fmt.Errorf("dockerComposeFile is set but service is not specified")
@@ -435,7 +435,7 @@ func (e *Engine) Down(ctx context.Context, ws *workspace.Workspace) error {
 	result, _ := e.store.LoadResult(ws.ID)
 	cfg := storedComposeConfig(result)
 	if cfg != nil && e.compose == nil {
-		return fmt.Errorf("compose is not available (install docker compose or podman compose)")
+		return &ErrComposeNotAvailable{}
 	}
 
 	// Clear hook markers so the next "up" runs all lifecycle hooks.
@@ -455,7 +455,7 @@ func (e *Engine) Down(ctx context.Context, ws *workspace.Workspace) error {
 		return fmt.Errorf("finding container: %w", err)
 	}
 	if container == nil {
-		return fmt.Errorf("no container found for workspace %s", ws.ID)
+		return &ErrNoContainer{WorkspaceID: ws.ID}
 	}
 
 	return e.driver.DeleteContainer(ctx, ws.ID, container.ID)
@@ -470,7 +470,7 @@ func (e *Engine) Stop(ctx context.Context, ws *workspace.Workspace) error {
 	result, _ := e.store.LoadResult(ws.ID)
 	cfg := storedComposeConfig(result)
 	if cfg != nil && e.compose == nil {
-		return fmt.Errorf("compose is not available (install docker compose or podman compose)")
+		return &ErrComposeNotAvailable{}
 	}
 
 	// For compose workspaces, use compose stop.
@@ -485,7 +485,7 @@ func (e *Engine) Stop(ctx context.Context, ws *workspace.Workspace) error {
 		return fmt.Errorf("finding container: %w", err)
 	}
 	if container == nil {
-		return fmt.Errorf("no container found for workspace %s", ws.ID)
+		return &ErrNoContainer{WorkspaceID: ws.ID}
 	}
 
 	if !container.State.IsRunning() {
@@ -542,7 +542,7 @@ func (e *Engine) Remove(ctx context.Context, ws *workspace.Workspace) error {
 	result, _ := e.store.LoadResult(ws.ID)
 	cfg := storedComposeConfig(result)
 	if cfg != nil && e.compose == nil {
-		return fmt.Errorf("compose is not available (install docker compose or podman compose)")
+		return &ErrComposeNotAvailable{}
 	}
 
 	// Remove snapshot image before tearing down.

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -632,6 +632,23 @@ func (e *Engine) cleanupWorkspaceImages(ctx context.Context, wsID string) {
 	}
 }
 
+// RequireRunningContainer finds the container for the workspace and returns it
+// if it is running. Returns ErrNoContainer if no container exists, or
+// ErrContainerStopped if the container exists but is not running.
+func (e *Engine) RequireRunningContainer(ctx context.Context, ws *workspace.Workspace) (*driver.ContainerDetails, error) {
+	container, err := e.driver.FindContainer(ctx, ws.ID)
+	if err != nil {
+		return nil, fmt.Errorf("finding container: %w", err)
+	}
+	if container == nil {
+		return nil, &ErrNoContainer{WorkspaceID: ws.ID}
+	}
+	if !container.State.IsRunning() {
+		return nil, &ErrContainerStopped{WorkspaceID: ws.ID, ContainerID: container.ID}
+	}
+	return container, nil
+}
+
 // storedComposeConfig returns the stored DevContainerConfig if it is a compose
 // workspace, or nil otherwise. Returns nil when result is nil, MergedConfig is
 // missing, JSON is malformed, or DockerComposeFile is empty.

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -205,15 +205,7 @@ func (e *Engine) Up(ctx context.Context, ws *workspace.Workspace, opts UpOptions
 		return nil, err
 	}
 
-	// Run initializeCommand on the host before image build/pull.
-	if err := e.runInitializeCommand(ctx, ws, cfg); err != nil {
-		return nil, fmt.Errorf("initializeCommand: %w", err)
-	}
-	if cfg.WaitFor == "initializeCommand" {
-		e.reportProgress(PhaseInit, "Container ready.")
-	}
-
-	// Compose guards.
+	// Compose guards - fail before any side effects.
 	if len(cfg.DockerComposeFile) > 0 {
 		if e.compose == nil {
 			return nil, fmt.Errorf("compose is not available (install docker compose or podman compose)")
@@ -221,6 +213,14 @@ func (e *Engine) Up(ctx context.Context, ws *workspace.Workspace, opts UpOptions
 		if cfg.Service == "" {
 			return nil, fmt.Errorf("dockerComposeFile is set but service is not specified")
 		}
+	}
+
+	// Run initializeCommand on the host before image build/pull.
+	if err := e.runInitializeCommand(ctx, ws, cfg); err != nil {
+		return nil, fmt.Errorf("initializeCommand: %w", err)
+	}
+	if cfg.WaitFor == "initializeCommand" {
+		e.reportProgress(PhaseInit, "Container ready.")
 	}
 
 	b := e.newBackend(ws, cfg, workspaceFolder)
@@ -432,20 +432,21 @@ func (e *Engine) saveResult(ws *workspace.Workspace, cfg *config.DevContainerCon
 func (e *Engine) Down(ctx context.Context, ws *workspace.Workspace) error {
 	e.logger.Debug("down", "workspace", ws.ID)
 
+	result, _ := e.store.LoadResult(ws.ID)
+	cfg := storedComposeConfig(result)
+	if cfg != nil && e.compose == nil {
+		return fmt.Errorf("compose is not available (install docker compose or podman compose)")
+	}
+
 	// Clear hook markers so the next "up" runs all lifecycle hooks.
 	if err := e.store.ClearHookMarkers(ws.ID); err != nil {
 		e.logger.Warn("failed to clear hook markers", "error", err)
 	}
 
 	// For compose workspaces, use compose down to stop and remove all services.
-	if result, err := e.store.LoadResult(ws.ID); err == nil && result != nil {
-		var cfg config.DevContainerConfig
-		if json.Unmarshal(result.MergedConfig, &cfg) == nil && len(cfg.DockerComposeFile) > 0 {
-			if e.compose != nil {
-				inv := newComposeInvocation(ws, &cfg, result.WorkspaceFolder)
-				return e.composeDown(ctx, inv, ws.ID, false)
-			}
-		}
+	if cfg != nil {
+		inv := newComposeInvocation(ws, cfg, result.WorkspaceFolder)
+		return e.composeDown(ctx, inv, ws.ID, false)
 	}
 
 	// Non-compose path: stop and remove the individual container.
@@ -466,15 +467,16 @@ func (e *Engine) Down(ctx context.Context, ws *workspace.Workspace) error {
 func (e *Engine) Stop(ctx context.Context, ws *workspace.Workspace) error {
 	e.logger.Debug("stop", "workspace", ws.ID)
 
+	result, _ := e.store.LoadResult(ws.ID)
+	cfg := storedComposeConfig(result)
+	if cfg != nil && e.compose == nil {
+		return fmt.Errorf("compose is not available (install docker compose or podman compose)")
+	}
+
 	// For compose workspaces, use compose stop.
-	if result, err := e.store.LoadResult(ws.ID); err == nil && result != nil {
-		var cfg config.DevContainerConfig
-		if json.Unmarshal(result.MergedConfig, &cfg) == nil && len(cfg.DockerComposeFile) > 0 {
-			if e.compose != nil {
-				inv := newComposeInvocation(ws, &cfg, result.WorkspaceFolder)
-				return e.composeStop(ctx, inv, ws.ID)
-			}
-		}
+	if cfg != nil {
+		inv := newComposeInvocation(ws, cfg, result.WorkspaceFolder)
+		return e.composeStop(ctx, inv, ws.ID)
 	}
 
 	// Non-compose path: stop the individual container.
@@ -537,6 +539,12 @@ func (e *Engine) PreviewRemove(ctx context.Context, ws *workspace.Workspace) *Re
 func (e *Engine) Remove(ctx context.Context, ws *workspace.Workspace) error {
 	e.logger.Debug("remove", "workspace", ws.ID)
 
+	result, _ := e.store.LoadResult(ws.ID)
+	cfg := storedComposeConfig(result)
+	if cfg != nil && e.compose == nil {
+		return fmt.Errorf("compose is not available (install docker compose or podman compose)")
+	}
+
 	// Remove snapshot image before tearing down.
 	e.clearSnapshot(ctx, ws)
 
@@ -544,17 +552,12 @@ func (e *Engine) Remove(ctx context.Context, ws *workspace.Workspace) error {
 	// For compose workspaces, use compose down --volumes to also remove
 	// named volumes declared in the compose file (e.g. database data).
 	composeTornDown := false
-	if result, err := e.store.LoadResult(ws.ID); err == nil && result != nil {
-		var cfg config.DevContainerConfig
-		if json.Unmarshal(result.MergedConfig, &cfg) == nil && len(cfg.DockerComposeFile) > 0 {
-			if e.compose != nil {
-				inv := newComposeInvocation(ws, &cfg, result.WorkspaceFolder)
-				if err := e.composeDown(ctx, inv, ws.ID, true); err != nil {
-					e.logger.Warn("failed to remove compose services", "error", err)
-				}
-				composeTornDown = true
-			}
+	if cfg != nil {
+		inv := newComposeInvocation(ws, cfg, result.WorkspaceFolder)
+		if err := e.composeDown(ctx, inv, ws.ID, true); err != nil {
+			e.logger.Warn("failed to remove compose services", "error", err)
 		}
+		composeTornDown = true
 	}
 
 	if !composeTornDown {
@@ -588,16 +591,13 @@ func (e *Engine) Status(ctx context.Context, ws *workspace.Workspace) (*StatusRe
 	result := &StatusResult{Container: container}
 
 	// For compose workspaces, also fetch service statuses.
-	if e.compose != nil {
-		if stored, err := e.store.LoadResult(ws.ID); err == nil && stored != nil {
-			var cfg config.DevContainerConfig
-			if json.Unmarshal(stored.MergedConfig, &cfg) == nil && len(cfg.DockerComposeFile) > 0 {
-				inv := newComposeInvocation(ws, &cfg, stored.WorkspaceFolder)
-				if statuses, err := e.compose.ListServiceStatuses(ctx, inv.projectName, inv.files, inv.env); err == nil {
-					result.Services = statuses
-				} else {
-					e.logger.Debug("failed to list compose services", "error", err)
-				}
+	if stored, err := e.store.LoadResult(ws.ID); err == nil {
+		if cfg := storedComposeConfig(stored); cfg != nil && e.compose != nil {
+			inv := newComposeInvocation(ws, cfg, stored.WorkspaceFolder)
+			if statuses, err := e.compose.ListServiceStatuses(ctx, inv.projectName, inv.files, inv.env); err == nil {
+				result.Services = statuses
+			} else {
+				e.logger.Debug("failed to list compose services", "error", err)
 			}
 		}
 	}
@@ -630,6 +630,23 @@ func (e *Engine) cleanupWorkspaceImages(ctx context.Context, wsID string) {
 			e.logger.Debug("failed to remove workspace image", "image", ref, "error", err)
 		}
 	}
+}
+
+// storedComposeConfig returns the stored DevContainerConfig if it is a compose
+// workspace, or nil otherwise. Returns nil when result is nil, MergedConfig is
+// missing, JSON is malformed, or DockerComposeFile is empty.
+func storedComposeConfig(result *workspace.Result) *config.DevContainerConfig {
+	if result == nil {
+		return nil
+	}
+	var cfg config.DevContainerConfig
+	if err := json.Unmarshal(result.MergedConfig, &cfg); err != nil {
+		return nil
+	}
+	if len(cfg.DockerComposeFile) == 0 {
+		return nil
+	}
+	return &cfg
 }
 
 // --- shared helpers ---

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -57,6 +57,75 @@ func TestComposeStderr_Verbose(t *testing.T) {
 	}
 }
 
+// composeWorkspaceResult returns a stored result with a compose devcontainer config.
+func composeWorkspaceResult(t *testing.T, store *workspace.Store, wsID string) {
+	t.Helper()
+	result := &workspace.Result{
+		MergedConfig: []byte(`{"dockerComposeFile":["docker-compose.yml"],"service":"app"}`),
+	}
+	if err := store.SaveResult(wsID, result); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDown_ComposeMissing_ReturnsError(t *testing.T) {
+	store := workspace.NewStoreAt(t.TempDir())
+	ws := &workspace.Workspace{ID: "test-down-compose-nil", Source: t.TempDir(), DevContainerPath: ".devcontainer/devcontainer.json"}
+	if err := store.Save(ws); err != nil {
+		t.Fatal(err)
+	}
+	composeWorkspaceResult(t, store, ws.ID)
+
+	e := &Engine{driver: &mockDriver{}, store: store, logger: slog.Default(), stdout: io.Discard, stderr: io.Discard}
+	// compose is nil (not set)
+
+	err := e.Down(context.Background(), ws)
+	if err == nil {
+		t.Fatal("expected error when compose is nil for compose workspace")
+	}
+	if !strings.Contains(err.Error(), "compose is not available") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestStop_ComposeMissing_ReturnsError(t *testing.T) {
+	store := workspace.NewStoreAt(t.TempDir())
+	ws := &workspace.Workspace{ID: "test-stop-compose-nil", Source: t.TempDir(), DevContainerPath: ".devcontainer/devcontainer.json"}
+	if err := store.Save(ws); err != nil {
+		t.Fatal(err)
+	}
+	composeWorkspaceResult(t, store, ws.ID)
+
+	e := &Engine{driver: &mockDriver{}, store: store, logger: slog.Default(), stdout: io.Discard, stderr: io.Discard}
+
+	err := e.Stop(context.Background(), ws)
+	if err == nil {
+		t.Fatal("expected error when compose is nil for compose workspace")
+	}
+	if !strings.Contains(err.Error(), "compose is not available") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRemove_ComposeMissing_ReturnsError(t *testing.T) {
+	store := workspace.NewStoreAt(t.TempDir())
+	ws := &workspace.Workspace{ID: "test-remove-compose-nil", Source: t.TempDir(), DevContainerPath: ".devcontainer/devcontainer.json"}
+	if err := store.Save(ws); err != nil {
+		t.Fatal(err)
+	}
+	composeWorkspaceResult(t, store, ws.ID)
+
+	e := &Engine{driver: &mockDriver{}, store: store, logger: slog.Default(), stdout: io.Discard, stderr: io.Discard}
+
+	err := e.Remove(context.Background(), ws)
+	if err == nil {
+		t.Fatal("expected error when compose is nil for compose workspace")
+	}
+	if !strings.Contains(err.Error(), "compose is not available") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
 func TestDown_ClearsHookMarkers(t *testing.T) {
 	store := workspace.NewStoreAt(t.TempDir())
 
@@ -412,6 +481,28 @@ func TestRemove_SkipsBaseImages(t *testing.T) {
 		if img == "ubuntu:22.04" {
 			t.Errorf("should not have removed base image %s", img)
 		}
+	}
+}
+
+func TestStoredComposeConfig(t *testing.T) {
+	tests := []struct {
+		name   string
+		result *workspace.Result
+		want   bool // true == non-nil return
+	}{
+		{"nil result", nil, false},
+		{"non-compose config", &workspace.Result{MergedConfig: []byte(`{"image":"ubuntu"}`)}, false},
+		{"compose config", &workspace.Result{MergedConfig: []byte(`{"dockerComposeFile":["docker-compose.yml"]}`)}, true},
+		{"invalid JSON", &workspace.Result{MergedConfig: []byte(`{bad}`)}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := storedComposeConfig(tt.result)
+			if (got != nil) != tt.want {
+				t.Errorf("storedComposeConfig() = %v, want non-nil=%v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -319,6 +319,71 @@ func TestRemove_DeletesWorkspaceState(t *testing.T) {
 	}
 }
 
+func TestRequireRunningContainer_Running(t *testing.T) {
+	store := workspace.NewStoreAt(t.TempDir())
+	ws := &workspace.Workspace{ID: "ws-1", Source: t.TempDir()}
+	if err := store.Save(ws); err != nil {
+		t.Fatal(err)
+	}
+
+	drv := &fixedFindContainerDriver{
+		container: &driver.ContainerDetails{ID: "abc123", State: driver.ContainerState{Status: "running"}},
+	}
+	eng := &Engine{driver: drv, store: store, logger: slog.Default()}
+
+	got, err := eng.RequireRunningContainer(context.Background(), ws)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if got.ID != "abc123" {
+		t.Errorf("container ID = %q, want %q", got.ID, "abc123")
+	}
+}
+
+func TestRequireRunningContainer_NoContainer(t *testing.T) {
+	store := workspace.NewStoreAt(t.TempDir())
+	ws := &workspace.Workspace{ID: "ws-2", Source: t.TempDir()}
+	if err := store.Save(ws); err != nil {
+		t.Fatal(err)
+	}
+
+	eng := &Engine{driver: &mockDriver{}, store: store, logger: slog.Default()} // FindContainer returns nil
+
+	_, err := eng.RequireRunningContainer(context.Background(), ws)
+	if err == nil {
+		t.Fatal("expected error for missing container")
+	}
+	var target *ErrNoContainer
+	if !errors.As(err, &target) {
+		t.Errorf("expected ErrNoContainer, got: %v", err)
+	}
+}
+
+func TestRequireRunningContainer_Stopped(t *testing.T) {
+	store := workspace.NewStoreAt(t.TempDir())
+	ws := &workspace.Workspace{ID: "ws-3", Source: t.TempDir()}
+	if err := store.Save(ws); err != nil {
+		t.Fatal(err)
+	}
+
+	drv := &fixedFindContainerDriver{
+		container: &driver.ContainerDetails{ID: "abc123", State: driver.ContainerState{Status: "exited"}},
+	}
+	eng := &Engine{driver: drv, store: store, logger: slog.Default()}
+
+	_, err := eng.RequireRunningContainer(context.Background(), ws)
+	if err == nil {
+		t.Fatal("expected error for stopped container")
+	}
+	var target *ErrContainerStopped
+	if !errors.As(err, &target) {
+		t.Errorf("expected ErrContainerStopped, got: %v", err)
+	}
+	if target.ContainerID != "abc123" {
+		t.Errorf("ContainerID = %q, want %q", target.ContainerID, "abc123")
+	}
+}
+
 func TestEnsureContainerRunning_Running(t *testing.T) {
 	eng := &Engine{driver: &mockDriver{}, logger: slog.Default()}
 

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"strings"
@@ -77,14 +78,14 @@ func TestDown_ComposeMissing_ReturnsError(t *testing.T) {
 	composeWorkspaceResult(t, store, ws.ID)
 
 	e := &Engine{driver: &mockDriver{}, store: store, logger: slog.Default(), stdout: io.Discard, stderr: io.Discard}
-	// compose is nil (not set)
 
 	err := e.Down(context.Background(), ws)
 	if err == nil {
 		t.Fatal("expected error when compose is nil for compose workspace")
 	}
-	if !strings.Contains(err.Error(), "compose is not available") {
-		t.Errorf("unexpected error: %v", err)
+	var target *ErrComposeNotAvailable
+	if !errors.As(err, &target) {
+		t.Errorf("expected ErrComposeNotAvailable, got: %v", err)
 	}
 }
 
@@ -102,8 +103,9 @@ func TestStop_ComposeMissing_ReturnsError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when compose is nil for compose workspace")
 	}
-	if !strings.Contains(err.Error(), "compose is not available") {
-		t.Errorf("unexpected error: %v", err)
+	var target *ErrComposeNotAvailable
+	if !errors.As(err, &target) {
+		t.Errorf("expected ErrComposeNotAvailable, got: %v", err)
 	}
 }
 
@@ -121,8 +123,9 @@ func TestRemove_ComposeMissing_ReturnsError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when compose is nil for compose workspace")
 	}
-	if !strings.Contains(err.Error(), "compose is not available") {
-		t.Errorf("unexpected error: %v", err)
+	var target *ErrComposeNotAvailable
+	if !errors.As(err, &target) {
+		t.Errorf("expected ErrComposeNotAvailable, got: %v", err)
 	}
 }
 
@@ -241,8 +244,9 @@ func TestStop_NoContainer(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when no container exists")
 	}
-	if !strings.Contains(err.Error(), "no container found") {
-		t.Errorf("expected 'no container found' in error, got: %v", err)
+	var target *ErrNoContainer
+	if !errors.As(err, &target) {
+		t.Errorf("expected ErrNoContainer, got: %v", err)
 	}
 }
 

--- a/internal/engine/errors.go
+++ b/internal/engine/errors.go
@@ -20,7 +20,7 @@ type ErrContainerStopped struct {
 }
 
 func (e *ErrContainerStopped) Error() string {
-	return fmt.Sprintf("container %s is stopped (run 'crib up' to start it)", e.WorkspaceID)
+	return "container is stopped (run 'crib up' to start it)"
 }
 
 // ErrComposeNotAvailable is returned when an operation requires docker compose

--- a/internal/engine/errors.go
+++ b/internal/engine/errors.go
@@ -1,0 +1,32 @@
+package engine
+
+import "fmt"
+
+// ErrNoContainer is returned when a workspace operation requires a container
+// but none exists.
+type ErrNoContainer struct {
+	WorkspaceID string
+}
+
+func (e *ErrNoContainer) Error() string {
+	return fmt.Sprintf("no container found for workspace %s (run 'crib up' first)", e.WorkspaceID)
+}
+
+// ErrContainerStopped is returned when a workspace operation requires a running
+// container but the container exists in a stopped state.
+type ErrContainerStopped struct {
+	WorkspaceID string
+	ContainerID string
+}
+
+func (e *ErrContainerStopped) Error() string {
+	return fmt.Sprintf("container %s is stopped (run 'crib up' to start it)", e.WorkspaceID)
+}
+
+// ErrComposeNotAvailable is returned when an operation requires docker compose
+// or podman compose but neither is installed.
+type ErrComposeNotAvailable struct{}
+
+func (e *ErrComposeNotAvailable) Error() string {
+	return "compose is not available (install docker compose or podman compose)"
+}

--- a/internal/engine/errors_test.go
+++ b/internal/engine/errors_test.go
@@ -1,0 +1,52 @@
+package engine
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestErrNoContainer_As(t *testing.T) {
+	wrapped := fmt.Errorf("outer: %w", &ErrNoContainer{WorkspaceID: "my-ws"})
+
+	var target *ErrNoContainer
+	if !errors.As(wrapped, &target) {
+		t.Fatal("errors.As should unwrap ErrNoContainer")
+	}
+	if target.WorkspaceID != "my-ws" {
+		t.Errorf("WorkspaceID = %q, want %q", target.WorkspaceID, "my-ws")
+	}
+	if target.Error() == "" {
+		t.Error("Error() should return a non-empty string")
+	}
+}
+
+func TestErrContainerStopped_As(t *testing.T) {
+	wrapped := fmt.Errorf("outer: %w", &ErrContainerStopped{WorkspaceID: "my-ws", ContainerID: "abc123"})
+
+	var target *ErrContainerStopped
+	if !errors.As(wrapped, &target) {
+		t.Fatal("errors.As should unwrap ErrContainerStopped")
+	}
+	if target.WorkspaceID != "my-ws" {
+		t.Errorf("WorkspaceID = %q, want %q", target.WorkspaceID, "my-ws")
+	}
+	if target.ContainerID != "abc123" {
+		t.Errorf("ContainerID = %q, want %q", target.ContainerID, "abc123")
+	}
+	if target.Error() == "" {
+		t.Error("Error() should return a non-empty string")
+	}
+}
+
+func TestErrComposeNotAvailable_As(t *testing.T) {
+	wrapped := fmt.Errorf("outer: %w", &ErrComposeNotAvailable{})
+
+	var target *ErrComposeNotAvailable
+	if !errors.As(wrapped, &target) {
+		t.Fatal("errors.As should unwrap ErrComposeNotAvailable")
+	}
+	if target.Error() == "" {
+		t.Error("Error() should return a non-empty string")
+	}
+}

--- a/internal/engine/logs.go
+++ b/internal/engine/logs.go
@@ -35,6 +35,9 @@ func (e *Engine) Logs(ctx context.Context, ws *workspace.Workspace, opts LogsOpt
 		return fmt.Errorf("unmarshaling stored config: %w", err)
 	}
 	if len(cfg.DockerComposeFile) > 0 {
+		if e.compose == nil {
+			return fmt.Errorf("compose is not available (install docker compose or podman compose)")
+		}
 		return e.logsCompose(ctx, ws, storedResult, &cfg, opts)
 	}
 
@@ -60,10 +63,6 @@ func (e *Engine) logsSingle(ctx context.Context, ws *workspace.Workspace, stored
 
 // logsCompose streams logs from all compose services.
 func (e *Engine) logsCompose(ctx context.Context, ws *workspace.Workspace, storedResult *workspace.Result, cfg *config.DevContainerConfig, opts LogsOptions) error {
-	if e.compose == nil {
-		return fmt.Errorf("compose is not available")
-	}
-
 	cd := configDir(ws)
 	composeFiles := resolveComposeFiles(cd, cfg.DockerComposeFile)
 	projectName := compose.ProjectName(ws.ID)

--- a/internal/engine/logs.go
+++ b/internal/engine/logs.go
@@ -29,7 +29,10 @@ func (e *Engine) Logs(ctx context.Context, ws *workspace.Workspace, opts LogsOpt
 		return fmt.Errorf("no previous result found for workspace %s (run 'crib up' first)", ws.ID)
 	}
 
-	// Check if this is a compose workspace.
+	// Check if this is a compose workspace. Unlike storedComposeConfig (which
+	// swallows parse errors and returns nil), Logs() surfaces corrupt configs
+	// as an error rather than silently falling through to the single-container
+	// path.
 	var cfg config.DevContainerConfig
 	if err := json.Unmarshal(storedResult.MergedConfig, &cfg); err != nil {
 		return fmt.Errorf("unmarshaling stored config: %w", err)

--- a/internal/engine/logs.go
+++ b/internal/engine/logs.go
@@ -36,7 +36,7 @@ func (e *Engine) Logs(ctx context.Context, ws *workspace.Workspace, opts LogsOpt
 	}
 	if len(cfg.DockerComposeFile) > 0 {
 		if e.compose == nil {
-			return fmt.Errorf("compose is not available (install docker compose or podman compose)")
+			return &ErrComposeNotAvailable{}
 		}
 		return e.logsCompose(ctx, ws, storedResult, &cfg, opts)
 	}
@@ -51,7 +51,7 @@ func (e *Engine) logsSingle(ctx context.Context, ws *workspace.Workspace, stored
 		return fmt.Errorf("finding container: %w", err)
 	}
 	if container == nil {
-		return fmt.Errorf("no container found for workspace %s", ws.ID)
+		return &ErrNoContainer{WorkspaceID: ws.ID}
 	}
 
 	driverOpts := &driver.LogsOptions{

--- a/internal/engine/logs_test.go
+++ b/internal/engine/logs_test.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
-	"strings"
 	"testing"
 
 	"github.com/fgrehm/crib/internal/config"
@@ -113,8 +113,9 @@ func TestLogs_ComposeMissing_ReturnsError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when compose is nil for compose workspace")
 	}
-	if !strings.Contains(err.Error(), "compose is not available") {
-		t.Errorf("unexpected error: %v", err)
+	var target *ErrComposeNotAvailable
+	if !errors.As(err, &target) {
+		t.Errorf("expected ErrComposeNotAvailable, got: %v", err)
 	}
 }
 

--- a/internal/engine/logs_test.go
+++ b/internal/engine/logs_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"io"
 	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/fgrehm/crib/internal/config"
@@ -84,6 +85,36 @@ func TestLogs_SingleContainer(t *testing.T) {
 	}
 	if stdout.String() != "test log output\n" {
 		t.Errorf("stdout = %q, want %q", stdout.String(), "test log output\n")
+	}
+}
+
+func TestLogs_ComposeMissing_ReturnsError(t *testing.T) {
+	store := workspace.NewStoreAt(t.TempDir())
+	ws := &workspace.Workspace{ID: "ws-logs-compose-nil", Source: "/home/user/project"}
+	if err := store.Save(ws); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveResult(ws.ID, &workspace.Result{
+		MergedConfig: []byte(`{"dockerComposeFile":["docker-compose.yml"],"service":"app"}`),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	eng := &Engine{
+		driver: &mockDriver{},
+		store:  store,
+		logger: slog.Default(),
+		stdout: io.Discard,
+		stderr: io.Discard,
+		// compose is nil
+	}
+
+	err := eng.Logs(context.Background(), ws, LogsOptions{})
+	if err == nil {
+		t.Fatal("expected error when compose is nil for compose workspace")
+	}
+	if !strings.Contains(err.Error(), "compose is not available") {
+		t.Errorf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/engine/restart.go
+++ b/internal/engine/restart.go
@@ -58,7 +58,7 @@ func (e *Engine) Restart(ctx context.Context, ws *workspace.Workspace) (*Restart
 	// Compose guards (mirrors Up).
 	if len(cfg.DockerComposeFile) > 0 {
 		if e.compose == nil {
-			return nil, fmt.Errorf("compose is not available (install docker compose or podman compose)")
+			return nil, &ErrComposeNotAvailable{}
 		}
 		if cfg.Service == "" {
 			return nil, fmt.Errorf("dockerComposeFile is set but service is not specified")
@@ -123,7 +123,7 @@ func (e *Engine) restartSimple(ctx context.Context, ws *workspace.Workspace, cfg
 		return nil, fmt.Errorf("finding container: %w", err)
 	}
 	if container == nil {
-		return nil, fmt.Errorf("no container found for workspace %s", ws.ID)
+		return nil, &ErrNoContainer{WorkspaceID: ws.ID}
 	}
 
 	// Dispatch plugins.


### PR DESCRIPTION
## Summary

- Extracts `storedComposeConfig` helper to eliminate duplicated
  `json.Unmarshal` + `DockerComposeFile` checks across `Down`, `Stop`,
  `Remove`, `Status`, and `Logs`. Compose availability is now checked as
  a precondition before any side effects in all methods that touch
  compose workspaces (including moving the guard in `Up` to before
  `runInitializeCommand`).
- Introduces typed errors (`ErrNoContainer`, `ErrContainerStopped`,
  `ErrComposeNotAvailable`) that support `errors.As` unwrapping.
  Adds `RequireRunningContainer` to the engine so `exec`, `run`, and
  `shell` no longer construct or check error types directly.
- Bumps invalid port parsing log level from `Debug` to `Warn` in the
  OCI driver so bad inspect output surfaces without `--debug`.

## Behavior changes

- `crib down`, `crib stop`, `crib remove` now return an error
  immediately when a compose workspace is detected but compose is
  unavailable, instead of silently falling through to single-container
  cleanup.

## Test plan

- [x] `make test` passes
- [x] `make lint` passes
- [x] `make deadcode` passes