### PR TITLE
feat(dotfiles): per-project config and opt-out via .cribrc

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,8 +54,12 @@ jobs:
           cache: true
       - name: Install gotestfmt
         run: go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
-      - name: Install podman-compose
-        run: pip3 install podman-compose
+      # Suppress "Executing external compose provider" warnings that make
+      # CI output look like failures (containers/podman#23441).
+      - name: Configure podman
+        run: |
+          mkdir -p ~/.config/containers
+          printf '[engine]\ncompose_warning_logs=false\n' >> ~/.config/containers/containers.conf
       - name: Start podman daemon
         run: |
           podman system service -t 0 &
@@ -63,7 +67,6 @@ jobs:
       - name: Integration tests
         run: set -euo pipefail && make test-integration | tee /tmp/gotest.log | gotestfmt
         env:
-          PODMAN_COMPOSE_PROVIDER: podman-compose
           CRIB_RUNTIME: podman
           GO_TEST_FLAGS: -json
       - name: E2E tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,7 @@ jobs:
       - name: Integration tests
         run: set -euo pipefail && make test-integration | tee /tmp/gotest.log | gotestfmt
         env:
+          PODMAN_COMPOSE_PROVIDER: podman-compose
           CRIB_RUNTIME: podman
           GO_TEST_FLAGS: -json
       - name: E2E tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,8 @@ jobs:
           cache: true
       - name: Install gotestfmt
         run: go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
+      - name: Install podman-compose
+        run: pip3 install podman-compose
       - name: Start podman daemon
         run: |
           podman system service -t 0 &

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Dotfiles plugin**: clones and installs a dotfiles repository inside the
   container on creation. Configured via global config. Supports custom target
   path, install command override, and auto-detection of common install scripts.
+  Per-project overrides and opt-out via `.cribrc` (`dotfiles.repository`,
+  `dotfiles.targetPath`, `dotfiles.installCommand`, `dotfiles = false`).
   See [#17](https://github.com/fgrehm/crib/issues/17).
 - **Global config** (`~/.config/crib/config.toml`, respects `$XDG_CONFIG_HOME`):
   user-level settings applied across all workspaces. Currently supports

--- a/cmd/cribrc.go
+++ b/cmd/cribrc.go
@@ -7,10 +7,19 @@ import (
 	"strings"
 )
 
+// dotfilesRC holds per-project dotfiles settings from .cribrc.
+type dotfilesRC struct {
+	Disabled       bool
+	Repository     string
+	TargetPath     string
+	InstallCommand string
+}
+
 // cribRC holds values loaded from a .cribrc file.
 type cribRC struct {
-	Config string   // devcontainer config directory (same as --config / -C)
-	Cache  []string // package cache providers (e.g. "npm", "pip", "go")
+	Config   string   // devcontainer config directory (same as --config / -C)
+	Cache    []string // package cache providers (e.g. "npm", "pip", "go")
+	Dotfiles dotfilesRC
 }
 
 // loadCribRC reads a .cribrc file from cwd. Returns nil, nil if not found.
@@ -51,6 +60,16 @@ func loadCribRC() (*cribRC, error) {
 					rc.Cache = append(rc.Cache, p)
 				}
 			}
+		case "dotfiles":
+			if strings.TrimSpace(val) == "false" {
+				rc.Dotfiles.Disabled = true
+			}
+		case "dotfiles.repository":
+			rc.Dotfiles.Repository = strings.TrimSpace(val)
+		case "dotfiles.targetPath":
+			rc.Dotfiles.TargetPath = strings.TrimSpace(val)
+		case "dotfiles.installCommand":
+			rc.Dotfiles.InstallCommand = strings.TrimSpace(val)
 		}
 	}
 	return rc, scanner.Err()

--- a/cmd/cribrc.go
+++ b/cmd/cribrc.go
@@ -50,9 +50,10 @@ func loadCribRC() (*cribRC, error) {
 		if !ok {
 			continue
 		}
+		val = strings.TrimSpace(val)
 		switch strings.TrimSpace(key) {
 		case "config":
-			rc.Config = strings.TrimSpace(val)
+			rc.Config = val
 		case "cache":
 			for p := range strings.SplitSeq(val, ",") {
 				p = strings.TrimSpace(p)
@@ -61,15 +62,15 @@ func loadCribRC() (*cribRC, error) {
 				}
 			}
 		case "dotfiles":
-			if strings.TrimSpace(val) == "false" {
+			if val == "false" {
 				rc.Dotfiles.Disabled = true
 			}
 		case "dotfiles.repository":
-			rc.Dotfiles.Repository = strings.TrimSpace(val)
+			rc.Dotfiles.Repository = val
 		case "dotfiles.targetPath":
-			rc.Dotfiles.TargetPath = strings.TrimSpace(val)
+			rc.Dotfiles.TargetPath = val
 		case "dotfiles.installCommand":
-			rc.Dotfiles.InstallCommand = strings.TrimSpace(val)
+			rc.Dotfiles.InstallCommand = val
 		}
 	}
 	return rc, scanner.Err()

--- a/cmd/cribrc_test.go
+++ b/cmd/cribrc_test.go
@@ -55,3 +55,106 @@ func TestLoadCribRC_BothKeys(t *testing.T) {
 		t.Errorf("Cache = %v, want [npm]", rc.Cache)
 	}
 }
+
+func TestLoadCribRC_DotfilesDisable(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".cribrc"), []byte("dotfiles = false\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+
+	rc, err := loadCribRC()
+	if err != nil {
+		t.Fatalf("loadCribRC: %v", err)
+	}
+	if !rc.Dotfiles.Disabled {
+		t.Error("expected Dotfiles.Disabled = true")
+	}
+}
+
+func TestLoadCribRC_DotfilesUnknownValue_Ignored(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".cribrc"), []byte("dotfiles = maybe\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+
+	rc, err := loadCribRC()
+	if err != nil {
+		t.Fatalf("loadCribRC: %v", err)
+	}
+	if rc.Dotfiles.Disabled {
+		t.Error("expected Dotfiles.Disabled = false for unknown value")
+	}
+}
+
+func TestLoadCribRC_DotfilesRepository(t *testing.T) {
+	dir := t.TempDir()
+	content := "dotfiles.repository = git@github.com:user/dots\n"
+	if err := os.WriteFile(filepath.Join(dir, ".cribrc"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+
+	rc, err := loadCribRC()
+	if err != nil {
+		t.Fatalf("loadCribRC: %v", err)
+	}
+	if rc.Dotfiles.Repository != "git@github.com:user/dots" {
+		t.Errorf("Repository = %q, want git@github.com:user/dots", rc.Dotfiles.Repository)
+	}
+}
+
+func TestLoadCribRC_DotfilesTargetPath(t *testing.T) {
+	dir := t.TempDir()
+	content := "dotfiles.targetPath = ~/my-dots\n"
+	if err := os.WriteFile(filepath.Join(dir, ".cribrc"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+
+	rc, err := loadCribRC()
+	if err != nil {
+		t.Fatalf("loadCribRC: %v", err)
+	}
+	if rc.Dotfiles.TargetPath != "~/my-dots" {
+		t.Errorf("TargetPath = %q, want ~/my-dots", rc.Dotfiles.TargetPath)
+	}
+}
+
+func TestLoadCribRC_DotfilesInstallCommand(t *testing.T) {
+	dir := t.TempDir()
+	content := "dotfiles.installCommand = make install\n"
+	if err := os.WriteFile(filepath.Join(dir, ".cribrc"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+
+	rc, err := loadCribRC()
+	if err != nil {
+		t.Fatalf("loadCribRC: %v", err)
+	}
+	if rc.Dotfiles.InstallCommand != "make install" {
+		t.Errorf("InstallCommand = %q, want make install", rc.Dotfiles.InstallCommand)
+	}
+}
+
+func TestLoadCribRC_DotfilesDisableWithRepository(t *testing.T) {
+	dir := t.TempDir()
+	content := "dotfiles = false\ndotfiles.repository = git@github.com:user/dots\n"
+	if err := os.WriteFile(filepath.Join(dir, ".cribrc"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+
+	rc, err := loadCribRC()
+	if err != nil {
+		t.Fatalf("loadCribRC: %v", err)
+	}
+	if !rc.Dotfiles.Disabled {
+		t.Error("expected Dotfiles.Disabled = true")
+	}
+	if rc.Dotfiles.Repository != "git@github.com:user/dots" {
+		t.Errorf("Repository = %q, want git@github.com:user/dots", rc.Dotfiles.Repository)
+	}
+}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -99,6 +99,8 @@ Use -- to separate crib flags from the container command:
 		execArgs = append(execArgs, container.ID)
 		execArgs = append(execArgs, shellArgs...)
 
+		// syscall.Exec replaces the current process with the container runtime.
+		// On success it never returns; the only return path is an error.
 		return syscall.Exec(runtimeBin, execArgs, os.Environ())
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,12 +38,13 @@ func noArgs(cmd *cobra.Command, args []string) error {
 }
 
 var (
-	debugFlag      bool
-	verboseFlag    bool
-	configDirFlag  string
-	dirFlag        string
-	logger         *slog.Logger
-	cacheProviders []string // loaded from .cribrc cache key
+	debugFlag       bool
+	verboseFlag     bool
+	configDirFlag   string
+	dirFlag         string
+	logger          *slog.Logger
+	cacheProviders  []string   // loaded from .cribrc cache key
+	projectDotfiles dotfilesRC // loaded from .cribrc dotfiles keys
 )
 
 // version variables injected at build time via ldflags.
@@ -88,6 +89,7 @@ var rootCmd = &cobra.Command{
 				cacheProviders = rc.Cache
 				logger.Debug("loaded cache providers from .cribrc", "providers", rc.Cache)
 			}
+			projectDotfiles = rc.Dotfiles
 		}
 
 		return nil
@@ -242,6 +244,38 @@ func composePortsToDriver(ports []compose.PortBinding) []driver.PortBinding {
 	return result
 }
 
+// resolveDotfilesPlugin merges global config with per-project overrides and
+// returns the effective config and whether the plugin should be registered.
+func resolveDotfilesPlugin(gcfg globalconfig.DotfilesConfig, rc dotfilesRC) (globalconfig.DotfilesConfig, bool) {
+	if rc.Disabled {
+		return globalconfig.DotfilesConfig{}, false
+	}
+
+	// Merge: start with global, apply per-project overrides.
+	merged := gcfg
+	if rc.Repository != "" {
+		merged.Repository = rc.Repository
+	}
+	if rc.TargetPath != "" {
+		merged.TargetPath = rc.TargetPath
+	}
+	if rc.InstallCommand != "" {
+		merged.InstallCommand = rc.InstallCommand
+	}
+
+	if merged.Repository == "" {
+		return globalconfig.DotfilesConfig{}, false
+	}
+
+	// Apply ~/dotfiles default: applyDefaults only ran on the global config
+	// struct; the repo may have come from per-project.
+	if merged.TargetPath == "" {
+		merged.TargetPath = "~/dotfiles"
+	}
+
+	return merged, true
+}
+
 // setupPlugins creates a plugin manager with bundled plugins and attaches it
 // to the engine. Called from commands that create containers (up, rebuild, restart).
 func setupPlugins(eng *engine.Engine, d *oci.OCIDriver) {
@@ -252,8 +286,8 @@ func setupPlugins(eng *engine.Engine, d *oci.OCIDriver) {
 	mgr.Register(pluginssh.New())
 	if gcfg, err := globalconfig.Load(); err != nil {
 		logger.Warn("failed to load global config", "error", err)
-	} else if gcfg.Dotfiles.Repository != "" {
-		mgr.Register(dotfiles.New(gcfg.Dotfiles))
+	} else if cfg, ok := resolveDotfilesPlugin(gcfg.Dotfiles, projectDotfiles); ok {
+		mgr.Register(dotfiles.New(cfg))
 	}
 	if len(cacheProviders) > 0 {
 		if unknown := packagecache.ValidateProviders(cacheProviders); len(unknown) > 0 {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -284,9 +284,13 @@ func setupPlugins(eng *engine.Engine, d *oci.OCIDriver) {
 	mgr.Register(codingagents.New())
 	mgr.Register(shellhistory.New())
 	mgr.Register(pluginssh.New())
+	var globalDotfiles globalconfig.DotfilesConfig
 	if gcfg, err := globalconfig.Load(); err != nil {
 		logger.Warn("failed to load global config", "error", err)
-	} else if cfg, ok := resolveDotfilesPlugin(gcfg.Dotfiles, projectDotfiles); ok {
+	} else {
+		globalDotfiles = gcfg.Dotfiles
+	}
+	if cfg, ok := resolveDotfilesPlugin(globalDotfiles, projectDotfiles); ok {
 		mgr.Register(dotfiles.New(cfg))
 	}
 	if len(cacheProviders) > 0 {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,6 +1,10 @@
 package cmd
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/fgrehm/crib/internal/globalconfig"
+)
 
 func TestVersionString_Dev(t *testing.T) {
 	origV, origC, origD := version, commit, date
@@ -59,5 +63,114 @@ func TestVersionString_UnknownCommit(t *testing.T) {
 	want := "crib 0.3.0-dev"
 	if got != want {
 		t.Errorf("versionString() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveDotfilesPlugin(t *testing.T) {
+	globalSet := globalconfig.DotfilesConfig{
+		Repository: "https://github.com/user/dotfiles",
+		TargetPath: "~/dotfiles",
+	}
+	globalEmpty := globalconfig.DotfilesConfig{}
+
+	tests := []struct {
+		name           string
+		gcfg           globalconfig.DotfilesConfig
+		rc             dotfilesRC
+		wantRun        bool
+		wantRepo       string
+		wantTargetPath string
+		wantInstall    string
+	}{
+		{
+			name:     "global set, no project override → runs",
+			gcfg:     globalSet,
+			rc:       dotfilesRC{},
+			wantRun:  true,
+			wantRepo: "https://github.com/user/dotfiles",
+		},
+		{
+			name:    "global set, project disabled → does not run",
+			gcfg:    globalSet,
+			rc:      dotfilesRC{Disabled: true},
+			wantRun: false,
+		},
+		{
+			name:     "global set, project repo override → runs with override",
+			gcfg:     globalSet,
+			rc:       dotfilesRC{Repository: "https://github.com/user/other"},
+			wantRun:  true,
+			wantRepo: "https://github.com/user/other",
+		},
+		{
+			name:           "global set, project targetPath override → merged",
+			gcfg:           globalSet,
+			rc:             dotfilesRC{TargetPath: "~/custom"},
+			wantRun:        true,
+			wantRepo:       "https://github.com/user/dotfiles",
+			wantTargetPath: "~/custom",
+		},
+		{
+			name:        "global set, project installCommand override → merged",
+			gcfg:        globalSet,
+			rc:          dotfilesRC{InstallCommand: "make install"},
+			wantRun:     true,
+			wantRepo:    "https://github.com/user/dotfiles",
+			wantInstall: "make install",
+		},
+		{
+			name:     "no global repo, project repo → runs with project settings",
+			gcfg:     globalEmpty,
+			rc:       dotfilesRC{Repository: "https://github.com/user/dots"},
+			wantRun:  true,
+			wantRepo: "https://github.com/user/dots",
+		},
+		{
+			name:           "no global repo, project repo, no targetPath → default applied",
+			gcfg:           globalEmpty,
+			rc:             dotfilesRC{Repository: "https://github.com/user/dots"},
+			wantRun:        true,
+			wantRepo:       "https://github.com/user/dots",
+			wantTargetPath: "~/dotfiles",
+		},
+		{
+			name:    "no global repo, no project override → does not run",
+			gcfg:    globalEmpty,
+			rc:      dotfilesRC{},
+			wantRun: false,
+		},
+		{
+			name:    "no global repo, project disabled → does not run",
+			gcfg:    globalEmpty,
+			rc:      dotfilesRC{Disabled: true},
+			wantRun: false,
+		},
+		{
+			name:    "no global repo, project targetPath only → does not run",
+			gcfg:    globalEmpty,
+			rc:      dotfilesRC{TargetPath: "~/custom"},
+			wantRun: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, ok := resolveDotfilesPlugin(tt.gcfg, tt.rc)
+			if ok != tt.wantRun {
+				t.Fatalf("wantRun=%v got %v", tt.wantRun, ok)
+			}
+			if !ok {
+				return
+			}
+			if tt.wantRepo != "" && cfg.Repository != tt.wantRepo {
+				t.Errorf("Repository = %q, want %q", cfg.Repository, tt.wantRepo)
+			}
+			if tt.wantTargetPath != "" && cfg.TargetPath != tt.wantTargetPath {
+				t.Errorf("TargetPath = %q, want %q", cfg.TargetPath, tt.wantTargetPath)
+			}
+			if tt.wantInstall != "" && cfg.InstallCommand != tt.wantInstall {
+				t.Errorf("InstallCommand = %q, want %q", cfg.InstallCommand, tt.wantInstall)
+			}
+		})
 	}
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -89,6 +89,8 @@ Use -- to separate crib flags from the container command:
 		escaped := plugin.ShellQuoteJoin(args)
 		execArgs = append(execArgs, container.ID, shellPath, "-lc", escaped)
 
+		// syscall.Exec replaces the current process with the container runtime.
+		// On success it never returns; the only return path is an error.
 		return syscall.Exec(runtimeBin, execArgs, os.Environ())
 	},
 }

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -77,6 +77,8 @@ Working directory is set to the workspace folder if available.`,
 
 		execArgs = append(execArgs, container.ID, shellPath, "-l")
 
+		// syscall.Exec replaces the current process with the container runtime.
+		// On success it never returns; the only return path is an error.
 		return syscall.Exec(runtimeBin, execArgs, os.Environ())
 	},
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -11,11 +11,12 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Show version information",
 	Args:  noArgs,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		u := newUI()
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "crib "+version)
 		u.Keyval("commit", commit)
 		u.Keyval("date", date)
 		u.Keyval("go", runtime.Version())
+		return nil
 	},
 }

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -152,6 +152,22 @@ targetPath = "~/dotfiles"        # optional, default ~/dotfiles
 installCommand = "make install"  # optional, auto-detects if omitted
 ```
 
+When `repository` is set, the plugin runs for every workspace. Use a `.cribrc` to override this per project (see below).
+
+**Per-project override via `.cribrc`:**
+
+```ini
+# Use different dotfiles for this project:
+dotfiles.repository = https://github.com/user/work-dotfiles
+dotfiles.targetPath = ~/work-dotfiles    # optional
+dotfiles.installCommand = make install   # optional
+
+# Or disable dotfiles entirely for this project:
+dotfiles = false
+```
+
+Per-project settings override the global config. Setting `dotfiles.repository` in `.cribrc` also works when no global config is set, enabling dotfiles for a single project without a global config file.
+
 **What it does:**
 
 1. Clones the repository into `targetPath` inside the container (default `~/dotfiles`)
@@ -164,7 +180,7 @@ Tilde (`~`) in `targetPath` expands to the remote user's home directory inside t
 
 The plugin runs during `crib up` (first creation only). Because the effects are baked into the snapshot, dotfiles survive `crib stop` + `crib up` and restarts. A `crib rebuild` re-runs the clone and install.
 
-**No-op when `repository` is not set.** If you don't configure dotfiles, the plugin does nothing.
+**No-op when `repository` is not set in either the global config or `.cribrc`.** If you don't configure dotfiles, the plugin does nothing.
 
 :::note[Git required]
 The container must have `git` installed for the clone to work. Most devcontainer base images include it. If yours doesn't, add it via a Feature or `postCreateCommand`.

--- a/internal/engine/dotfiles_integration_test.go
+++ b/internal/engine/dotfiles_integration_test.go
@@ -77,10 +77,10 @@ func dotfilesDevcontainerConfig(repoDir string) string {
 	}`, repoDir, dotfilesSourceMount)
 }
 
-// dotfilesDockerfile builds a minimal image with git. Uses alpine/git as the base
-// to avoid an apk network round-trip during the test build, and clears the entrypoint
-// so the image behaves like plain alpine.
-const dotfilesDockerfile = "FROM alpine/git:latest\nENTRYPOINT []\n"
+// dotfilesDockerfile builds a minimal image with git from alpine:3.20.
+// Avoids alpine/git which declares /git as a VOLUME (changes there are lost
+// on commit/recreate) and carries ENTRYPOINT/WorkingDir baggage.
+const dotfilesDockerfile = "FROM alpine:3.20\nRUN apk add --no-cache git\n"
 
 func TestIntegrationDotfilesPlugin(t *testing.T) {
 	if testing.Short() {

--- a/internal/engine/dotfiles_integration_test.go
+++ b/internal/engine/dotfiles_integration_test.go
@@ -74,7 +74,7 @@ func dotfilesDevcontainerConfig(repoDir string) string {
 // dotfilesDockerfile builds a minimal image with git. Uses alpine/git as the base
 // to avoid an apk network round-trip during the test build, and clears the entrypoint
 // so the image behaves like plain alpine.
-const dotfilesDockerfile = "FROM alpine/git:2.47.0\nENTRYPOINT []\n"
+const dotfilesDockerfile = "FROM alpine/git:latest\nENTRYPOINT []\n"
 
 func TestIntegrationDotfilesPlugin(t *testing.T) {
 	if testing.Short() {

--- a/internal/engine/dotfiles_integration_test.go
+++ b/internal/engine/dotfiles_integration_test.go
@@ -66,6 +66,7 @@ func setupLocalDotfilesRepo(t *testing.T, installMarker string) string {
 func dotfilesDevcontainerConfig(repoDir string) string {
 	return fmt.Sprintf(`{
 		"build": {"dockerfile": "Dockerfile"},
+		"remoteUser": "root",
 		"overrideCommand": true,
 		"containerEnv": {
 			"GIT_CONFIG_COUNT": "1",

--- a/internal/engine/dotfiles_integration_test.go
+++ b/internal/engine/dotfiles_integration_test.go
@@ -59,14 +59,11 @@ func setupLocalDotfilesRepo(t *testing.T, installMarker string) string {
 
 // dotfilesDevcontainerConfig returns a devcontainer.json that builds a git-enabled
 // image and mounts repoDir at dotfilesSourceMount (read-only).
-// onCreateCommand sets safe.directory='*' to bypass the dubious-ownership check:
-// the bind-mounted repo is owned by the host user, which git rejects.
 func dotfilesDevcontainerConfig(repoDir string) string {
 	return fmt.Sprintf(`{
 		"build": {"dockerfile": "Dockerfile"},
 		"remoteUser": "root",
 		"overrideCommand": true,
-		"onCreateCommand": "git config --global --add safe.directory '*'",
 		"mounts": ["source=%s,target=%s,type=bind,readonly=true"]
 	}`, repoDir, dotfilesSourceMount)
 }
@@ -74,7 +71,9 @@ func dotfilesDevcontainerConfig(repoDir string) string {
 // dotfilesDockerfile builds a minimal image with git from alpine:3.20.
 // Avoids alpine/git which declares /git as a VOLUME (changes there are lost
 // on commit/recreate) and carries ENTRYPOINT/WorkingDir baggage.
-const dotfilesDockerfile = "FROM alpine:3.20\nRUN apk add --no-cache git\n"
+// Configures safe.directory='*' in the image so git trusts the bind-mounted
+// dotfiles source regardless of ownership (host vs container UID mismatch).
+const dotfilesDockerfile = "FROM alpine:3.20\nRUN apk add --no-cache git && git config --global --add safe.directory '*'\n"
 
 func TestIntegrationDotfilesPlugin(t *testing.T) {
 	if testing.Short() {

--- a/internal/engine/dotfiles_integration_test.go
+++ b/internal/engine/dotfiles_integration_test.go
@@ -59,20 +59,14 @@ func setupLocalDotfilesRepo(t *testing.T, installMarker string) string {
 
 // dotfilesDevcontainerConfig returns a devcontainer.json that builds a git-enabled
 // image and mounts repoDir at dotfilesSourceMount (read-only).
-// GIT_CONFIG_* env vars bypass the dubious-ownership check without writing to
-// ~/.gitconfig: the bind-mounted repo is owned by the host user, which git rejects
-// when the container runs as a different user. Using env vars avoids the file write
-// and works regardless of home directory permissions.
+// onCreateCommand sets safe.directory='*' to bypass the dubious-ownership check:
+// the bind-mounted repo is owned by the host user, which git rejects.
 func dotfilesDevcontainerConfig(repoDir string) string {
 	return fmt.Sprintf(`{
 		"build": {"dockerfile": "Dockerfile"},
 		"remoteUser": "root",
 		"overrideCommand": true,
-		"containerEnv": {
-			"GIT_CONFIG_COUNT": "1",
-			"GIT_CONFIG_KEY_0": "safe.directory",
-			"GIT_CONFIG_VALUE_0": "*"
-		},
+		"onCreateCommand": "git config --global --add safe.directory '*'",
 		"mounts": ["source=%s,target=%s,type=bind,readonly=true"]
 	}`, repoDir, dotfilesSourceMount)
 }

--- a/internal/engine/dotfiles_integration_test.go
+++ b/internal/engine/dotfiles_integration_test.go
@@ -58,13 +58,13 @@ func setupLocalDotfilesRepo(t *testing.T, installMarker string) string {
 }
 
 // dotfilesDevcontainerConfig returns a devcontainer.json that builds a git-enabled
-// image and mounts repoDir at dotfilesSourceMount (read-only).
+// image and mounts repoDir at dotfilesSourceMount.
 func dotfilesDevcontainerConfig(repoDir string) string {
 	return fmt.Sprintf(`{
 		"build": {"dockerfile": "Dockerfile"},
 		"remoteUser": "root",
 		"overrideCommand": true,
-		"mounts": ["source=%s,target=%s,type=bind,readonly=true"]
+		"mounts": ["source=%s,target=%s,type=bind"]
 	}`, repoDir, dotfilesSourceMount)
 }
 

--- a/internal/engine/dotfiles_integration_test.go
+++ b/internal/engine/dotfiles_integration_test.go
@@ -57,18 +57,24 @@ func setupLocalDotfilesRepo(t *testing.T, installMarker string) string {
 	return repoDir
 }
 
-// dotfilesDevcontainerConfig returns a devcontainer.json that builds alpine
-// with git and mounts repoDir at dotfilesSourceMount (read-only).
+// dotfilesDevcontainerConfig returns a devcontainer.json that builds a git-enabled
+// image and mounts repoDir at dotfilesSourceMount (read-only).
+// onCreateCommand sets safe.directory before the dotfiles plugin runs: the bind-mounted
+// repo is owned by the host user but the container runs as root, which triggers git's
+// dubious-ownership check without this config.
 func dotfilesDevcontainerConfig(repoDir string) string {
 	return fmt.Sprintf(`{
 		"build": {"dockerfile": "Dockerfile"},
 		"overrideCommand": true,
+		"onCreateCommand": "git config --global safe.directory '*'",
 		"mounts": ["source=%s,target=%s,type=bind,readonly=true"]
 	}`, repoDir, dotfilesSourceMount)
 }
 
-// dotfilesDockerfile is a minimal Dockerfile that adds git to alpine.
-const dotfilesDockerfile = "FROM alpine:3.20\nRUN apk add --no-cache git\n"
+// dotfilesDockerfile builds a minimal image with git. Uses alpine/git as the base
+// to avoid an apk network round-trip during the test build, and clears the entrypoint
+// so the image behaves like plain alpine.
+const dotfilesDockerfile = "FROM alpine/git:2.47.0\nENTRYPOINT []\n"
 
 func TestIntegrationDotfilesPlugin(t *testing.T) {
 	if testing.Short() {

--- a/internal/engine/dotfiles_integration_test.go
+++ b/internal/engine/dotfiles_integration_test.go
@@ -1,0 +1,200 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/fgrehm/crib/internal/driver/oci"
+	"github.com/fgrehm/crib/internal/globalconfig"
+	"github.com/fgrehm/crib/internal/plugin"
+	"github.com/fgrehm/crib/internal/plugin/dotfiles"
+	"github.com/fgrehm/crib/internal/workspace"
+)
+
+// mountPath is the path inside the container where the local dotfiles repo is mounted.
+const dotfilesSourceMount = "/dotfiles-source"
+
+// setupLocalDotfilesRepo creates a local git repo with an install.sh that
+// touches a marker file inside the container when executed. Returns the repo
+// directory, which callers should mount at dotfilesSourceMount.
+func setupLocalDotfilesRepo(t *testing.T, installMarker string) string {
+	t.Helper()
+
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("skipping: git not available on host")
+	}
+
+	repoDir := t.TempDir()
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repoDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	run("init")
+	run("config", "user.email", "test@crib.test")
+	run("config", "user.name", "Crib Test")
+
+	installSh := fmt.Sprintf("#!/bin/sh\ntouch %s\n", installMarker)
+	if err := os.WriteFile(filepath.Join(repoDir, "install.sh"), []byte(installSh), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	run("add", "install.sh")
+	run("commit", "-m", "init")
+
+	return repoDir
+}
+
+// dotfilesDevcontainerConfig returns a devcontainer.json that builds alpine
+// with git and mounts repoDir at dotfilesSourceMount (read-only).
+func dotfilesDevcontainerConfig(repoDir string) string {
+	return fmt.Sprintf(`{
+		"build": {"dockerfile": "Dockerfile"},
+		"overrideCommand": true,
+		"mounts": ["source=%s,target=%s,type=bind,readonly=true"]
+	}`, repoDir, dotfilesSourceMount)
+}
+
+// dotfilesDockerfile is a minimal Dockerfile that adds git to alpine.
+const dotfilesDockerfile = "FROM alpine:3.20\nRUN apk add --no-cache git\n"
+
+func TestIntegrationDotfilesPlugin(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	e, d, _ := newTestEngine(t)
+	e.SetOutput(os.Stdout, os.Stderr)
+
+	repoDir := setupLocalDotfilesRepo(t, "/tmp/dotfiles-installed")
+
+	mgr := plugin.NewManager(slog.Default())
+	mgr.Register(dotfiles.New(globalconfig.DotfilesConfig{
+		Repository: dotfilesSourceMount,
+		// TargetPath defaults to ~/dotfiles -> /root/dotfiles (root user)
+	}))
+	e.SetPlugins(mgr)
+	e.SetRuntime(d.Runtime().String())
+
+	projectDir := t.TempDir()
+	devcontainerDir := filepath.Join(projectDir, ".devcontainer")
+	if err := os.MkdirAll(devcontainerDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(devcontainerDir, "Dockerfile"), []byte(dotfilesDockerfile), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(devcontainerDir, "devcontainer.json"), []byte(dotfilesDevcontainerConfig(repoDir)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	wsID := "test-engine-dotfiles"
+	ws := &workspace.Workspace{
+		ID:               wsID,
+		Source:           projectDir,
+		DevContainerPath: ".devcontainer/devcontainer.json",
+		CreatedAt:        time.Now(),
+		LastUsedAt:       time.Now(),
+	}
+
+	_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
+	t.Cleanup(func() {
+		_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
+		cleanupWorkspaceImages(t, d, wsID)
+	})
+
+	result, err := e.Up(ctx, ws, UpOptions{})
+	if err != nil {
+		t.Fatalf("Up: %v", err)
+	}
+
+	// Verify the repo was cloned to the default target path.
+	var stdout bytes.Buffer
+	if err := d.ExecContainer(ctx, wsID, result.ContainerID, []string{"test", "-d", "/root/dotfiles"}, nil, &stdout, nil, nil, ""); err != nil {
+		t.Error("dotfiles not cloned: /root/dotfiles not found")
+	}
+
+	// Verify install.sh was auto-detected and executed.
+	stdout.Reset()
+	if err := d.ExecContainer(ctx, wsID, result.ContainerID, []string{"test", "-f", "/tmp/dotfiles-installed"}, nil, &stdout, nil, nil, ""); err != nil {
+		t.Error("install.sh did not run: /tmp/dotfiles-installed not found")
+	}
+}
+
+func TestIntegrationDotfilesPluginInstallCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	e, d, _ := newTestEngine(t)
+	e.SetOutput(os.Stdout, os.Stderr)
+
+	// The repo has an install.sh, but installCommand overrides it.
+	repoDir := setupLocalDotfilesRepo(t, "/tmp/autodetect-ran")
+
+	mgr := plugin.NewManager(slog.Default())
+	mgr.Register(dotfiles.New(globalconfig.DotfilesConfig{
+		Repository:     dotfilesSourceMount,
+		InstallCommand: "touch /tmp/custom-install-ran",
+	}))
+	e.SetPlugins(mgr)
+	e.SetRuntime(d.Runtime().String())
+
+	projectDir := t.TempDir()
+	devcontainerDir := filepath.Join(projectDir, ".devcontainer")
+	if err := os.MkdirAll(devcontainerDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(devcontainerDir, "Dockerfile"), []byte(dotfilesDockerfile), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(devcontainerDir, "devcontainer.json"), []byte(dotfilesDevcontainerConfig(repoDir)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	wsID := "test-engine-dotfiles-cmd"
+	ws := &workspace.Workspace{
+		ID:               wsID,
+		Source:           projectDir,
+		DevContainerPath: ".devcontainer/devcontainer.json",
+		CreatedAt:        time.Now(),
+		LastUsedAt:       time.Now(),
+	}
+
+	_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
+	t.Cleanup(func() {
+		_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
+		cleanupWorkspaceImages(t, d, wsID)
+	})
+
+	result, err := e.Up(ctx, ws, UpOptions{})
+	if err != nil {
+		t.Fatalf("Up: %v", err)
+	}
+
+	// Verify installCommand ran.
+	var stdout bytes.Buffer
+	if err := d.ExecContainer(ctx, wsID, result.ContainerID, []string{"test", "-f", "/tmp/custom-install-ran"}, nil, &stdout, nil, nil, ""); err != nil {
+		t.Error("installCommand did not run: /tmp/custom-install-ran not found")
+	}
+
+	// Verify install.sh was NOT auto-detected (installCommand takes precedence).
+	stdout.Reset()
+	if err := d.ExecContainer(ctx, wsID, result.ContainerID, []string{"test", "-f", "/tmp/autodetect-ran"}, nil, &stdout, nil, nil, ""); err == nil {
+		t.Error("install.sh should not have run when installCommand is set")
+	}
+}

--- a/internal/engine/dotfiles_integration_test.go
+++ b/internal/engine/dotfiles_integration_test.go
@@ -126,17 +126,15 @@ func TestIntegrationDotfilesPlugin(t *testing.T) {
 	}
 
 	// Verify the repo was cloned to the default target path.
-	var stdout, stderr bytes.Buffer
-	if err := d.ExecContainer(ctx, wsID, result.ContainerID, []string{"test", "-d", "/root/dotfiles"}, nil, &stdout, &stderr, nil, ""); err != nil {
-		// Dump diagnostics to understand Podman CI failures.
-		var diag bytes.Buffer
-		_ = d.ExecContainer(ctx, wsID, result.ContainerID, []string{"ls", "-la", "/root/"}, nil, &diag, &diag, nil, "")
-		t.Errorf("dotfiles not cloned: /root/dotfiles not found\ncontainer=%s\nstderr=%s\n/root/ listing:\n%s", result.ContainerID, stderr.String(), diag.String())
+	// Use "root" user to match remoteUser (Podman rootless defaults to a non-root user).
+	var stdout bytes.Buffer
+	if err := d.ExecContainer(ctx, wsID, result.ContainerID, []string{"test", "-d", "/root/dotfiles"}, nil, &stdout, nil, nil, "root"); err != nil {
+		t.Error("dotfiles not cloned: /root/dotfiles not found")
 	}
 
 	// Verify install.sh was auto-detected and executed.
 	stdout.Reset()
-	if err := d.ExecContainer(ctx, wsID, result.ContainerID, []string{"test", "-f", "/tmp/dotfiles-installed"}, nil, &stdout, nil, nil, ""); err != nil {
+	if err := d.ExecContainer(ctx, wsID, result.ContainerID, []string{"test", "-f", "/tmp/dotfiles-installed"}, nil, &stdout, nil, nil, "root"); err != nil {
 		t.Error("install.sh did not run: /tmp/dotfiles-installed not found")
 	}
 }
@@ -195,13 +193,13 @@ func TestIntegrationDotfilesPluginInstallCommand(t *testing.T) {
 
 	// Verify installCommand ran.
 	var stdout bytes.Buffer
-	if err := d.ExecContainer(ctx, wsID, result.ContainerID, []string{"test", "-f", "/tmp/custom-install-ran"}, nil, &stdout, nil, nil, ""); err != nil {
+	if err := d.ExecContainer(ctx, wsID, result.ContainerID, []string{"test", "-f", "/tmp/custom-install-ran"}, nil, &stdout, nil, nil, "root"); err != nil {
 		t.Error("installCommand did not run: /tmp/custom-install-ran not found")
 	}
 
 	// Verify install.sh was NOT auto-detected (installCommand takes precedence).
 	stdout.Reset()
-	if err := d.ExecContainer(ctx, wsID, result.ContainerID, []string{"test", "-f", "/tmp/autodetect-ran"}, nil, &stdout, nil, nil, ""); err == nil {
+	if err := d.ExecContainer(ctx, wsID, result.ContainerID, []string{"test", "-f", "/tmp/autodetect-ran"}, nil, &stdout, nil, nil, "root"); err == nil {
 		t.Error("install.sh should not have run when installCommand is set")
 	}
 }

--- a/internal/engine/dotfiles_integration_test.go
+++ b/internal/engine/dotfiles_integration_test.go
@@ -126,9 +126,12 @@ func TestIntegrationDotfilesPlugin(t *testing.T) {
 	}
 
 	// Verify the repo was cloned to the default target path.
-	var stdout bytes.Buffer
-	if err := d.ExecContainer(ctx, wsID, result.ContainerID, []string{"test", "-d", "/root/dotfiles"}, nil, &stdout, nil, nil, ""); err != nil {
-		t.Error("dotfiles not cloned: /root/dotfiles not found")
+	var stdout, stderr bytes.Buffer
+	if err := d.ExecContainer(ctx, wsID, result.ContainerID, []string{"test", "-d", "/root/dotfiles"}, nil, &stdout, &stderr, nil, ""); err != nil {
+		// Dump diagnostics to understand Podman CI failures.
+		var diag bytes.Buffer
+		_ = d.ExecContainer(ctx, wsID, result.ContainerID, []string{"ls", "-la", "/root/"}, nil, &diag, &diag, nil, "")
+		t.Errorf("dotfiles not cloned: /root/dotfiles not found\ncontainer=%s\nstderr=%s\n/root/ listing:\n%s", result.ContainerID, stderr.String(), diag.String())
 	}
 
 	// Verify install.sh was auto-detected and executed.

--- a/internal/engine/dotfiles_integration_test.go
+++ b/internal/engine/dotfiles_integration_test.go
@@ -90,7 +90,6 @@ func TestIntegrationDotfilesPlugin(t *testing.T) {
 	mgr := plugin.NewManager(slog.Default())
 	mgr.Register(dotfiles.New(globalconfig.DotfilesConfig{
 		Repository: dotfilesSourceMount,
-		// TargetPath defaults to ~/dotfiles -> /root/dotfiles (root user)
 	}))
 	e.SetPlugins(mgr)
 	e.SetRuntime(d.Runtime().String())

--- a/internal/engine/dotfiles_integration_test.go
+++ b/internal/engine/dotfiles_integration_test.go
@@ -59,14 +59,19 @@ func setupLocalDotfilesRepo(t *testing.T, installMarker string) string {
 
 // dotfilesDevcontainerConfig returns a devcontainer.json that builds a git-enabled
 // image and mounts repoDir at dotfilesSourceMount (read-only).
-// onCreateCommand sets safe.directory before the dotfiles plugin runs: the bind-mounted
-// repo is owned by the host user but the container runs as root, which triggers git's
-// dubious-ownership check without this config.
+// GIT_CONFIG_* env vars bypass the dubious-ownership check without writing to
+// ~/.gitconfig: the bind-mounted repo is owned by the host user, which git rejects
+// when the container runs as a different user. Using env vars avoids the file write
+// and works regardless of home directory permissions.
 func dotfilesDevcontainerConfig(repoDir string) string {
 	return fmt.Sprintf(`{
 		"build": {"dockerfile": "Dockerfile"},
 		"overrideCommand": true,
-		"onCreateCommand": "git config --global safe.directory '*'",
+		"containerEnv": {
+			"GIT_CONFIG_COUNT": "1",
+			"GIT_CONFIG_KEY_0": "safe.directory",
+			"GIT_CONFIG_VALUE_0": "*"
+		},
 		"mounts": ["source=%s,target=%s,type=bind,readonly=true"]
 	}`, repoDir, dotfilesSourceMount)
 }


### PR DESCRIPTION
## Summary

- Add `dotfiles.repository`, `dotfiles.targetPath`, `dotfiles.installCommand` keys to `.cribrc` for per-project dotfiles configuration
- Add `dotfiles = false` to `.cribrc` to suppress the plugin for a project even when globally configured
- Per-project settings override individual fields from global config; having `dotfiles.repository` in `.cribrc` enables the plugin for that project without a global config file
- Integration tests for clone + auto-detect install script and explicit `installCommand`

## Use cases

**Enable dotfiles for a single project** (no global config needed):
```ini
# .cribrc
dotfiles.repository = git@github.com:you/dotfiles
```

**Disable for a specific project** (e.g. the dotfiles repo itself):
```ini
# .cribrc
dotfiles = false
```

## Notes

- Finer-grained control (global `disabled` flag + per-project opt-in) left as a roadmap item