### PR TITLE
fix: pre-release bugs for v0.8.0

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,9 +26,6 @@ archives:
 checksum:
   name_template: checksums.txt
 
-changelog:
-  disable: true
-
 release:
   github:
     owner: fgrehm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-04-07
+
 ### Added
 
 - `crib stop` command: non-destructive container stop that preserves hook
   markers. The next `crib up` resumes with only start-time hooks.
 - **Dotfiles plugin**: clones and installs a dotfiles repository inside the
-  container on creation. Configured via global config. Supports custom target
-  path, install command override, and auto-detection of common install scripts.
-  Per-project overrides and opt-out via `.cribrc` (`dotfiles.repository`,
-  `dotfiles.targetPath`, `dotfiles.installCommand`, `dotfiles = false`).
-  See [#17](https://github.com/fgrehm/crib/issues/17).
+  container on creation. Configured via global config (`~/.config/crib/config.toml`).
+  Supports custom target path, install command override, and auto-detection of
+  common install scripts. Per-project overrides and opt-out via `.cribrc`
+  (`dotfiles.repository`, `dotfiles.targetPath`, `dotfiles.installCommand`,
+  `dotfiles = false`). See [#17](https://github.com/fgrehm/crib/issues/17).
 - **Global config** (`~/.config/crib/config.toml`, respects `$XDG_CONFIG_HOME`):
   user-level settings applied across all workspaces. Currently supports
   `[dotfiles]` configuration.
@@ -28,8 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `stop` is no longer an alias for `down`. `crib stop` pauses the container,
-  `crib down` removes it.
+- `stop` is no longer an alias for `down`. `crib stop` pauses the container
+  (preserving state), `crib down` removes it.
 - `crib.home` container label only applied when `CRIB_HOME` is explicitly set.
 - Compose override generation uses compose-go types instead of string
   concatenation.
@@ -41,8 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `crib down`, `crib stop`, and `crib remove` now return a clear error
   immediately when a compose workspace is detected but compose is not
-  installed, instead of silently falling through to single-container
-  cleanup.
+  installed, instead of silently falling through to single-container cleanup.
 - Invalid port numbers in container inspect output are now logged at
   `WARN` level instead of `DEBUG`, making them visible in `crib status`
   output without `--debug`.

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -252,9 +252,11 @@ func (e *Engine) Up(ctx context.Context, ws *workspace.Workspace, opts UpOptions
 // upExisting handles the case where a container already exists.
 func (e *Engine) upExisting(ctx context.Context, ws *workspace.Workspace, cfg *config.DevContainerConfig, workspaceFolder string, b containerBackend, container *driver.ContainerDetails) (*UpResult, error) {
 	// Load stored result for image name and feature entrypoints.
+	var storedResult *workspace.Result
 	var storedImageName string
 	var storedHasEntrypoints bool
 	if stored, err := e.store.LoadResult(ws.ID); err == nil && stored != nil {
+		storedResult = stored
 		storedImageName = stored.ImageName
 		storedHasEntrypoints = stored.HasFeatureEntrypoints
 	}
@@ -289,6 +291,8 @@ func (e *Engine) upExisting(ctx context.Context, ws *workspace.Workspace, cfg *c
 		imageName:      storedImageName,
 		hasEntrypoints: storedHasEntrypoints,
 		pluginResp:     pluginResp,
+		storedResult:   storedResult,
+		fromSnapshot:   storedResult != nil,
 	})
 }
 

--- a/internal/engine/plugin_test.go
+++ b/internal/engine/plugin_test.go
@@ -134,7 +134,7 @@ func TestExecPluginCopies(t *testing.T) {
 	if !strings.Contains(cmdStr, "chmod '0600'") {
 		t.Errorf("expected chmod '0600' in command, got: %s", cmdStr)
 	}
-	if !strings.Contains(cmdStr, "chown 'vscode' '/home/vscode/.config' '/home/vscode/.config/test.json'") {
+	if !strings.Contains(cmdStr, "chown 'vscode:vscode' '/home/vscode/.config' '/home/vscode/.config/test.json'") {
 		t.Errorf("expected chown of both dir and file in command, got: %s", cmdStr)
 	}
 }

--- a/internal/engine/plugin_test.go
+++ b/internal/engine/plugin_test.go
@@ -134,7 +134,7 @@ func TestExecPluginCopies(t *testing.T) {
 	if !strings.Contains(cmdStr, "chmod '0600'") {
 		t.Errorf("expected chmod '0600' in command, got: %s", cmdStr)
 	}
-	if !strings.Contains(cmdStr, "chown 'vscode:vscode' '/home/vscode/.config' '/home/vscode/.config/test.json'") {
+	if !strings.Contains(cmdStr, "chown 'vscode:' '/home/vscode/.config' '/home/vscode/.config/test.json'") {
 		t.Errorf("expected chown of both dir and file in command, got: %s", cmdStr)
 	}
 }

--- a/internal/engine/single.go
+++ b/internal/engine/single.go
@@ -275,7 +275,7 @@ func (e *Engine) execPluginCopies(ctx context.Context, cc containerContext, copi
 		}
 		if cp.User != "" {
 			owner := plugin.ShellQuote(cp.User)
-			writeCmd += fmt.Sprintf(" && chown '%s:%s' '%s' '%s'", owner, owner, dir, target)
+			writeCmd += fmt.Sprintf(" && chown '%s:' '%s' '%s'", owner, dir, target)
 		}
 
 		var shellCmd string

--- a/internal/engine/single.go
+++ b/internal/engine/single.go
@@ -274,7 +274,8 @@ func (e *Engine) execPluginCopies(ctx context.Context, cc containerContext, copi
 			writeCmd += fmt.Sprintf(" && chmod '%s' '%s'", plugin.ShellQuote(cp.Mode), target)
 		}
 		if cp.User != "" {
-			writeCmd += fmt.Sprintf(" && chown '%s' '%s' '%s'", plugin.ShellQuote(cp.User), dir, target)
+			owner := plugin.ShellQuote(cp.User)
+			writeCmd += fmt.Sprintf(" && chown '%s:%s' '%s' '%s'", owner, owner, dir, target)
 		}
 
 		var shellCmd string

--- a/internal/engine/single_test.go
+++ b/internal/engine/single_test.go
@@ -782,6 +782,103 @@ func TestUpExisting_FallsBackToContainerUser(t *testing.T) {
 	}
 }
 
+// commitTrackingDriver wraps fixedFindContainerDriver and tracks CommitContainer calls.
+type commitTrackingDriver struct {
+	fixedFindContainerDriver
+	commitCalls int
+}
+
+func (m *commitTrackingDriver) CommitContainer(_ context.Context, _, _, _ string, _ []string) error {
+	m.commitCalls++
+	return nil
+}
+
+func TestUpExisting_StoppedContainer_UsesResumePath(t *testing.T) {
+	store := workspace.NewStoreAt(t.TempDir())
+	ws := &workspace.Workspace{ID: "ws-stop-resume", Source: "/home/user/project"}
+	if err := store.Save(ws); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate a previous successful crib up by saving a result.
+	if err := store.SaveResult(ws.ID, &workspace.Result{
+		ImageName:     "ruby:3.2",
+		ContainerID:   "stopped-c",
+		RemoteUser:    "vscode",
+		RemoteEnv:     map[string]string{"PATH": "/usr/local/bin:/usr/bin"},
+		SnapshotImage: "crib-ws-stop-resume:snapshot",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	drv := &commitTrackingDriver{
+		fixedFindContainerDriver: fixedFindContainerDriver{
+			container: &driver.ContainerDetails{
+				ID:    "stopped-c",
+				State: driver.ContainerState{Status: "exited"},
+			},
+		},
+	}
+
+	// Track PostContainerCreate calls via a custom plugin.
+	postCreateCalled := false
+	tp := &postCreateTrackingPlugin{called: &postCreateCalled}
+	mgr := plugin.NewManager(slog.Default())
+	mgr.Register(tp)
+
+	eng := &Engine{
+		driver:      drv,
+		store:       store,
+		plugins:     mgr,
+		runtimeName: "docker",
+		logger:      slog.Default(),
+		stdout:      io.Discard,
+		stderr:      io.Discard,
+		progress:    func(ProgressEvent) {},
+	}
+
+	cfg := &config.DevContainerConfig{}
+	cfg.Image = "ruby:3.2"
+	cfg.RemoteUser = "vscode"
+
+	container := &driver.ContainerDetails{
+		ID:    "stopped-c",
+		State: driver.ContainerState{Status: "exited"},
+	}
+	b := eng.newBackend(ws, cfg, "/workspaces/project")
+	result, err := eng.upExisting(context.Background(), ws, cfg, "/workspaces/project", b, container)
+	if err != nil {
+		t.Fatalf("upExisting: %v", err)
+	}
+
+	if result.ContainerID != "stopped-c" {
+		t.Errorf("ContainerID = %q, want stopped-c", result.ContainerID)
+	}
+
+	// Resume path should NOT commit a new snapshot.
+	if drv.commitCalls > 0 {
+		t.Error("should not commit snapshot when resuming a stopped container")
+	}
+
+	// Resume path should NOT run PostContainerCreate plugins (e.g. dotfiles).
+	if postCreateCalled {
+		t.Error("PostContainerCreate should not run when resuming a stopped container")
+	}
+}
+
+// postCreateTrackingPlugin tracks whether PostContainerCreate was called.
+type postCreateTrackingPlugin struct {
+	plugin.BasePlugin
+	called *bool
+}
+
+func (p *postCreateTrackingPlugin) Name() string { return "post-create-tracker" }
+
+func (p *postCreateTrackingPlugin) PostContainerCreate(_ context.Context, _ *plugin.PostContainerCreateRequest) (*plugin.PostContainerCreateResponse, error) {
+	*p.called = true
+	return nil, nil
+}
+
 func TestConfigRemoteUser(t *testing.T) {
 	tests := []struct {
 		remoteUser    string

--- a/internal/plugin/dotfiles/plugin.go
+++ b/internal/plugin/dotfiles/plugin.go
@@ -46,6 +46,13 @@ func (p *Plugin) PostContainerCreate(ctx context.Context, req *plugin.PostContai
 	remoteHome := plugin.InferRemoteHome(req.RemoteUser)
 	targetPath := p.resolveTargetPath(remoteHome)
 
+	// Skip clone if the target directory already exists (e.g. resume after
+	// crib stop, where dotfiles were cloned during the initial crib up).
+	if _, err := req.Exec(ctx, []string{"test", "-d", targetPath}, req.RemoteUser, ""); err == nil {
+		slog.Debug("dotfiles: target directory already exists, skipping clone", "path", targetPath)
+		return nil, nil
+	}
+
 	// Clone the repository. Use accept-new so the first connection to a host
 	// (e.g. github.com) auto-accepts its key without a known_hosts entry.
 	cloneCmd := []string{"git", "clone", "--", p.cfg.Repository, targetPath}

--- a/internal/plugin/dotfiles/plugin_test.go
+++ b/internal/plugin/dotfiles/plugin_test.go
@@ -89,11 +89,11 @@ func TestPostContainerCreate_ClonesRepository(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(exec.calls) == 0 {
-		t.Fatal("expected at least one exec call for clone")
+	// Call order: which git (0), test -d (1), git clone (2).
+	if len(exec.calls) < 3 {
+		t.Fatalf("expected at least 3 exec calls, got %d", len(exec.calls))
 	}
 
-	// First call is which git, second is git clone.
 	cloneCmd := strings.Join(exec.calls[2].cmd, " ")
 	if !strings.Contains(cloneCmd, "git clone") {
 		t.Errorf("expected git clone command, got: %s", cloneCmd)

--- a/internal/plugin/dotfiles/plugin_test.go
+++ b/internal/plugin/dotfiles/plugin_test.go
@@ -23,6 +23,10 @@ type fakeExecCall struct {
 
 func (f *fakeExec) fn(_ context.Context, cmd []string, user string, workDir string) ([]byte, error) {
 	f.calls = append(f.calls, fakeExecCall{cmd: cmd, user: user, workDir: workDir})
+	// "test -d" should fail by default (directory doesn't exist yet).
+	if len(cmd) >= 2 && cmd[0] == "test" && cmd[1] == "-d" {
+		return nil, &fakeError{}
+	}
 	return nil, nil
 }
 
@@ -90,7 +94,7 @@ func TestPostContainerCreate_ClonesRepository(t *testing.T) {
 	}
 
 	// First call is which git, second is git clone.
-	cloneCmd := strings.Join(exec.calls[1].cmd, " ")
+	cloneCmd := strings.Join(exec.calls[2].cmd, " ")
 	if !strings.Contains(cloneCmd, "git clone") {
 		t.Errorf("expected git clone command, got: %s", cloneCmd)
 	}
@@ -101,8 +105,8 @@ func TestPostContainerCreate_ClonesRepository(t *testing.T) {
 	if !strings.Contains(cloneCmd, "/home/vscode/dotfiles") {
 		t.Errorf("expected default target path, got: %s", cloneCmd)
 	}
-	if exec.calls[1].user != "vscode" {
-		t.Errorf("expected user vscode, got %s", exec.calls[1].user)
+	if exec.calls[2].user != "vscode" {
+		t.Errorf("expected user vscode, got %s", exec.calls[2].user)
 	}
 }
 
@@ -118,7 +122,7 @@ func TestPostContainerCreate_SSHRepo_AcceptsNewHostKey(t *testing.T) {
 	}
 
 	// Clone via SSH should use sh -c with GIT_SSH_COMMAND.
-	cloneCmd := strings.Join(exec.calls[1].cmd, " ")
+	cloneCmd := strings.Join(exec.calls[2].cmd, " ")
 	if !strings.Contains(cloneCmd, "StrictHostKeyChecking=accept-new") {
 		t.Errorf("expected StrictHostKeyChecking=accept-new for SSH repo, got: %s", cloneCmd)
 	}
@@ -139,7 +143,7 @@ func TestPostContainerCreate_CustomTargetPath(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	cloneCmd := strings.Join(exec.calls[1].cmd, " ")
+	cloneCmd := strings.Join(exec.calls[2].cmd, " ")
 	if !strings.Contains(cloneCmd, "/home/vscode/my-dotfiles") {
 		t.Errorf("expected custom target path with tilde expanded, got: %s", cloneCmd)
 	}
@@ -156,12 +160,12 @@ func TestPostContainerCreate_RootUser(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	cloneCmd := strings.Join(exec.calls[1].cmd, " ")
+	cloneCmd := strings.Join(exec.calls[2].cmd, " ")
 	if !strings.Contains(cloneCmd, "/root/dotfiles") {
 		t.Errorf("expected root home path, got: %s", cloneCmd)
 	}
-	if exec.calls[1].user != "root" {
-		t.Errorf("expected user root, got %s", exec.calls[1].user)
+	if exec.calls[2].user != "root" {
+		t.Errorf("expected user root, got %s", exec.calls[2].user)
 	}
 }
 
@@ -177,6 +181,10 @@ func TestPostContainerCreate_AutoDetectsInstallScript(t *testing.T) {
 		// which git succeeds.
 		if cmd[0] == "which" {
 			return nil, nil
+		}
+		// test -d (directory exists check) fails (not cloned yet).
+		if len(cmd) >= 2 && cmd[0] == "test" && cmd[1] == "-d" {
+			return nil, &fakeError{}
 		}
 		// For test -f checks, succeed on install.sh only.
 		if strings.Contains(cmdStr, "test -f") && strings.Contains(cmdStr, "install.sh") {
@@ -219,18 +227,18 @@ func TestPostContainerCreate_InstallCommandOverride(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Should have which git (exec) + clone (stream) + install (stream).
-	if len(exec.calls) != 3 {
-		t.Fatalf("expected 3 exec calls (which + clone + install), got %d", len(exec.calls))
+	// Should have which git (exec) + test -d (exec) + clone (stream) + install (stream).
+	if len(exec.calls) != 4 {
+		t.Fatalf("expected 4 exec calls (which + test -d + clone + install), got %d", len(exec.calls))
 	}
 
-	installCmd := strings.Join(exec.calls[2].cmd, " ")
+	installCmd := strings.Join(exec.calls[3].cmd, " ")
 	if !strings.Contains(installCmd, "make install") {
 		t.Errorf("expected install command override, got: %s", installCmd)
 	}
 	// Install should run in the target directory.
-	if exec.calls[2].workDir != "/home/vscode/dotfiles" {
-		t.Errorf("expected workDir /home/vscode/dotfiles, got %s", exec.calls[2].workDir)
+	if exec.calls[3].workDir != "/home/vscode/dotfiles" {
+		t.Errorf("expected workDir /home/vscode/dotfiles, got %s", exec.calls[3].workDir)
 	}
 }
 
@@ -246,9 +254,45 @@ func TestPostContainerCreate_AbsoluteTargetPath(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	cloneCmd := strings.Join(exec.calls[1].cmd, " ")
+	cloneCmd := strings.Join(exec.calls[2].cmd, " ")
 	if !strings.Contains(cloneCmd, "/opt/dotfiles") {
 		t.Errorf("expected absolute target path, got: %s", cloneCmd)
+	}
+}
+
+func TestPostContainerCreate_SkipsCloneWhenTargetExists(t *testing.T) {
+	p := New(globalconfig.DotfilesConfig{
+		Repository: "https://github.com/user/dotfiles",
+	})
+
+	execFn := func(_ context.Context, cmd []string, _ string, _ string) ([]byte, error) {
+		if cmd[0] == "which" {
+			return nil, nil
+		}
+		// test -d succeeds: directory already exists.
+		if len(cmd) >= 2 && cmd[0] == "test" && cmd[1] == "-d" {
+			return nil, nil
+		}
+		t.Fatalf("unexpected exec call: %v", cmd)
+		return nil, nil
+	}
+
+	var streamCalls int
+	streamFn := func(_ context.Context, _ []string, _ string, _ string, _, _ io.Writer) error {
+		streamCalls++
+		return nil
+	}
+
+	_, err := p.PostContainerCreate(context.Background(), &plugin.PostContainerCreateRequest{
+		RemoteUser: "vscode",
+		Exec:       execFn,
+		StreamExec: streamFn,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if streamCalls > 0 {
+		t.Error("should not clone or run install when target directory already exists")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fix `crib up` after `crib stop` running full setup instead of resume path (re-cloning dotfiles, committing snapshot)
- Fix plugin file copies (SSH keys, config) having root group ownership
- Add defense-in-depth: dotfiles plugin skips clone when target directory already exists
- Move changelog [Unreleased] to [0.8.0]

## Test plan

- [x] Unit tests pass (`go test ./internal/... -short`)
- [x] Lint and deadcode clean
- [x] New regression tests for all three bugs