### PR TITLE
fix(driver): allow runArgs --name to override container name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `crib doctor --fix` no longer deletes containers belonging to a different
   `CRIB_HOME`.
 - Integration and e2e tests no longer interfere with active workspaces.
+- `runArgs: ["--name", "..."]` in `devcontainer.json` no longer causes a
+  duplicate `--name` flag error. The user-specified name now overrides crib's
+  default container name. See [#35](https://github.com/fgrehm/crib/issues/35).
 
 ## [0.7.1] - 2026-03-25
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,6 +11,10 @@ Items move between sections as priorities shift.
 
 Detect project type (Ruby, Node, Go, etc.) from conventions and generate a working devcontainer config without the user writing one. See the [RFC](https://github.com/fgrehm/crib/blob/main/docs/rfcs/init.md) for the full design.
 
+### Display actual container name when overridden via `runArgs`
+
+As of v0.8.0, `runArgs: ["--name", "my-container"]` correctly overrides crib's default container name ([#35](https://github.com/fgrehm/crib/issues/35)). However, CLI output (`crib up`, `crib status`, `crib restart`, `crib rebuild`) still displays the default `crib-{id}` name. Fixing this requires threading the actual container name through `UpResult`/`RestartResult` and updating the display sites in `cmd/`. The plugin request's `ContainerName` field should also reflect the override.
+
 ## Considering
 
 ### Features

--- a/internal/driver/oci/container.go
+++ b/internal/driver/oci/container.go
@@ -73,6 +73,8 @@ func (d *OCIDriver) buildRunArgs(workspaceID string, opts *driver.RunOptions) []
 		if userName != "" {
 			name = userName
 			d.logger.Warn("runArgs overrides container name, CLI output may still show the default", "name", userName)
+		} else {
+			d.logger.Warn("runArgs specifies --name without a value, using default container name", "name", name)
 		}
 	}
 

--- a/internal/driver/oci/container.go
+++ b/internal/driver/oci/container.go
@@ -64,13 +64,16 @@ func (d *OCIDriver) RunContainer(ctx context.Context, workspaceID string, option
 // buildRunArgs constructs the `docker run` argument list.
 func (d *OCIDriver) buildRunArgs(workspaceID string, opts *driver.RunOptions) []string {
 	// Allow runArgs to override the container name. If --name is present in
-	// ExtraArgs, use it instead of crib's default naming scheme.
+	// ExtraArgs, always strip it to avoid duplicate flags; use the value as
+	// the container name when non-empty.
 	extraArgs := opts.ExtraArgs
 	name := ContainerName(workspaceID)
-	if userName, rest := extractName(extraArgs); userName != "" {
-		name = userName
+	if userName, rest := extractName(extraArgs); rest != nil {
 		extraArgs = rest
-		d.logger.Warn("runArgs overrides container name, CLI output may still show the default", "name", userName)
+		if userName != "" {
+			name = userName
+			d.logger.Warn("runArgs overrides container name, CLI output may still show the default", "name", userName)
+		}
 	}
 
 	args := []string{"run", "-d", "--name", name}
@@ -344,8 +347,24 @@ func hasUsernsArg(args []string) bool {
 }
 
 // extractName removes --name/--name=value from args and returns the extracted
-// name plus the remaining args. Returns ("", nil) if no --name is present.
+// name plus the remaining args. Returns ("", nil) if no --name flag is present.
+// When --name is found, rest is always non-nil (even if empty or value is blank),
+// so callers can use rest != nil to detect presence independent of the value.
 func extractName(args []string) (name string, rest []string) {
+	// First pass: check presence before allocating.
+	found := false
+	for _, a := range args {
+		if a == "--name" || strings.HasPrefix(a, "--name=") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return "", nil
+	}
+
+	// Second pass: extract value and strip all --name tokens.
+	rest = make([]string, 0, len(args))
 	i := 0
 	for i < len(args) {
 		a := args[i]
@@ -366,9 +385,6 @@ func extractName(args []string) (name string, rest []string) {
 		}
 		rest = append(rest, a)
 		i++
-	}
-	if name == "" {
-		return "", nil
 	}
 	return
 }

--- a/internal/driver/oci/container.go
+++ b/internal/driver/oci/container.go
@@ -63,7 +63,15 @@ func (d *OCIDriver) RunContainer(ctx context.Context, workspaceID string, option
 
 // buildRunArgs constructs the `docker run` argument list.
 func (d *OCIDriver) buildRunArgs(workspaceID string, opts *driver.RunOptions) []string {
+	// Allow runArgs to override the container name. If --name is present in
+	// ExtraArgs, use it instead of crib's default naming scheme.
+	extraArgs := opts.ExtraArgs
 	name := ContainerName(workspaceID)
+	if userName, rest := extractName(extraArgs); userName != "" {
+		name = userName
+		extraArgs = rest
+		d.logger.Warn("runArgs overrides container name, CLI output may still show the default", "name", userName)
+	}
 
 	args := []string{"run", "-d", "--name", name}
 
@@ -120,12 +128,12 @@ func (d *OCIDriver) buildRunArgs(workspaceID string, opts *driver.RunOptions) []
 	// Auto-inject --userns=keep-id for rootless Podman to fix bind mount
 	// permissions. This maps the host UID to the same UID inside the
 	// container, so workspace files have correct ownership for non-root users.
-	if d.runtime == RuntimePodman && getuid() != 0 && !hasUsernsArg(opts.ExtraArgs) {
+	if d.runtime == RuntimePodman && getuid() != 0 && !hasUsernsArg(extraArgs) {
 		args = append(args, "--userns=keep-id")
 	}
 
 	// Passthrough CLI args from runArgs.
-	args = append(args, opts.ExtraArgs...)
+	args = append(args, extraArgs...)
 
 	// Image (required).
 	args = append(args, opts.Image)
@@ -333,6 +341,36 @@ func hasUsernsArg(args []string) bool {
 		}
 	}
 	return false
+}
+
+// extractName removes --name/--name=value from args and returns the extracted
+// name plus the remaining args. Returns ("", nil) if no --name is present.
+func extractName(args []string) (name string, rest []string) {
+	i := 0
+	for i < len(args) {
+		a := args[i]
+		// --name=value
+		if strings.HasPrefix(a, "--name=") {
+			name = a[len("--name="):]
+			i++
+			continue
+		}
+		// --name value
+		if a == "--name" {
+			i++
+			if i < len(args) {
+				name = args[i]
+				i++
+			}
+			continue
+		}
+		rest = append(rest, a)
+		i++
+	}
+	if name == "" {
+		return "", nil
+	}
+	return
 }
 
 // appendFlags appends "--flag value" pairs to args for each value in values.

--- a/internal/driver/oci/container.go
+++ b/internal/driver/oci/container.go
@@ -374,10 +374,10 @@ func extractName(args []string) (name string, rest []string) {
 			i++
 			continue
 		}
-		// --name value
+		// --name value (only consume next token if it looks like a value, not a flag)
 		if a == "--name" {
 			i++
-			if i < len(args) {
+			if i < len(args) && !strings.HasPrefix(args[i], "-") {
 				name = args[i]
 				i++
 			}

--- a/internal/driver/oci/container_test.go
+++ b/internal/driver/oci/container_test.go
@@ -359,6 +359,12 @@ func TestExtractName(t *testing.T) {
 			wantName: "second",
 			wantRest: []string{"--network=host"},
 		},
+		{
+			name:     "name followed by another flag is not consumed",
+			args:     []string{"--name", "--network=host"},
+			wantName: "",
+			wantRest: []string{"--network=host"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/driver/oci/container_test.go
+++ b/internal/driver/oci/container_test.go
@@ -335,12 +335,40 @@ func TestExtractName(t *testing.T) {
 			wantName: "",
 			wantRest: nil,
 		},
+		{
+			name:     "empty value equals form",
+			args:     []string{"--name=", "--network=host"},
+			wantName: "",
+			wantRest: []string{"--network=host"},
+		},
+		{
+			name:     "dangling name at end",
+			args:     []string{"--network=host", "--name"},
+			wantName: "",
+			wantRest: []string{"--network=host"},
+		},
+		{
+			name:     "dangling name only",
+			args:     []string{"--name"},
+			wantName: "",
+			wantRest: []string{},
+		},
+		{
+			name:     "multiple name flags last wins",
+			args:     []string{"--name", "first", "--name=second", "--network=host"},
+			wantName: "second",
+			wantRest: []string{"--network=host"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			name, rest := extractName(tt.args)
 			if name != tt.wantName {
 				t.Errorf("name = %q, want %q", name, tt.wantName)
+			}
+			if (rest == nil) != (tt.wantRest == nil) {
+				t.Errorf("rest nil-ness: got %v (nil=%v), want nil=%v", rest, rest == nil, tt.wantRest == nil)
+				return
 			}
 			if len(rest) != len(tt.wantRest) {
 				t.Errorf("rest = %v, want %v", rest, tt.wantRest)

--- a/internal/driver/oci/container_test.go
+++ b/internal/driver/oci/container_test.go
@@ -258,6 +258,103 @@ func TestBuildRunArgs_ExtraArgsPassthrough(t *testing.T) {
 	}
 }
 
+func TestBuildRunArgs_UserNameOverridesDefault(t *testing.T) {
+	d := newTestDockerDriver()
+
+	opts := &driver.RunOptions{
+		Image:     "alpine",
+		ExtraArgs: []string{"--network=host", "--name", "my-container", "--gpus", "all"},
+	}
+
+	args := d.buildRunArgs("ws1", opts)
+	got := strings.Join(args, " ")
+
+	// User-specified name wins over crib's default.
+	assertContains(t, got, "--name my-container")
+	if strings.Contains(got, "crib-ws1") {
+		t.Errorf("crib default name should not appear, got: %s", got)
+	}
+	// Other extra args are preserved.
+	assertContains(t, got, "--network=host")
+	assertContains(t, got, "--gpus all")
+	// Workspace label is still present (lookup depends on it).
+	assertContains(t, got, "--label crib.workspace=ws1")
+}
+
+func TestBuildRunArgs_UserNameEqualsForm(t *testing.T) {
+	d := newTestDockerDriver()
+
+	opts := &driver.RunOptions{
+		Image:     "alpine",
+		ExtraArgs: []string{"--name=my-container"},
+	}
+
+	args := d.buildRunArgs("ws1", opts)
+	got := strings.Join(args, " ")
+
+	assertContains(t, got, "--name my-container")
+	if strings.Count(got, "--name") != 1 {
+		t.Errorf("expected exactly one --name flag, got: %s", got)
+	}
+}
+
+func TestExtractName(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		wantName string
+		wantRest []string
+	}{
+		{
+			name:     "no name flag",
+			args:     []string{"--network=host", "--gpus", "all"},
+			wantName: "",
+			wantRest: nil,
+		},
+		{
+			name:     "name as two tokens",
+			args:     []string{"--name", "my-container", "--network=host"},
+			wantName: "my-container",
+			wantRest: []string{"--network=host"},
+		},
+		{
+			name:     "name with equals",
+			args:     []string{"--name=my-container", "--network=host"},
+			wantName: "my-container",
+			wantRest: []string{"--network=host"},
+		},
+		{
+			name:     "name at end",
+			args:     []string{"--network=host", "--name", "my-container"},
+			wantName: "my-container",
+			wantRest: []string{"--network=host"},
+		},
+		{
+			name:     "empty args",
+			args:     nil,
+			wantName: "",
+			wantRest: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name, rest := extractName(tt.args)
+			if name != tt.wantName {
+				t.Errorf("name = %q, want %q", name, tt.wantName)
+			}
+			if len(rest) != len(tt.wantRest) {
+				t.Errorf("rest = %v, want %v", rest, tt.wantRest)
+				return
+			}
+			for i := range rest {
+				if rest[i] != tt.wantRest[i] {
+					t.Errorf("rest[%d] = %q, want %q", i, rest[i], tt.wantRest[i])
+				}
+			}
+		})
+	}
+}
+
 func TestParseLines(t *testing.T) {
 	tests := []struct {
 		input string


### PR DESCRIPTION
## Summary

- When `devcontainer.json` includes `runArgs: ["--name", "my-container"]`, crib now uses the user-specified name instead of the default `crib-<workspace>`. Previously both names were passed to `docker run`, causing a duplicate `--name` flag error (exit 125).
- Handles both `--name value` and `--name=value` forms.
- Logs a warning since CLI output does not yet reflect the override (follow-up tracked in roadmap).

Ref: #35

## Test plan

- [x] Unit tests for `extractName` (both flag forms, positional variants, nil input)
- [x] Unit tests for `buildRunArgs` with user-specified `--name` (override applied, default name absent, workspace label preserved)
- [x] Full test suite passes (`make test`, `make lint`)
- [ ] Manual test with `runArgs: ["--name", "my-container"]` in `devcontainer.json`