### PR TITLE
fix: spec compliance for remoteUser resolution

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -64,12 +64,19 @@ the regex definition before flagging injection concerns.
 
 ## Go Version
 
-This project requires Go 1.26+ (see `go.mod`). Modern Go features are used
-throughout the codebase:
+This project requires Go 1.26+ (see `go.mod`). The minimum version is
+enforced by `go.mod` and CI. Do not flag Go 1.22+ features as compatibility
+issues; backwards compatibility with older Go versions is not a concern.
 
-- `for i := range n` (integer range) is valid and idiomatic. Do not flag it
-  as a compilation error or suggest rewriting to `for i := 0; i < n; i++`.
-- `range` over function iterators may also appear.
+Modern Go features are used throughout the codebase:
+
+- `for i := range n` (integer range, Go 1.22+): **valid and enforced by the
+  `intrange` linter**. The pre-commit hook rewrites `for i := 0; i < n; i++`
+  to `for i := range n` automatically. Do not flag this form or suggest
+  reverting it to the old style.
+- `range` over function iterators (Go 1.23+) may also appear.
+- `strings.Cut`, `slices.*`, `maps.*` and other stdlib additions are used
+  freely without compatibility shims.
 
 ## Conventions
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,7 @@ jobs:
         working-directory: website
       - run: npm run build
         working-directory: website
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: website/dist
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in `result.json` at `crib up` time. Changes to `remoteUser` take effect
   without a rebuild.
 - `remoteUser` and `containerUser` are now inferred from the image when
-  `devcontainer.json` does not set them explicitly. Pre-built images that carry
-  a `devcontainer.metadata` label (e.g.
+  `devcontainer.json` does not set them explicitly. Per the devcontainers spec,
+  `containerUser` and `remoteUser` are resolved independently from the
+  `devcontainer.metadata` label (each following "last value wins" merge), with
+  `Config.User` as the final fallback. Pre-built images that carry a
+  `devcontainer.metadata` label (e.g.
   `mcr.microsoft.com/devcontainers/javascript-node` sets `remoteUser: "node"`)
-  have their metadata merged as the spec requires. Images built from a
-  Dockerfile with a `USER` instruction now have that user reflected in
-  `remoteUser` automatically.
+  now correctly use the label user instead of `Config.User` (often `root`) for
+  feature context and plugin dispatch. Images built from a Dockerfile with a
+  `USER` instruction have that user reflected in `remoteUser` automatically.
+- Plugin user dispatch now threads image-derived and stored-result fallbacks
+  through both single-container and compose backends. On restart recreate,
+  `storedResult.RemoteUser` is used as a last fallback when image inspection
+  yields no user, preserving prior user resolution instead of falling back to
+  empty.
 
 ## [0.8.0] - 2026-04-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `crib shell`, `crib exec`, and `crib run` now re-read `remoteUser` from the
+  live `devcontainer.json` on each invocation instead of using the value cached
+  in `result.json` at `crib up` time. Changes to `remoteUser` take effect
+  without a rebuild.
+- `remoteUser` and `containerUser` are now inferred from the image when
+  `devcontainer.json` does not set them explicitly. Pre-built images that carry
+  a `devcontainer.metadata` label (e.g.
+  `mcr.microsoft.com/devcontainers/javascript-node` sets `remoteUser: "node"`)
+  have their metadata merged as the spec requires. Images built from a
+  Dockerfile with a `USER` instruction now have that user reflected in
+  `remoteUser` automatically.
+
 ## [0.8.0] - 2026-04-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,25 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+#### Spec-compliant `remoteUser` / `containerUser` resolution
+
 - `crib shell`, `crib exec`, and `crib run` now re-read `remoteUser` from the
-  live `devcontainer.json` on each invocation instead of using the value cached
-  in `result.json` at `crib up` time. Changes to `remoteUser` take effect
-  without a rebuild.
+  live `devcontainer.json` on each invocation. Changes take effect without a
+  rebuild.
 - `remoteUser` and `containerUser` are now inferred from the image when
-  `devcontainer.json` does not set them explicitly. Per the devcontainers spec,
-  `containerUser` and `remoteUser` are resolved independently from the
-  `devcontainer.metadata` label (each following "last value wins" merge), with
-  `Config.User` as the final fallback. Pre-built images that carry a
+  `devcontainer.json` does not set them explicitly. Resolution follows the spec:
+  config wins, then `devcontainer.metadata` label (last-wins merge), then
+  Dockerfile `USER` / `Config.User`. Pre-built images that carry a
   `devcontainer.metadata` label (e.g.
   `mcr.microsoft.com/devcontainers/javascript-node` sets `remoteUser: "node"`)
-  now correctly use the label user instead of `Config.User` (often `root`) for
-  feature context and plugin dispatch. Images built from a Dockerfile with a
-  `USER` instruction have that user reflected in `remoteUser` automatically.
-- Plugin user dispatch now threads image-derived and stored-result fallbacks
-  through both single-container and compose backends. On restart recreate,
-  `storedResult.RemoteUser` is used as a last fallback when image inspection
-  yields no user, preserving prior user resolution instead of falling back to
-  empty.
+  now correctly use the label user for feature context and plugin dispatch.
+- `containerUser` and `remoteUser` are resolved independently -- neither falls
+  back to the other except `remoteUser` → `containerUser` (one direction only,
+  per spec).
+- Resume and restart recreate paths preserve a previously-inferred `remoteUser`
+  instead of silently falling back to `root` when image inspection yields no
+  metadata.
 
 ## [0.8.0] - 2026-04-07
 

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -59,8 +59,11 @@ Use -- to separate crib flags from the container command:
 		// Inject remoteEnv variables (before user-specified --env so user flags take precedence).
 		result, _ := store.LoadResult(ws.ID)
 
-		// Determine user: explicit --user flag takes precedence, then remoteUser from config.
+		// Determine user: explicit --user flag, then live config, then stored result.
 		user, _ := cmd.Flags().GetString("user")
+		if user == "" {
+			user = liveRemoteUser(ws)
+		}
 		if user == "" && result != nil {
 			user = result.RemoteUser
 		}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -64,6 +64,9 @@ Use -- to separate crib flags from the container command:
 		result, _ := store.LoadResult(ws.ID)
 
 		user, _ := cmd.Flags().GetString("user")
+		if user == "" {
+			user = liveRemoteUser(ws)
+		}
 		if user == "" && result != nil {
 			user = result.RemoteUser
 		}

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -67,8 +67,15 @@ Working directory is set to the workspace folder if available.`,
 
 		// Inject remoteEnv variables and set working directory from saved result.
 		result, _ := store.LoadResult(ws.ID)
-		if result != nil && result.RemoteUser != "" {
-			execArgs = append(execArgs, "-u", result.RemoteUser)
+
+		// Prefer remoteUser from current devcontainer.json; fall back to stored result.
+		// This ensures edits to remoteUser take effect without rebuilding.
+		remoteUser := liveRemoteUser(ws)
+		if remoteUser == "" && result != nil {
+			remoteUser = result.RemoteUser
+		}
+		if remoteUser != "" {
+			execArgs = append(execArgs, "-u", remoteUser)
 		}
 		execArgs = appendRemoteEnv(execArgs, result)
 		if result != nil && result.WorkspaceFolder != "" {

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -37,7 +36,7 @@ func liveRemoteUser(ws *workspace.Workspace) string {
 		DevContainerID:           ws.ID,
 		LocalWorkspaceFolder:     ws.Source,
 		ContainerWorkspaceFolder: workspaceFolder,
-		Env:                      envMap(),
+		Env:                      config.EnvMap(),
 	}
 
 	cfg, err = config.Substitute(subCtx, cfg)
@@ -55,18 +54,4 @@ func liveRemoteUser(ws *workspace.Workspace) string {
 		return cfg.ContainerUser
 	}
 	return ""
-}
-
-// envMap returns the current process environment as a map.
-func envMap() map[string]string {
-	env := make(map[string]string, len(os.Environ()))
-	for _, e := range os.Environ() {
-		for i := range len(e) {
-			if e[i] == '=' {
-				env[e[:i]] = e[i+1:]
-				break
-			}
-		}
-	}
-	return env
 }

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"os"
 	"path/filepath"
 
 	"github.com/fgrehm/crib/internal/config"
@@ -17,8 +18,30 @@ func liveRemoteUser(ws *workspace.Workspace) string {
 	if err != nil {
 		return ""
 	}
-	if cfg.RemoteUser != "" {
-		return cfg.RemoteUser
+	subCtx := &config.SubstitutionContext{
+		DevContainerID:       ws.ID,
+		LocalWorkspaceFolder: ws.Source,
+		Env:                  envMap(),
 	}
-	return cfg.ContainerUser
+	if cfg.RemoteUser != "" {
+		return config.SubstituteString(subCtx, cfg.RemoteUser)
+	}
+	if cfg.ContainerUser != "" {
+		return config.SubstituteString(subCtx, cfg.ContainerUser)
+	}
+	return ""
+}
+
+// envMap returns the current process environment as a map.
+func envMap() map[string]string {
+	env := make(map[string]string, len(os.Environ()))
+	for _, e := range os.Environ() {
+		for i := range len(e) {
+			if e[i] == '=' {
+				env[e[:i]] = e[i+1:]
+				break
+			}
+		}
+	}
+	return env
 }

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -20,9 +20,10 @@ func liveRemoteUser(ws *workspace.Workspace) string {
 		return ""
 	}
 
-	// Mirror Engine.parseAndSubstitute: resolve workspaceFolder, substitute
-	// local-path variables, then run full config substitution and re-resolve
-	// in case workspaceFolder references other variables (e.g. ${devcontainerId}).
+	// Mirror Engine.parseAndSubstitute: resolve workspaceFolder and substitute
+	// local-path variables so the SubstitutionContext has a concrete
+	// ContainerWorkspaceFolder. We skip the post-substitution re-resolve
+	// since we only need remoteUser/containerUser, not workspaceFolder.
 	workspaceFolder := cfg.WorkspaceFolder
 	if workspaceFolder == "" {
 		workspaceFolder = "/workspaces/" + filepath.Base(ws.Source)

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -19,6 +19,10 @@ func liveRemoteUser(ws *workspace.Workspace) string {
 	if err != nil {
 		return ""
 	}
+
+	// Mirror Engine.parseAndSubstitute: resolve workspaceFolder, substitute
+	// local-path variables, then run full config substitution and re-resolve
+	// in case workspaceFolder references other variables (e.g. ${devcontainerId}).
 	workspaceFolder := cfg.WorkspaceFolder
 	if workspaceFolder == "" {
 		workspaceFolder = "/workspaces/" + filepath.Base(ws.Source)
@@ -27,17 +31,27 @@ func liveRemoteUser(ws *workspace.Workspace) string {
 		"${localWorkspaceFolder}", ws.Source,
 		"${localWorkspaceFolderBasename}", filepath.Base(ws.Source),
 	).Replace(workspaceFolder)
+
 	subCtx := &config.SubstitutionContext{
 		DevContainerID:           ws.ID,
 		LocalWorkspaceFolder:     ws.Source,
 		ContainerWorkspaceFolder: workspaceFolder,
 		Env:                      envMap(),
 	}
+
+	cfg, err = config.Substitute(subCtx, cfg)
+	if err != nil {
+		// Fall back to stored result in result.json if substitution fails.
+		return ""
+	}
+
+	// RemoteUser/ContainerUser are already substituted by config.Substitute above.
+	// No need to re-resolve workspaceFolder since we don't return it.
 	if cfg.RemoteUser != "" {
-		return config.SubstituteString(subCtx, cfg.RemoteUser)
+		return cfg.RemoteUser
 	}
 	if cfg.ContainerUser != "" {
-		return config.SubstituteString(subCtx, cfg.ContainerUser)
+		return cfg.ContainerUser
 	}
 	return ""
 }

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -9,9 +9,10 @@ import (
 )
 
 // liveRemoteUser reads remoteUser/containerUser from the current
-// devcontainer.json for the given workspace. Returns "" on parse failure or
-// missing config. Used by shell, exec, and run to ensure edits to remoteUser
-// take effect without requiring a rebuild.
+// devcontainer.json for the given workspace. Returns "" on parse failure,
+// missing config, or when neither field is set. Callers fall back to the
+// stored result.json value when this returns "". Used by shell, exec, and run
+// to ensure edits to remoteUser take effect without requiring a rebuild.
 func liveRemoteUser(ws *workspace.Workspace) string {
 	cfgPath := filepath.Join(ws.Source, ws.DevContainerPath)
 	cfg, err := config.Parse(cfgPath)

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"path/filepath"
+
+	"github.com/fgrehm/crib/internal/config"
+	"github.com/fgrehm/crib/internal/workspace"
+)
+
+// liveRemoteUser reads remoteUser/containerUser from the current
+// devcontainer.json for the given workspace. Returns "" on parse failure or
+// missing config. Used by shell, exec, and run to ensure edits to remoteUser
+// take effect without requiring a rebuild.
+func liveRemoteUser(ws *workspace.Workspace) string {
+	cfgPath := filepath.Join(ws.Source, ws.DevContainerPath)
+	cfg, err := config.Parse(cfgPath)
+	if err != nil {
+		return ""
+	}
+	if cfg.RemoteUser != "" {
+		return cfg.RemoteUser
+	}
+	return cfg.ContainerUser
+}

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/fgrehm/crib/internal/config"
 	"github.com/fgrehm/crib/internal/workspace"
@@ -18,10 +19,19 @@ func liveRemoteUser(ws *workspace.Workspace) string {
 	if err != nil {
 		return ""
 	}
+	workspaceFolder := cfg.WorkspaceFolder
+	if workspaceFolder == "" {
+		workspaceFolder = "/workspaces/" + filepath.Base(ws.Source)
+	}
+	workspaceFolder = strings.NewReplacer(
+		"${localWorkspaceFolder}", ws.Source,
+		"${localWorkspaceFolderBasename}", filepath.Base(ws.Source),
+	).Replace(workspaceFolder)
 	subCtx := &config.SubstitutionContext{
-		DevContainerID:       ws.ID,
-		LocalWorkspaceFolder: ws.Source,
-		Env:                  envMap(),
+		DevContainerID:           ws.ID,
+		LocalWorkspaceFolder:     ws.Source,
+		ContainerWorkspaceFolder: workspaceFolder,
+		Env:                      envMap(),
 	}
 	if cfg.RemoteUser != "" {
 		return config.SubstituteString(subCtx, cfg.RemoteUser)

--- a/cmd/user_test.go
+++ b/cmd/user_test.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/fgrehm/crib/internal/workspace"
+)
+
+func TestLiveRemoteUser_RemoteUser(t *testing.T) {
+	dir := t.TempDir()
+	writeDevcontainerJSON(t, dir, `{"remoteUser":"liveuser"}`)
+	ws := wsAt(dir)
+
+	got := liveRemoteUser(ws)
+	if got != "liveuser" {
+		t.Errorf("got %q, want liveuser", got)
+	}
+}
+
+func TestLiveRemoteUser_ContainerUserFallback(t *testing.T) {
+	dir := t.TempDir()
+	writeDevcontainerJSON(t, dir, `{"containerUser":"cuser"}`)
+	ws := wsAt(dir)
+
+	got := liveRemoteUser(ws)
+	if got != "cuser" {
+		t.Errorf("got %q, want cuser", got)
+	}
+}
+
+func TestLiveRemoteUser_RemoteUserTakesPrecedence(t *testing.T) {
+	dir := t.TempDir()
+	writeDevcontainerJSON(t, dir, `{"remoteUser":"ruser","containerUser":"cuser"}`)
+	ws := wsAt(dir)
+
+	got := liveRemoteUser(ws)
+	if got != "ruser" {
+		t.Errorf("got %q, want ruser (remoteUser wins)", got)
+	}
+}
+
+func TestLiveRemoteUser_MissingConfig(t *testing.T) {
+	dir := t.TempDir()
+	ws := wsAt(dir)
+	// No .devcontainer/ directory.
+	got := liveRemoteUser(ws)
+	if got != "" {
+		t.Errorf("got %q, want empty string for missing config", got)
+	}
+}
+
+func TestLiveRemoteUser_MalformedJSON(t *testing.T) {
+	dir := t.TempDir()
+	writeDevcontainerJSON(t, dir, `{bad json`)
+	ws := wsAt(dir)
+
+	got := liveRemoteUser(ws)
+	if got != "" {
+		t.Errorf("got %q, want empty string for malformed JSON", got)
+	}
+}
+
+func TestLiveRemoteUser_NeitherSet(t *testing.T) {
+	dir := t.TempDir()
+	writeDevcontainerJSON(t, dir, `{"image":"alpine:3.20"}`)
+	ws := wsAt(dir)
+
+	got := liveRemoteUser(ws)
+	if got != "" {
+		t.Errorf("got %q, want empty string when neither user field is set", got)
+	}
+}
+
+// wsAt creates a minimal Workspace pointing to dir with a standard devcontainer path.
+func wsAt(dir string) *workspace.Workspace {
+	return &workspace.Workspace{
+		ID:               "test-ws",
+		Source:           dir,
+		DevContainerPath: ".devcontainer/devcontainer.json",
+	}
+}
+
+// writeDevcontainerJSON writes content to dir/.devcontainer/devcontainer.json.
+func writeDevcontainerJSON(t *testing.T, dir, content string) {
+	t.Helper()
+	devDir := filepath.Join(dir, ".devcontainer")
+	if err := os.MkdirAll(devDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(devDir, "devcontainer.json"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/docs/ai-instructions/engine.instructions.md
+++ b/docs/ai-instructions/engine.instructions.md
@@ -65,6 +65,21 @@ Steps in order:
 5. Lifecycle hooks or snapshot restore
 6. Final save after setup completes (with probed env)
 
+## imageMetadata vs featureMetadata
+
+The `finalizeOpts.imageMetadata` field serves two purposes, controlled by `fromBuild`:
+
+- **User inference**: Always used. Extracts `remoteUser`/`containerUser` from
+  `devcontainer.metadata` label entries when devcontainer.json omits user fields.
+- **Feature hook merging**: Only when `fromBuild=true`. Merges feature lifecycle
+  hooks with user hooks and stores them for the restart/resume path.
+
+**Why the distinction?** On restart recreate without a rebuild, we inspect the
+cached image for metadata labels. This label metadata typically lacks feature
+lifecycle hooks. If we used it for merging, we'd overwrite stored feature hooks
+with empty values. The `fromBuild` flag ensures we only merge+store hooks when
+metadata came from an actual build (which includes feature metadata).
+
 ## remoteEnv is injected at exec time, not baked in
 
 `remoteEnv` (including plugin `PathPrepend` entries) is injected via

--- a/docs/ai-instructions/engine.instructions.md
+++ b/docs/ai-instructions/engine.instructions.md
@@ -67,18 +67,21 @@ Steps in order:
 
 ## imageMetadata vs featureMetadata
 
-The `finalizeOpts.imageMetadata` field serves two purposes, controlled by `fromBuild`:
+The `finalizeOpts.imageMetadata` field serves two purposes, controlled by
+`shouldMergeFeatureHooks`:
 
 - **User inference**: Always used. Extracts `remoteUser`/`containerUser` from
   `devcontainer.metadata` label entries when devcontainer.json omits user fields.
-- **Feature hook merging**: Only when `fromBuild=true`. Merges feature lifecycle
-  hooks with user hooks and stores them for the restart/resume path.
+- **Feature hook merging**: Only when `shouldMergeFeatureHooks=true`. Merges
+  feature lifecycle hooks with user hooks and stores them for the restart/resume
+  path.
 
-**Why the distinction?** On restart recreate without a rebuild, we inspect the
+**Why the distinction?** On restart/recreate without a rebuild, we inspect the
 cached image for metadata labels. This label metadata typically lacks feature
 lifecycle hooks. If we used it for merging, we'd overwrite stored feature hooks
-with empty values. The `fromBuild` flag ensures we only merge+store hooks when
-metadata came from an actual build (which includes feature metadata).
+with empty values. `shouldMergeFeatureHooks` ensures we only merge+store hooks
+on first creation (when metadata includes feature hooks from the build) and
+restore stored hooks on resume.
 
 ## remoteEnv is injected at exec time, not baked in
 

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -65,14 +65,18 @@ The "config wins" contract is enforced by `backend.pluginUser()` before plugin d
 Both single and compose backends check `configRemoteUser(cfg)` first, then fall back to
 backend-specific resolution, then generic fallbacks.
 
-**Single containers:** `buildFromImage` and `buildFromDockerfile` both inspect the image after
-build to capture `Config.User` (the last `USER` instruction) and parse the `devcontainer.metadata`
-label (JSON array of `ImageMetadata`; used by pre-built images like
-`mcr.microsoft.com/devcontainers/*` to carry `remoteUser`). This data flows as `buildResult.imageUser`
-and `buildResult.imageMetadata` into `finalizeOpts`, where `resolveRemoteUser` applies it as a
-fallback before running `whoami` in the container. `crib shell`, `exec`, and `run` re-read the
-live `devcontainer.json` on each invocation (via `liveRemoteUser()` in `cmd/user.go`) rather
-than relying on the cached value in `result.json`.
+**Single containers:** `buildFromImage` and `buildFromDockerfile` both inspect images
+to capture `Config.User` (the last `USER` instruction) and parse the
+`devcontainer.metadata` label (JSON array of `ImageMetadata`; used by pre-built
+images like `mcr.microsoft.com/devcontainers/*` to carry `remoteUser`). For
+image-based devcontainers without features, the base image is inspected before
+use. After a build or runtime pull, a second inspection captures the final
+metadata. This data flows as `buildResult.imageUser` and
+`buildResult.imageMetadata` into `finalizeOpts`, where `resolveRemoteUser`
+applies it as a fallback before running `whoami` in the container. `crib shell`,
+`exec`, and `run` re-read the live `devcontainer.json` on each invocation (via
+`liveRemoteUser()` in `cmd/user.go`) rather than relying on the cached value in
+`result.json`.
 
 **Compose containers:** `resolveComposeUser()` resolves the user from compose configuration
 (service `user:` directive, Dockerfile `USER` instruction, or base image). It's called by

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -56,15 +56,21 @@ The probe shell type maps to:
 - `internal/engine/setup.go` (`probeUserEnv`, `detectUserShell`)
 - `internal/engine/env.go` (`mergeEnv`)
 
-### Container user detection for compose containers
+### Container user detection
 
-For single containers, `containerUser` and `remoteUser` from `devcontainer.json` control which
-user runs hooks. For compose containers, the Dockerfile's `USER` directive sets the running
-user, but `devcontainer.json` often doesn't set `remoteUser` or `containerUser`.
+`remoteUser` and `containerUser` from `devcontainer.json` are consulted first. When neither
+is set, crib falls back through several sources depending on the container type.
 
-There are two detection mechanisms, used at different stages:
+**Single containers:** `buildFromImage` and `buildFromDockerfile` both inspect the image after
+build to capture `Config.User` (the last `USER` instruction) and parse the `devcontainer.metadata`
+label (JSON array of `ImageMetadata`; used by pre-built images like
+`mcr.microsoft.com/devcontainers/*` to carry `remoteUser`). This data flows as `buildResult.imageUser`
+and `buildResult.imageMetadata` into `finalizeOpts`, where `resolveRemoteUser` applies it as a
+fallback before running `whoami` in the container. `crib shell`, `exec`, and `run` re-read the
+live `devcontainer.json` on each invocation (via `liveRemoteUser()` in `cmd/user.go`) rather
+than relying on the cached value in `result.json`.
 
-**Pre-start (for plugins):** `resolveComposeUser()` runs before the container exists, so plugins
+**Compose containers:** `resolveComposeUser()` runs before the container exists, so plugins
 get the correct home directory for mounts and file copies. It checks, in order:
 1. `remoteUser`/`containerUser` from devcontainer.json (if set, returns early).
 2. The `user:` directive from the compose service definition.
@@ -78,9 +84,11 @@ If the detected user is root, it falls through to the default "root" behavior. N
 
 **Files**:
 
+- `internal/engine/build.go` (`buildFromImage`, `buildFromDockerfile`, `parseImageMetadataLabel`, `resolveComposeContainerUser`)
 - `internal/engine/compose.go` (`resolveComposeUser`, `resolveComposeDockerfileInfo`)
-- `internal/engine/build.go` (`resolveComposeContainerUser`)
+- `internal/engine/engine.go` (`resolveRemoteUser`)
 - `internal/engine/single.go` (`detectContainerUser`, `setupAndReturn`)
+- `cmd/user.go` (`liveRemoteUser`)
 
 ### Smart restart with change detection
 

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -61,6 +61,10 @@ The probe shell type maps to:
 `remoteUser` and `containerUser` from `devcontainer.json` are consulted first. When neither
 is set, crib falls back through several sources depending on the container type.
 
+The "config wins" contract is enforced by `backend.pluginUser()` before plugin dispatch.
+Both single and compose backends check `configRemoteUser(cfg)` first, then fall back to
+backend-specific resolution, then generic fallbacks.
+
 **Single containers:** `buildFromImage` and `buildFromDockerfile` both inspect the image after
 build to capture `Config.User` (the last `USER` instruction) and parse the `devcontainer.metadata`
 label (JSON array of `ImageMetadata`; used by pre-built images like
@@ -70,9 +74,10 @@ fallback before running `whoami` in the container. `crib shell`, `exec`, and `ru
 live `devcontainer.json` on each invocation (via `liveRemoteUser()` in `cmd/user.go`) rather
 than relying on the cached value in `result.json`.
 
-**Compose containers:** `resolveComposeUser()` runs before the container exists, so plugins
-get the correct home directory for mounts and file copies. It checks, in order:
-1. `remoteUser`/`containerUser` from devcontainer.json (if set, returns early).
+**Compose containers:** `resolveComposeUser()` resolves the user from compose configuration
+(service `user:` directive, Dockerfile `USER` instruction, or base image). It's called by
+`pluginUser()` after the config check. The precedence:
+1. `remoteUser`/`containerUser` from devcontainer.json (handled by pluginUser).
 2. The `user:` directive from the compose service definition.
 3. For build-based services (`build:` instead of `image:`), parses the Dockerfile to find the
    last `USER` instruction and the base image (`resolveComposeDockerfileInfo`).
@@ -84,6 +89,9 @@ If the detected user is root, it falls through to the default "root" behavior. N
 
 **Files**:
 
+- `internal/engine/backend.go` (`pluginUser` interface with config-first contract)
+- `internal/engine/backend_single.go` (config → fallbacks precedence)
+- `internal/engine/backend_compose.go` (config → compose user → fallbacks)
 - `internal/engine/build.go` (`buildFromImage`, `buildFromDockerfile`, `parseImageMetadataLabel`, `resolveComposeContainerUser`)
 - `internal/engine/compose.go` (`resolveComposeUser`, `resolveComposeDockerfileInfo`)
 - `internal/engine/engine.go` (`resolveRemoteUser`)

--- a/e2e/remote_user_test.go
+++ b/e2e/remote_user_test.go
@@ -1,0 +1,79 @@
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestE2ERemoteUserLiveOverride verifies the liveRemoteUser behavior end-to-end:
+//  1. crib up with a metadata-labeled image (no remoteUser in config) infers the user
+//  2. crib exec whoami returns the metadata-inferred user
+//  3. Editing devcontainer.json to set explicit remoteUser takes effect immediately
+//  4. crib exec whoami returns the overridden user without rebuild
+func TestE2ERemoteUserLiveOverride(t *testing.T) {
+	if !hasRuntime() {
+		t.Fatal("container runtime not available or not working (docker or podman required)")
+	}
+	t.Parallel()
+
+	projectDir := t.TempDir()
+	cribHome := t.TempDir()
+	devDir := filepath.Join(projectDir, ".devcontainer")
+	if err := os.MkdirAll(devDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Dockerfile with a devcontainer.metadata label declaring remoteUser.
+	dockerfile := "FROM alpine:3.20\n" +
+		"RUN adduser -D metauser\n" +
+		`LABEL devcontainer.metadata='[{"remoteUser":"metauser"}]'` + "\n"
+	if err := os.WriteFile(filepath.Join(devDir, "Dockerfile"), []byte(dockerfile), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Initial config: no remoteUser, should be inferred from metadata.
+	configPath := filepath.Join(devDir, "devcontainer.json")
+	initialConfig := `{
+		"build": {"dockerfile": "Dockerfile"},
+		"overrideCommand": true
+	}`
+	if err := os.WriteFile(configPath, []byte(initialConfig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Cleanup: restore workspace permissions (chownWorkspace transfers to non-root
+	// remoteUser) and remove the workspace. Uses runCrib (not mustRunCrib) so
+	// cleanup doesn't mask the real test failure.
+	wsFolder := "/workspaces/" + filepath.Base(projectDir)
+	t.Cleanup(func() {
+		_, _ = runCrib(t, projectDir, cribHome, "exec", "--user", "root", "--", "chmod", "-R", "a+rwX", wsFolder)
+		_, _ = runCrib(t, projectDir, cribHome, "remove", "--force")
+	})
+
+	// 1. Up: remoteUser inferred from metadata label.
+	mustRunCrib(t, projectDir, cribHome, "up")
+
+	// 2. exec whoami: should run as the metadata-inferred user.
+	out := mustRunCrib(t, projectDir, cribHome, "exec", "--", "whoami")
+	if got := strings.TrimSpace(out); got != "metauser" {
+		t.Errorf("whoami after up: got %q, want %q (from metadata label)", got, "metauser")
+	}
+
+	// 3. Edit devcontainer.json to override remoteUser (container still running).
+	overrideConfig := `{
+		"build": {"dockerfile": "Dockerfile"},
+		"remoteUser": "root",
+		"overrideCommand": true
+	}`
+	if err := os.WriteFile(configPath, []byte(overrideConfig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// 4. exec whoami: liveRemoteUser picks up the config change without rebuild.
+	out = mustRunCrib(t, projectDir, cribHome, "exec", "--", "whoami")
+	if got := strings.TrimSpace(out); got != "root" {
+		t.Errorf("whoami after config override: got %q, want %q (live config wins)", got, "root")
+	}
+}

--- a/e2e/remote_user_test.go
+++ b/e2e/remote_user_test.go
@@ -61,7 +61,12 @@ func TestE2ERemoteUserLiveOverride(t *testing.T) {
 		t.Errorf("whoami after up: got %q, want %q (from metadata label)", got, "metauser")
 	}
 
-	// 3. Edit devcontainer.json to override remoteUser (container still running).
+	// 3. Restore write access to the workspace. chownWorkspace transferred
+	// ownership to metauser; on Docker the chown takes real effect so the
+	// test runner can't write to .devcontainer/ without this.
+	mustRunCrib(t, projectDir, cribHome, "exec", "--user", "root", "--", "chmod", "-R", "a+rwX", wsFolder)
+
+	// Edit devcontainer.json to override remoteUser (container still running).
 	overrideConfig := `{
 		"build": {"dockerfile": "Dockerfile"},
 		"remoteUser": "root",

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -1,0 +1,24 @@
+package config
+
+import "os"
+
+// EnvMap returns the current process environment as a map.
+func EnvMap() map[string]string {
+	env := make(map[string]string, len(os.Environ()))
+	for _, e := range os.Environ() {
+		if k, v, ok := cutEnv(e); ok {
+			env[k] = v
+		}
+	}
+	return env
+}
+
+// cutEnv splits an environment variable string at the first '='.
+func cutEnv(s string) (string, string, bool) {
+	for i := range len(s) {
+		if s[i] == '=' {
+			return s[:i], s[i+1:], true
+		}
+	}
+	return s, "", false
+}

--- a/internal/engine/backend.go
+++ b/internal/engine/backend.go
@@ -14,8 +14,13 @@ import (
 // shared orchestration layer.
 type containerBackend interface {
 	// pluginUser returns the remote user for plugin dispatch.
-	// Compose resolves from service config; single returns "" (config fallback).
-	pluginUser(ctx context.Context) string
+	//
+	// For compose backends, resolves from compose config (ignores fallbacks).
+	// For single backends, returns configRemoteUser(cfg) if set, otherwise
+	// iterates fallbacks in order and returns the first non-empty value.
+	//
+	// The contract: config always wins over fallbacks.
+	pluginUser(ctx context.Context, fallbacks ...string) string
 
 	// start brings up a stopped container (and dependent services for compose).
 	// pluginResp is passed for compose override regeneration.

--- a/internal/engine/backend.go
+++ b/internal/engine/backend.go
@@ -15,11 +15,15 @@ import (
 type containerBackend interface {
 	// pluginUser returns the remote user for plugin dispatch.
 	//
-	// For compose backends, resolves from compose config (ignores fallbacks).
-	// For single backends, returns configRemoteUser(cfg) if set, otherwise
+	// Single backends: returns configRemoteUser(cfg) if set, otherwise
 	// iterates fallbacks in order and returns the first non-empty value.
 	//
-	// The contract: config always wins over fallbacks.
+	// Compose backends: returns configRemoteUser(cfg) if set, otherwise
+	// resolveComposeUser (compose service user), otherwise iterates
+	// fallbacks in order.
+	//
+	// The contract: config always wins over fallbacks. Compose-derived
+	// user sits between config and generic fallbacks.
 	pluginUser(ctx context.Context, fallbacks ...string) string
 
 	// start brings up a stopped container (and dependent services for compose).

--- a/internal/engine/backend_compose.go
+++ b/internal/engine/backend_compose.go
@@ -20,8 +20,21 @@ type composeBackend struct {
 	inv             composeInvocation
 }
 
-func (b *composeBackend) pluginUser(ctx context.Context) string {
-	return b.e.resolveComposeUser(ctx, b.cfg, b.inv.files)
+func (b *composeBackend) pluginUser(ctx context.Context, fallbacks ...string) string {
+	// Config always wins over fallbacks/compose-derived user.
+	if user := configRemoteUser(b.cfg); user != "" {
+		return user
+	}
+	// Compose-derived user takes precedence over generic fallbacks.
+	if user := b.e.resolveComposeUser(ctx, b.cfg, b.inv.files); user != "" {
+		return user
+	}
+	for _, f := range fallbacks {
+		if f != "" {
+			return f
+		}
+	}
+	return ""
 }
 
 func (b *composeBackend) start(ctx context.Context, containerID string, pluginResp *plugin.PreContainerRunResponse) (string, error) {

--- a/internal/engine/backend_compose_test.go
+++ b/internal/engine/backend_compose_test.go
@@ -15,9 +15,8 @@ func TestComposeBackend_CanResumeFromStored_ReturnsTrue(t *testing.T) {
 	}
 }
 
-func TestComposeBackend_PluginUser_Delegates(t *testing.T) {
-	// When config has remoteUser set, resolveComposeUser returns ""
-	// (the config user is used as fallback by dispatchPlugins).
+func TestComposeBackend_PluginUser_ConfigWins(t *testing.T) {
+	// When config has remoteUser set, pluginUser returns it directly.
 	eng := &Engine{logger: slog.Default()}
 
 	cfg := &config.DevContainerConfig{}
@@ -30,9 +29,8 @@ func TestComposeBackend_PluginUser_Delegates(t *testing.T) {
 	}
 
 	user := b.pluginUser(context.Background())
-	// resolveComposeUser returns "" when config already has remoteUser.
-	if user != "" {
-		t.Errorf("pluginUser() = %q, want empty (config has remoteUser)", user)
+	if user != "vscode" {
+		t.Errorf("pluginUser() = %q, want vscode (from config)", user)
 	}
 }
 
@@ -62,8 +60,8 @@ func TestComposeBackend_BuildImage_SkipsWhenNoFeatures(t *testing.T) {
 func TestComposeBackend_PluginUser_NoConfigUser_ReturnsEmpty(t *testing.T) {
 	eng := &Engine{logger: slog.Default()}
 
-	// No remoteUser or containerUser. resolveComposeUser will try to inspect
-	// the compose service but with no files, it returns "".
+	// No remoteUser or containerUser. resolveComposeUser returns ""
+	// because there are no compose files to inspect.
 	cfg := &config.DevContainerConfig{}
 	cfg.Service = "app"
 

--- a/internal/engine/backend_compose_test.go
+++ b/internal/engine/backend_compose_test.go
@@ -28,7 +28,7 @@ func TestComposeBackend_PluginUser_ConfigWins(t *testing.T) {
 		inv: composeInvocation{files: []string{}},
 	}
 
-	user := b.pluginUser(context.Background())
+	user := b.pluginUser(context.Background(), "fallback-user")
 	if user != "vscode" {
 		t.Errorf("pluginUser() = %q, want vscode (from config)", user)
 	}
@@ -57,11 +57,11 @@ func TestComposeBackend_BuildImage_SkipsWhenNoFeatures(t *testing.T) {
 	}
 }
 
-func TestComposeBackend_PluginUser_NoConfigUser_ReturnsEmpty(t *testing.T) {
+func TestComposeBackend_PluginUser_Fallbacks(t *testing.T) {
 	eng := &Engine{logger: slog.Default()}
 
 	// No remoteUser or containerUser. resolveComposeUser returns ""
-	// because there are no compose files to inspect.
+	// because there are no compose files to inspect. Fallbacks are used.
 	cfg := &config.DevContainerConfig{}
 	cfg.Service = "app"
 
@@ -71,9 +71,16 @@ func TestComposeBackend_PluginUser_NoConfigUser_ReturnsEmpty(t *testing.T) {
 		inv: composeInvocation{files: []string{}},
 	}
 
-	user := b.pluginUser(context.Background())
+	// First non-empty fallback is used.
+	user := b.pluginUser(context.Background(), "", "node", "root")
+	if user != "node" {
+		t.Errorf("pluginUser() = %q, want node (first non-empty fallback)", user)
+	}
+
+	// No config and no fallbacks.
+	user = b.pluginUser(context.Background())
 	if user != "" {
-		t.Errorf("pluginUser() = %q, want empty", user)
+		t.Errorf("pluginUser() = %q, want empty (no config or fallbacks)", user)
 	}
 }
 

--- a/internal/engine/backend_single.go
+++ b/internal/engine/backend_single.go
@@ -18,7 +18,18 @@ type singleBackend struct {
 	workspaceFolder string
 }
 
-func (b *singleBackend) pluginUser(_ context.Context) string {
+func (b *singleBackend) pluginUser(_ context.Context, fallbacks ...string) string {
+	// Config always wins over fallbacks.
+	if b.cfg != nil {
+		if user := configRemoteUser(b.cfg); user != "" {
+			return user
+		}
+	}
+	for _, f := range fallbacks {
+		if f != "" {
+			return f
+		}
+	}
 	return ""
 }
 

--- a/internal/engine/backend_single_test.go
+++ b/internal/engine/backend_single_test.go
@@ -13,7 +13,31 @@ import (
 	"github.com/fgrehm/crib/internal/workspace"
 )
 
-func TestSingleBackend_PluginUser_ReturnsEmpty(t *testing.T) {
+func TestSingleBackend_PluginUser_ConfigWinsOverFallbacks(t *testing.T) {
+	cfg := &config.DevContainerConfig{}
+	cfg.RemoteUser = "vscode"
+
+	b := &singleBackend{cfg: cfg}
+
+	// Config should take priority over fallbacks.
+	got := b.pluginUser(context.Background(), "fallback-user")
+	if got != "vscode" {
+		t.Errorf("pluginUser() = %q, want vscode (config wins)", got)
+	}
+}
+
+func TestSingleBackend_PluginUser_FirstNonEmptyFallback(t *testing.T) {
+	cfg := &config.DevContainerConfig{} // no remoteUser or containerUser
+
+	b := &singleBackend{cfg: cfg}
+
+	got := b.pluginUser(context.Background(), "", "node", "root")
+	if got != "node" {
+		t.Errorf("pluginUser() = %q, want node (first non-empty fallback)", got)
+	}
+}
+
+func TestSingleBackend_PluginUser_NoConfigNoFallbacks(t *testing.T) {
 	b := &singleBackend{}
 	if got := b.pluginUser(context.Background()); got != "" {
 		t.Errorf("pluginUser() = %q, want empty", got)

--- a/internal/engine/build.go
+++ b/internal/engine/build.go
@@ -92,11 +92,13 @@ func (e *Engine) buildFromImage(ctx context.Context, ws *workspace.Workspace, cf
 	// than the pre-build base image inspection.
 	if details, inspErr := e.driver.InspectImage(ctx, result.imageName); inspErr == nil {
 		result.imageUser = userFromConfigUser(details.Config.User)
-		// Always replace pre-build labelMetadata with the built image's label,
-		// even when the built image has no label (it may have cleared it).
-		_, labelPresent := details.Config.Labels["devcontainer.metadata"]
-		if labelPresent {
+		// Replace pre-build labelMetadata with the built image's label.
+		// If the label is absent from the built image, clear it so pre-build
+		// metadata from the base image doesn't leak into the result.
+		if _, labelPresent := details.Config.Labels["devcontainer.metadata"]; labelPresent {
 			labelMetadata = parseImageMetadataLabel(details.Config.Labels)
+		} else {
+			labelMetadata = nil
 		}
 	} else {
 		result.imageUser = imageUser // fall back to pre-build inspection

--- a/internal/engine/build.go
+++ b/internal/engine/build.go
@@ -514,18 +514,14 @@ func remoteUserFromMetadata(metadata []*config.ImageMetadata) string {
 }
 
 // containerUserFromMetadata returns the containerUser from the highest-priority
-// metadata entry that declares one. Falls back to remoteUser per the
-// devcontainers spec (remoteUser defaults to containerUser, so if only
-// remoteUser is set, it implies the containerUser as well).
+// metadata entry that declares one. Returns "" when no entry sets containerUser.
+// Does NOT fall back to remoteUser: the spec relationship is one-way
+// (remoteUser defaults to containerUser, never the reverse). Callers should
+// fall back to imageUser/Dockerfile USER when this returns "".
 func containerUserFromMetadata(metadata []*config.ImageMetadata) string {
 	for i := len(metadata) - 1; i >= 0; i-- {
 		if metadata[i] != nil && metadata[i].ContainerUser != "" {
 			return metadata[i].ContainerUser
-		}
-	}
-	for i := len(metadata) - 1; i >= 0; i-- {
-		if metadata[i] != nil && metadata[i].RemoteUser != "" {
-			return metadata[i].RemoteUser
 		}
 	}
 	return ""

--- a/internal/engine/build.go
+++ b/internal/engine/build.go
@@ -52,7 +52,7 @@ func (e *Engine) buildFromImage(ctx context.Context, ws *workspace.Workspace, cf
 	// Fail open: image may not be pulled yet; the runtime pulls it at container start.
 	var imageUser string
 	var labelMetadata []*config.ImageMetadata
-	if details, err := e.driver.InspectImage(ctx, cfg.Image); err == nil {
+	if details, err := e.driver.InspectImage(ctx, cfg.Image); err == nil && details != nil {
 		imageUser = userFromConfigUser(details.Config.User)
 		labelMetadata = parseImageMetadataLabel(details.Config.Labels)
 	}
@@ -90,7 +90,7 @@ func (e *Engine) buildFromImage(ctx context.Context, ws *workspace.Workspace, cf
 	// Inspect the built image for the final Config.User and metadata label.
 	// Features may add a USER instruction, so we use result.imageName rather
 	// than the pre-build base image inspection.
-	if details, inspErr := e.driver.InspectImage(ctx, result.imageName); inspErr == nil {
+	if details, inspErr := e.driver.InspectImage(ctx, result.imageName); inspErr == nil && details != nil {
 		result.imageUser = userFromConfigUser(details.Config.User)
 		// Replace pre-build labelMetadata with the built image's label.
 		// If the label is absent from the built image, clear it so pre-build
@@ -177,7 +177,7 @@ func (e *Engine) buildFromDockerfile(ctx context.Context, ws *workspace.Workspac
 	}
 
 	// Inspect the built image for Config.User and metadata label.
-	if details, inspErr := e.driver.InspectImage(ctx, result.imageName); inspErr == nil {
+	if details, inspErr := e.driver.InspectImage(ctx, result.imageName); inspErr == nil && details != nil {
 		result.imageUser = userFromConfigUser(details.Config.User)
 		if labelMeta := parseImageMetadataLabel(details.Config.Labels); len(labelMeta) > 0 {
 			result.imageMetadata = append(labelMeta, result.imageMetadata...)
@@ -341,7 +341,7 @@ func (e *Engine) resolveComposeContainerUser(ctx context.Context, cfg *config.De
 		return serviceUser
 	}
 	if baseImage != "" {
-		if details, err := e.driver.InspectImage(ctx, baseImage); err == nil && details.Config.User != "" {
+		if details, err := e.driver.InspectImage(ctx, baseImage); err == nil && details != nil && details.Config.User != "" {
 			return userFromConfigUser(details.Config.User)
 		}
 	}

--- a/internal/engine/build.go
+++ b/internal/engine/build.go
@@ -92,8 +92,11 @@ func (e *Engine) buildFromImage(ctx context.Context, ws *workspace.Workspace, cf
 	// than the pre-build base image inspection.
 	if details, inspErr := e.driver.InspectImage(ctx, result.imageName); inspErr == nil {
 		result.imageUser = userFromConfigUser(details.Config.User)
-		if builtLabelMeta := parseImageMetadataLabel(details.Config.Labels); len(builtLabelMeta) > 0 {
-			labelMetadata = builtLabelMeta
+		// Always replace pre-build labelMetadata with the built image's label,
+		// even when the built image has no label (it may have cleared it).
+		_, labelPresent := details.Config.Labels["devcontainer.metadata"]
+		if labelPresent {
+			labelMetadata = parseImageMetadataLabel(details.Config.Labels)
 		}
 	} else {
 		result.imageUser = imageUser // fall back to pre-build inspection
@@ -478,12 +481,12 @@ func userFromConfigUser(configUser string) string {
 // "last entry wins" semantics of config.MergeConfiguration.
 func remoteUserFromMetadata(metadata []*config.ImageMetadata) string {
 	for i := len(metadata) - 1; i >= 0; i-- {
-		if metadata[i].RemoteUser != "" {
+		if metadata[i] != nil && metadata[i].RemoteUser != "" {
 			return metadata[i].RemoteUser
 		}
 	}
 	for i := len(metadata) - 1; i >= 0; i-- {
-		if metadata[i].ContainerUser != "" {
+		if metadata[i] != nil && metadata[i].ContainerUser != "" {
 			return metadata[i].ContainerUser
 		}
 	}

--- a/internal/engine/build.go
+++ b/internal/engine/build.go
@@ -456,6 +456,9 @@ func parseImageMetadataLabel(labels map[string]string) []*config.ImageMetadata {
 				out = append(out, m)
 			}
 		}
+		if len(out) == 0 {
+			return nil
+		}
 		return out
 	}
 	// Fall back to single object.

--- a/internal/engine/build.go
+++ b/internal/engine/build.go
@@ -49,12 +49,14 @@ func (e *Engine) buildImage(ctx context.Context, ws *workspace.Workspace, cfg *c
 // If features are specified, generates a Dockerfile that extends the base image.
 func (e *Engine) buildFromImage(ctx context.Context, ws *workspace.Workspace, cfg *config.DevContainerConfig, features []*feature.FeatureSet, containerUser string) (*buildResult, error) {
 	// Inspect image for metadata label and Config.User.
-	// Fail open: image may not be pulled yet; the runtime pulls it at container start.
+	// Fail open: image may not be pulled yet; the build below will pull it.
 	var imageUser string
 	var labelMetadata []*config.ImageMetadata
+	baseImageInspected := false
 	if details, err := e.driver.InspectImage(ctx, cfg.Image); err == nil && details != nil {
 		imageUser = userFromConfigUser(details.Config.User)
 		labelMetadata = parseImageMetadataLabel(details.Config.Labels)
+		baseImageInspected = true
 	}
 
 	if len(features) == 0 {
@@ -118,6 +120,21 @@ func (e *Engine) buildFromImage(ctx context.Context, ws *workspace.Workspace, cf
 	} else {
 		result.imageUser = imageUser // fall back to pre-build inspection
 	}
+
+	// If the base image wasn't locally available before the build, re-inspect
+	// it now that doBuild has pulled it. The built image doesn't inherit the
+	// base image's devcontainer.metadata label (each Dockerfile stage starts
+	// fresh), so this is the only way to recover remoteUser/containerUser from
+	// images like mcr.microsoft.com/devcontainers/* on first pull.
+	if !baseImageInspected && labelMetadata == nil {
+		if details, inspErr := e.driver.InspectImage(ctx, cfg.Image); inspErr == nil && details != nil {
+			labelMetadata = parseImageMetadataLabel(details.Config.Labels)
+			if result.imageUser == "" {
+				result.imageUser = userFromConfigUser(details.Config.User)
+			}
+		}
+	}
+
 	// Prepend label metadata before feature metadata (label = lower priority than features).
 	if len(labelMetadata) > 0 {
 		result.imageMetadata = append(labelMetadata, result.imageMetadata...)

--- a/internal/engine/build.go
+++ b/internal/engine/build.go
@@ -66,14 +66,13 @@ func (e *Engine) buildFromImage(ctx context.Context, ws *workspace.Workspace, cf
 		}, nil
 	}
 
-	// Override containerUser from image if config didn't set either user field.
-	// Prefer metadata label users over Config.User: images like
-	// mcr.microsoft.com/devcontainers/* set Config.User to root but
-	// the devcontainer.metadata label specifies remoteUser (e.g. "node").
-	// Resolve containerUser and remoteUser separately from metadata per
-	// the spec: containerUser and remoteUser are independent properties
-	// that each follow "last value wins" merge semantics.
-	if cfg.ContainerUser == "" && cfg.RemoteUser == "" {
+	// Override containerUser from image when config didn't set containerUser
+	// explicitly. containerUser and remoteUser are independent properties per
+	// the spec; infer containerUser from metadata/Config.User even when
+	// cfg.RemoteUser is set. Prefer metadata over Config.User: images like
+	// mcr.microsoft.com/devcontainers/* set Config.User to root but carry
+	// a devcontainer.metadata label with containerUser or remoteUser.
+	if cfg.ContainerUser == "" {
 		if cu := containerUserFromMetadata(labelMetadata); cu != "" {
 			containerUser = cu
 		} else if imageUser != "" {
@@ -107,13 +106,14 @@ func (e *Engine) buildFromImage(ctx context.Context, ws *workspace.Workspace, cf
 	// than the pre-build base image inspection.
 	if details, inspErr := e.driver.InspectImage(ctx, result.imageName); inspErr == nil && details != nil {
 		result.imageUser = userFromConfigUser(details.Config.User)
-		// Replace pre-build labelMetadata with the built image's label.
-		// If the label is absent from the built image, clear it so pre-build
-		// metadata from the base image doesn't leak into the result.
+		// Replace pre-build labelMetadata with the built image's label when
+		// present. Feature overlay Dockerfiles don't inherit labels from the
+		// base image (each stage starts fresh), so absence of the label in the
+		// built image is expected -- retain the pre-build base image metadata
+		// so remoteUser inference remains correct for images that carry it
+		// (e.g. mcr.microsoft.com/devcontainers/*).
 		if _, labelPresent := details.Config.Labels["devcontainer.metadata"]; labelPresent {
 			labelMetadata = parseImageMetadataLabel(details.Config.Labels)
-		} else {
-			labelMetadata = nil
 		}
 	} else {
 		result.imageUser = imageUser // fall back to pre-build inspection
@@ -155,13 +155,18 @@ func (e *Engine) buildFromDockerfile(ctx context.Context, ws *workspace.Workspac
 			buildTarget = cfg.Build.Target
 		}
 
-		// Determine the container user from the Dockerfile if config didn't set
-		// either user field. resolveContainerUser defaults to "root" when both
-		// are empty, so check the config fields directly here.
-		if cfg.ContainerUser == "" && cfg.RemoteUser == "" {
+		// Determine the container user from the Dockerfile USER when config
+		// didn't set containerUser explicitly. containerUser and remoteUser are
+		// independent per the spec, so infer containerUser even when
+		// cfg.RemoteUser is set. Only fall remoteUser through to the Dockerfile
+		// USER when config also didn't set remoteUser (it already defaults to
+		// containerUser when empty, but this keeps the intent explicit).
+		if cfg.ContainerUser == "" {
 			if dfUser := df.FindUserStatement(nil, nil, buildTarget); dfUser != "" {
 				containerUser = dfUser
-				remoteUser = dfUser
+				if cfg.RemoteUser == "" {
+					remoteUser = dfUser
+				}
 			}
 		}
 

--- a/internal/engine/build.go
+++ b/internal/engine/build.go
@@ -125,12 +125,14 @@ func (e *Engine) buildFromDockerfile(ctx context.Context, ws *workspace.Workspac
 			buildTarget = cfg.Build.Target
 		}
 
-		// Determine the container user from the Dockerfile if not set.
-		if containerUser == "" {
-			containerUser = df.FindUserStatement(nil, nil, buildTarget)
-		}
-		if remoteUser == "" {
-			remoteUser = containerUser
+		// Determine the container user from the Dockerfile if config didn't set
+		// either user field. resolveContainerUser defaults to "root" when both
+		// are empty, so check the config fields directly here.
+		if cfg.ContainerUser == "" && cfg.RemoteUser == "" {
+			if dfUser := df.FindUserStatement(nil, nil, buildTarget); dfUser != "" {
+				containerUser = dfUser
+				remoteUser = dfUser
+			}
 		}
 
 		// Ensure the final stage has a name for feature overlay.
@@ -432,7 +434,14 @@ func parseImageMetadataLabel(labels map[string]string) []*config.ImageMetadata {
 	// Try array first (standard format).
 	var arr []*config.ImageMetadata
 	if err := json.Unmarshal([]byte(raw), &arr); err == nil {
-		return arr
+		// Filter out null entries that JSON unmarshaling may produce.
+		out := arr[:0]
+		for _, m := range arr {
+			if m != nil {
+				out = append(out, m)
+			}
+		}
+		return out
 	}
 	// Fall back to single object.
 	var single config.ImageMetadata

--- a/internal/engine/build.go
+++ b/internal/engine/build.go
@@ -442,6 +442,22 @@ func parseImageMetadataLabel(labels map[string]string) []*config.ImageMetadata {
 	return nil
 }
 
+// remoteUserFromMetadata returns the first non-empty RemoteUser found in the
+// metadata entries, then the first non-empty ContainerUser, or "" if none set.
+func remoteUserFromMetadata(metadata []*config.ImageMetadata) string {
+	for _, m := range metadata {
+		if m.RemoteUser != "" {
+			return m.RemoteUser
+		}
+	}
+	for _, m := range metadata {
+		if m.ContainerUser != "" {
+			return m.ContainerUser
+		}
+	}
+	return ""
+}
+
 // featureToMetadata converts a FeatureSet to an ImageMetadata entry.
 func featureToMetadata(f *feature.FeatureSet) *config.ImageMetadata {
 	m := &config.ImageMetadata{

--- a/internal/engine/build.go
+++ b/internal/engine/build.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -19,7 +20,8 @@ import (
 type buildResult struct {
 	imageName      string
 	imageMetadata  []*config.ImageMetadata
-	hasEntrypoints bool // true if any feature declared an entrypoint
+	imageUser      string // Config.User from image inspect (Dockerfile USER)
+	hasEntrypoints bool   // true if any feature declared an entrypoint
 }
 
 // buildImage handles image building for the single container path.
@@ -46,9 +48,27 @@ func (e *Engine) buildImage(ctx context.Context, ws *workspace.Workspace, cfg *c
 // buildFromImage handles the image-based devcontainer path.
 // If features are specified, generates a Dockerfile that extends the base image.
 func (e *Engine) buildFromImage(ctx context.Context, ws *workspace.Workspace, cfg *config.DevContainerConfig, features []*feature.FeatureSet, containerUser string) (*buildResult, error) {
+	// Inspect image for metadata label and Config.User.
+	// Fail open: image may not be pulled yet; the runtime pulls it at container start.
+	var imageUser string
+	var labelMetadata []*config.ImageMetadata
+	if details, err := e.driver.InspectImage(ctx, cfg.Image); err == nil {
+		imageUser = details.Config.User
+		labelMetadata = parseImageMetadataLabel(details.Config.Labels)
+	}
+
 	if len(features) == 0 {
 		// No features, no build needed. Just use the image directly.
-		return &buildResult{imageName: cfg.Image}, nil
+		return &buildResult{
+			imageName:     cfg.Image,
+			imageMetadata: labelMetadata,
+			imageUser:     imageUser,
+		}, nil
+	}
+
+	// Override containerUser from image if config didn't set either user field.
+	if cfg.ContainerUser == "" && cfg.RemoteUser == "" && imageUser != "" {
+		containerUser = imageUser
 	}
 
 	// Generate a Dockerfile that installs features on top of the base image.
@@ -63,7 +83,16 @@ func (e *Engine) buildFromImage(ctx context.Context, ws *workspace.Workspace, cf
 	featurePrefix = strings.ReplaceAll(featurePrefix, "=placeholder", "="+cfg.Image)
 	dockerfileContent := featurePrefix + "\n" + featureContent
 
-	return e.doBuild(ctx, ws, cfg, dockerfileContent, features, containerUser, remoteUser)
+	result, err := e.doBuild(ctx, ws, cfg, dockerfileContent, features, containerUser, remoteUser)
+	if err != nil {
+		return nil, err
+	}
+	result.imageUser = imageUser
+	// Prepend label metadata before feature metadata (label = lower priority than features).
+	if len(labelMetadata) > 0 {
+		result.imageMetadata = append(labelMetadata, result.imageMetadata...)
+	}
+	return result, nil
 }
 
 // buildFromDockerfile handles the Dockerfile-based devcontainer path.
@@ -125,7 +154,19 @@ func (e *Engine) buildFromDockerfile(ctx context.Context, ws *workspace.Workspac
 		dockerfileContent = featurePrefix + "\n" + dockerfileContent + "\n" + featureContent
 	}
 
-	return e.doBuild(ctx, ws, cfg, dockerfileContent, features, containerUser, remoteUser)
+	result, err := e.doBuild(ctx, ws, cfg, dockerfileContent, features, containerUser, remoteUser)
+	if err != nil {
+		return nil, err
+	}
+
+	// Inspect the built image for Config.User and metadata label.
+	if details, inspErr := e.driver.InspectImage(ctx, result.imageName); inspErr == nil {
+		result.imageUser = details.Config.User
+		if labelMeta := parseImageMetadataLabel(details.Config.Labels); len(labelMeta) > 0 {
+			result.imageMetadata = append(labelMeta, result.imageMetadata...)
+		}
+	}
+	return result, nil
 }
 
 // doBuild writes the final Dockerfile and invokes the driver to build.
@@ -378,6 +419,27 @@ func (e *Engine) cleanupPreviousBuildImage(ctx context.Context, wsID, newImageNa
 	if err := e.driver.RemoveImage(ctx, oldImage); err != nil {
 		e.logger.Debug("failed to remove previous build image", "image", oldImage, "error", err)
 	}
+}
+
+// parseImageMetadataLabel parses the devcontainer.metadata label from image
+// labels. The label value is either a JSON array of ImageMetadata objects or a
+// single object. Returns nil on missing label, empty label, or parse error.
+func parseImageMetadataLabel(labels map[string]string) []*config.ImageMetadata {
+	raw, ok := labels["devcontainer.metadata"]
+	if !ok || raw == "" {
+		return nil
+	}
+	// Try array first (standard format).
+	var arr []*config.ImageMetadata
+	if err := json.Unmarshal([]byte(raw), &arr); err == nil {
+		return arr
+	}
+	// Fall back to single object.
+	var single config.ImageMetadata
+	if err := json.Unmarshal([]byte(raw), &single); err == nil {
+		return []*config.ImageMetadata{&single}
+	}
+	return nil
 }
 
 // featureToMetadata converts a FeatureSet to an ImageMetadata entry.

--- a/internal/engine/build.go
+++ b/internal/engine/build.go
@@ -67,13 +67,15 @@ func (e *Engine) buildFromImage(ctx context.Context, ws *workspace.Workspace, cf
 	}
 
 	// Override containerUser from image if config didn't set either user field.
-	// Prefer metadata label user over Config.User: images like
+	// Prefer metadata label users over Config.User: images like
 	// mcr.microsoft.com/devcontainers/* set Config.User to root but
 	// the devcontainer.metadata label specifies remoteUser (e.g. "node").
+	// Resolve containerUser and remoteUser separately from metadata per
+	// the spec: containerUser and remoteUser are independent properties
+	// that each follow "last value wins" merge semantics.
 	if cfg.ContainerUser == "" && cfg.RemoteUser == "" {
-		labelUser := remoteUserFromMetadata(labelMetadata)
-		if labelUser != "" {
-			containerUser = labelUser
+		if cu := containerUserFromMetadata(labelMetadata); cu != "" {
+			containerUser = cu
 		} else if imageUser != "" {
 			containerUser = imageUser
 		}
@@ -82,7 +84,12 @@ func (e *Engine) buildFromImage(ctx context.Context, ws *workspace.Workspace, cf
 	// Generate a Dockerfile that installs features on top of the base image.
 	remoteUser := cfg.RemoteUser
 	if remoteUser == "" {
-		remoteUser = containerUser
+		ru := remoteUserFromMetadata(labelMetadata)
+		if ru != "" {
+			remoteUser = ru
+		} else {
+			remoteUser = containerUser
+		}
 	}
 
 	featureContent, featurePrefix := feature.GenerateDockerfile(features, containerUser, remoteUser, e.buildCacheMounts)
@@ -501,6 +508,24 @@ func remoteUserFromMetadata(metadata []*config.ImageMetadata) string {
 	for i := len(metadata) - 1; i >= 0; i-- {
 		if metadata[i] != nil && metadata[i].ContainerUser != "" {
 			return metadata[i].ContainerUser
+		}
+	}
+	return ""
+}
+
+// containerUserFromMetadata returns the containerUser from the highest-priority
+// metadata entry that declares one. Falls back to remoteUser per the
+// devcontainers spec (remoteUser defaults to containerUser, so if only
+// remoteUser is set, it implies the containerUser as well).
+func containerUserFromMetadata(metadata []*config.ImageMetadata) string {
+	for i := len(metadata) - 1; i >= 0; i-- {
+		if metadata[i] != nil && metadata[i].ContainerUser != "" {
+			return metadata[i].ContainerUser
+		}
+	}
+	for i := len(metadata) - 1; i >= 0; i-- {
+		if metadata[i] != nil && metadata[i].RemoteUser != "" {
+			return metadata[i].RemoteUser
 		}
 	}
 	return ""

--- a/internal/engine/build.go
+++ b/internal/engine/build.go
@@ -53,7 +53,7 @@ func (e *Engine) buildFromImage(ctx context.Context, ws *workspace.Workspace, cf
 	var imageUser string
 	var labelMetadata []*config.ImageMetadata
 	if details, err := e.driver.InspectImage(ctx, cfg.Image); err == nil {
-		imageUser = details.Config.User
+		imageUser = userFromConfigUser(details.Config.User)
 		labelMetadata = parseImageMetadataLabel(details.Config.Labels)
 	}
 
@@ -87,7 +87,17 @@ func (e *Engine) buildFromImage(ctx context.Context, ws *workspace.Workspace, cf
 	if err != nil {
 		return nil, err
 	}
-	result.imageUser = imageUser
+	// Inspect the built image for the final Config.User and metadata label.
+	// Features may add a USER instruction, so we use result.imageName rather
+	// than the pre-build base image inspection.
+	if details, inspErr := e.driver.InspectImage(ctx, result.imageName); inspErr == nil {
+		result.imageUser = userFromConfigUser(details.Config.User)
+		if builtLabelMeta := parseImageMetadataLabel(details.Config.Labels); len(builtLabelMeta) > 0 {
+			labelMetadata = builtLabelMeta
+		}
+	} else {
+		result.imageUser = imageUser // fall back to pre-build inspection
+	}
 	// Prepend label metadata before feature metadata (label = lower priority than features).
 	if len(labelMetadata) > 0 {
 		result.imageMetadata = append(labelMetadata, result.imageMetadata...)
@@ -163,7 +173,7 @@ func (e *Engine) buildFromDockerfile(ctx context.Context, ws *workspace.Workspac
 
 	// Inspect the built image for Config.User and metadata label.
 	if details, inspErr := e.driver.InspectImage(ctx, result.imageName); inspErr == nil {
-		result.imageUser = details.Config.User
+		result.imageUser = userFromConfigUser(details.Config.User)
 		if labelMeta := parseImageMetadataLabel(details.Config.Labels); len(labelMeta) > 0 {
 			result.imageMetadata = append(labelMeta, result.imageMetadata...)
 		}
@@ -327,7 +337,7 @@ func (e *Engine) resolveComposeContainerUser(ctx context.Context, cfg *config.De
 	}
 	if baseImage != "" {
 		if details, err := e.driver.InspectImage(ctx, baseImage); err == nil && details.Config.User != "" {
-			return details.Config.User
+			return userFromConfigUser(details.Config.User)
 		}
 	}
 	return "root"
@@ -451,17 +461,30 @@ func parseImageMetadataLabel(labels map[string]string) []*config.ImageMetadata {
 	return nil
 }
 
-// remoteUserFromMetadata returns the first non-empty RemoteUser found in the
-// metadata entries, then the first non-empty ContainerUser, or "" if none set.
+// userFromConfigUser extracts the user portion from an image Config.User value.
+// Docker/OCI images may set Config.User as "user", "uid", "user:group", or
+// "uid:gid". Only the user/uid portion is meaningful for exec --user and chown.
+func userFromConfigUser(configUser string) string {
+	if before, _, ok := strings.Cut(configUser, ":"); ok {
+		return before
+	}
+	return configUser
+}
+
+// remoteUserFromMetadata returns the remoteUser from the highest-priority
+// metadata entry that declares one, or the containerUser as fallback.
+// Metadata is stored [label..., feature...] where features have higher
+// priority; iterating in reverse (last entry first) matches the
+// "last entry wins" semantics of config.MergeConfiguration.
 func remoteUserFromMetadata(metadata []*config.ImageMetadata) string {
-	for _, m := range metadata {
-		if m.RemoteUser != "" {
-			return m.RemoteUser
+	for i := len(metadata) - 1; i >= 0; i-- {
+		if metadata[i].RemoteUser != "" {
+			return metadata[i].RemoteUser
 		}
 	}
-	for _, m := range metadata {
-		if m.ContainerUser != "" {
-			return m.ContainerUser
+	for i := len(metadata) - 1; i >= 0; i-- {
+		if metadata[i].ContainerUser != "" {
+			return metadata[i].ContainerUser
 		}
 	}
 	return ""

--- a/internal/engine/build.go
+++ b/internal/engine/build.go
@@ -67,8 +67,16 @@ func (e *Engine) buildFromImage(ctx context.Context, ws *workspace.Workspace, cf
 	}
 
 	// Override containerUser from image if config didn't set either user field.
-	if cfg.ContainerUser == "" && cfg.RemoteUser == "" && imageUser != "" {
-		containerUser = imageUser
+	// Prefer metadata label user over Config.User: images like
+	// mcr.microsoft.com/devcontainers/* set Config.User to root but
+	// the devcontainer.metadata label specifies remoteUser (e.g. "node").
+	if cfg.ContainerUser == "" && cfg.RemoteUser == "" {
+		labelUser := remoteUserFromMetadata(labelMetadata)
+		if labelUser != "" {
+			containerUser = labelUser
+		} else if imageUser != "" {
+			containerUser = imageUser
+		}
 	}
 
 	// Generate a Dockerfile that installs features on top of the base image.

--- a/internal/engine/build_test.go
+++ b/internal/engine/build_test.go
@@ -273,6 +273,99 @@ func TestResolveComposeContainerUser(t *testing.T) {
 	}
 }
 
+func TestParseImageMetadataLabel(t *testing.T) {
+	tests := []struct {
+		name      string
+		labels    map[string]string
+		wantCount int
+		wantUser  string // remoteUser of first entry (if any)
+	}{
+		{
+			name:      "array format",
+			labels:    map[string]string{"devcontainer.metadata": `[{"remoteUser":"node"}]`},
+			wantCount: 1,
+			wantUser:  "node",
+		},
+		{
+			name:      "single object format",
+			labels:    map[string]string{"devcontainer.metadata": `{"remoteUser":"vscode"}`},
+			wantCount: 1,
+			wantUser:  "vscode",
+		},
+		{
+			name:      "multiple entries",
+			labels:    map[string]string{"devcontainer.metadata": `[{"id":"feature1"},{"remoteUser":"dev"}]`},
+			wantCount: 2,
+		},
+		{
+			name:      "missing label",
+			labels:    map[string]string{},
+			wantCount: 0,
+		},
+		{
+			name:      "empty label",
+			labels:    map[string]string{"devcontainer.metadata": ""},
+			wantCount: 0,
+		},
+		{
+			name:      "malformed JSON",
+			labels:    map[string]string{"devcontainer.metadata": "{bad json"},
+			wantCount: 0,
+		},
+		{
+			name:      "nil labels",
+			labels:    nil,
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseImageMetadataLabel(tt.labels)
+			if len(got) != tt.wantCount {
+				t.Errorf("got %d entries, want %d", len(got), tt.wantCount)
+			}
+			if tt.wantUser != "" && len(got) > 0 && got[0].RemoteUser != tt.wantUser {
+				t.Errorf("remoteUser = %q, want %q", got[0].RemoteUser, tt.wantUser)
+			}
+		})
+	}
+}
+
+func TestResolveRemoteUser_ImageUserFallback(t *testing.T) {
+	eng := &Engine{driver: &mockDriver{}, logger: slog.Default()}
+	cfg := &config.DevContainerConfig{} // no remoteUser or containerUser
+	cc := containerContext{workspaceID: "test", containerID: "abc"}
+
+	got := eng.resolveRemoteUser(context.Background(), cc, cfg, "node")
+	if got != "node" {
+		t.Errorf("resolveRemoteUser = %q, want %q (from imageUser)", got, "node")
+	}
+}
+
+func TestResolveRemoteUser_ConfigWinsOverImageUser(t *testing.T) {
+	eng := &Engine{driver: &mockDriver{}, logger: slog.Default()}
+	cfg := &config.DevContainerConfig{}
+	cfg.RemoteUser = "vscode"
+	cc := containerContext{workspaceID: "test", containerID: "abc"}
+
+	got := eng.resolveRemoteUser(context.Background(), cc, cfg, "node")
+	if got != "vscode" {
+		t.Errorf("resolveRemoteUser = %q, want %q (config wins)", got, "vscode")
+	}
+}
+
+func TestResolveRemoteUser_DefaultsToRoot(t *testing.T) {
+	eng := &Engine{driver: &mockDriver{}, logger: slog.Default()}
+	cfg := &config.DevContainerConfig{}
+	cc := containerContext{workspaceID: "test", containerID: "abc"}
+
+	got := eng.resolveRemoteUser(context.Background(), cc, cfg, "")
+	if got != "root" {
+		t.Errorf("resolveRemoteUser = %q, want root", got)
+	}
+}
+
 func TestResolveContainerUser_FromConfig(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/engine/build_test.go
+++ b/internal/engine/build_test.go
@@ -366,6 +366,92 @@ func TestResolveRemoteUser_DefaultsToRoot(t *testing.T) {
 	}
 }
 
+func TestUserFromConfigUser(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"plain user", "node", "node"},
+		{"user:group", "node:nodejs", "node"},
+		{"uid", "1000", "1000"},
+		{"uid:gid", "1000:1000", "1000"},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := userFromConfigUser(tt.input)
+			if got != tt.want {
+				t.Errorf("userFromConfigUser(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRemoteUserFromMetadata(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata []*config.ImageMetadata
+		want     string
+	}{
+		{
+			name:     "single remoteUser",
+			metadata: []*config.ImageMetadata{{DevContainerConfigBase: config.DevContainerConfigBase{RemoteUser: "node"}}},
+			want:     "node",
+		},
+		{
+			name: "last entry wins",
+			metadata: []*config.ImageMetadata{
+				{DevContainerConfigBase: config.DevContainerConfigBase{RemoteUser: "first"}},
+				{DevContainerConfigBase: config.DevContainerConfigBase{RemoteUser: "last"}},
+			},
+			want: "last",
+		},
+		{
+			name: "containerUser fallback",
+			metadata: []*config.ImageMetadata{
+				{NonComposeBase: config.NonComposeBase{ContainerUser: "cuser"}},
+			},
+			want: "cuser",
+		},
+		{
+			name: "remoteUser preferred over containerUser",
+			metadata: []*config.ImageMetadata{
+				{NonComposeBase: config.NonComposeBase{ContainerUser: "cuser"}},
+				{DevContainerConfigBase: config.DevContainerConfigBase{RemoteUser: "ruser"}},
+			},
+			want: "ruser",
+		},
+		{
+			name:     "empty metadata",
+			metadata: []*config.ImageMetadata{},
+			want:     "",
+		},
+		{
+			name:     "nil metadata",
+			metadata: nil,
+			want:     "",
+		},
+		{
+			name: "nil entries skipped",
+			metadata: []*config.ImageMetadata{
+				nil,
+				{DevContainerConfigBase: config.DevContainerConfigBase{RemoteUser: "valid"}},
+				nil,
+			},
+			want: "valid",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := remoteUserFromMetadata(tt.metadata)
+			if got != tt.want {
+				t.Errorf("remoteUserFromMetadata() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestResolveContainerUser_FromConfig(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/engine/build_test.go
+++ b/internal/engine/build_test.go
@@ -471,11 +471,11 @@ func TestContainerUserFromMetadata(t *testing.T) {
 			want: "root",
 		},
 		{
-			name: "remoteUser as fallback",
+			name: "remoteUser not used as fallback",
 			metadata: []*config.ImageMetadata{
 				{DevContainerConfigBase: config.DevContainerConfigBase{RemoteUser: "node"}},
 			},
-			want: "node",
+			want: "",
 		},
 		{
 			name: "last entry wins",

--- a/internal/engine/build_test.go
+++ b/internal/engine/build_test.go
@@ -452,6 +452,69 @@ func TestRemoteUserFromMetadata(t *testing.T) {
 	}
 }
 
+func TestContainerUserFromMetadata(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata []*config.ImageMetadata
+		want     string
+	}{
+		{
+			name:     "single containerUser",
+			metadata: []*config.ImageMetadata{{NonComposeBase: config.NonComposeBase{ContainerUser: "node"}}},
+			want:     "node",
+		},
+		{
+			name: "containerUser wins over remoteUser",
+			metadata: []*config.ImageMetadata{
+				{NonComposeBase: config.NonComposeBase{ContainerUser: "root"}, DevContainerConfigBase: config.DevContainerConfigBase{RemoteUser: "node"}},
+			},
+			want: "root",
+		},
+		{
+			name: "remoteUser as fallback",
+			metadata: []*config.ImageMetadata{
+				{DevContainerConfigBase: config.DevContainerConfigBase{RemoteUser: "node"}},
+			},
+			want: "node",
+		},
+		{
+			name: "last entry wins",
+			metadata: []*config.ImageMetadata{
+				{NonComposeBase: config.NonComposeBase{ContainerUser: "first"}},
+				{NonComposeBase: config.NonComposeBase{ContainerUser: "last"}},
+			},
+			want: "last",
+		},
+		{
+			name:     "empty metadata",
+			metadata: []*config.ImageMetadata{},
+			want:     "",
+		},
+		{
+			name:     "nil metadata",
+			metadata: nil,
+			want:     "",
+		},
+		{
+			name: "nil entries skipped",
+			metadata: []*config.ImageMetadata{
+				nil,
+				{NonComposeBase: config.NonComposeBase{ContainerUser: "valid"}},
+				nil,
+			},
+			want: "valid",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := containerUserFromMetadata(tt.metadata)
+			if got != tt.want {
+				t.Errorf("containerUserFromMetadata() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestResolveContainerUser_FromConfig(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/engine/compose.go
+++ b/internal/engine/compose.go
@@ -60,13 +60,9 @@ func (e *Engine) buildComposeFeatures(ctx context.Context, ws *workspace.Workspa
 // resolveComposeUser determines the container user for the compose service by
 // querying the compose config and delegating to resolveComposeContainerUser.
 // This is used before plugin dispatch so plugins get the correct remote user
-// even when devcontainer.json doesn't set remoteUser/containerUser.
+// when devcontainer.json doesn't set remoteUser/containerUser.
+// Caller (pluginUser) checks config first; this only resolves from compose files.
 func (e *Engine) resolveComposeUser(ctx context.Context, cfg *config.DevContainerConfig, composeFiles []string) string {
-	// If devcontainer.json already specifies a user, no need to inspect.
-	if cfg.RemoteUser != "" || cfg.ContainerUser != "" {
-		return ""
-	}
-
 	serviceName := cfg.Service
 	svcInfo, err := composehelper.GetServiceInfo(ctx, composeFiles, serviceName, nil)
 	if err != nil {

--- a/internal/engine/compose_test.go
+++ b/internal/engine/compose_test.go
@@ -1,7 +1,6 @@
 package engine
 
 import (
-	"context"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -438,30 +437,6 @@ func TestGenerateComposeOverride_NoBuildSection(t *testing.T) {
 	// Container labels should still be present.
 	if !strings.Contains(content, "crib.workspace") {
 		t.Errorf("expected container label, got:\n%s", content)
-	}
-}
-
-func TestResolveComposeUser_ConfigUserTakesPrecedence(t *testing.T) {
-	eng := &Engine{
-		logger: slog.Default(),
-		driver: &mockDriver{},
-	}
-
-	cfg := &config.DevContainerConfig{}
-	cfg.RemoteUser = "devuser"
-
-	// When config already specifies a user, resolveComposeUser returns empty
-	// (meaning: don't override, let dispatchPlugins use cfg fields).
-	user := eng.resolveComposeUser(context.Background(), cfg, nil)
-	if user != "" {
-		t.Errorf("expected empty user when config has remoteUser, got %q", user)
-	}
-
-	cfg.RemoteUser = ""
-	cfg.ContainerUser = "devuser"
-	user = eng.resolveComposeUser(context.Background(), cfg, nil)
-	if user != "" {
-		t.Errorf("expected empty user when config has containerUser, got %q", user)
 	}
 }
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -293,6 +293,7 @@ func (e *Engine) upExisting(ctx context.Context, ws *workspace.Workspace, cfg *c
 		pluginResp:     pluginResp,
 		storedResult:   storedResult,
 		fromSnapshot:   storedResult != nil,
+		fromBuild:      false,
 	})
 }
 
@@ -356,6 +357,7 @@ func (e *Engine) upCreate(ctx context.Context, ws *workspace.Workspace, cfg *con
 		pluginResp:     pluginResp,
 		imageMetadata:  buildRes.imageMetadata,
 		imageUser:      buildRes.imageUser,
+		fromBuild:      true,
 	})
 }
 
@@ -398,6 +400,7 @@ func (e *Engine) upFromImage(ctx context.Context, ws *workspace.Workspace, cfg *
 		pluginResp:     pluginResp,
 		storedResult:   storedResult,
 		fromSnapshot:   isSnapshot,
+		fromBuild:      false,
 	})
 }
 
@@ -728,11 +731,13 @@ func configRemoteUser(cfg *config.DevContainerConfig) string {
 }
 
 // resolveRemoteUser determines the remote user for a container. Precedence:
-// config (remoteUser/containerUser) > imageUser (image Config.User) > whoami > "root".
-func (e *Engine) resolveRemoteUser(ctx context.Context, cc containerContext, cfg *config.DevContainerConfig, imageUser string) string {
+// config (remoteUser/containerUser) > fallbackUser (metadata/image-derived) > whoami > "root".
+// The fallbackUser is typically derived from devcontainer.metadata or image Config.User
+// when the devcontainer.json does not explicitly set user fields.
+func (e *Engine) resolveRemoteUser(ctx context.Context, cc containerContext, cfg *config.DevContainerConfig, fallbackUser string) string {
 	remoteUser := configRemoteUser(cfg)
-	if remoteUser == "" && imageUser != "" {
-		remoteUser = imageUser
+	if remoteUser == "" && fallbackUser != "" {
+		remoteUser = fallbackUser
 	}
 	if remoteUser == "" {
 		remoteUser = e.detectContainerUser(ctx, cc)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -346,6 +346,7 @@ func (e *Engine) upCreate(ctx context.Context, ws *workspace.Workspace, cfg *con
 		hasEntrypoints: buildRes.hasEntrypoints,
 		pluginResp:     pluginResp,
 		imageMetadata:  buildRes.imageMetadata,
+		imageUser:      buildRes.imageUser,
 	})
 }
 
@@ -717,11 +718,13 @@ func configRemoteUser(cfg *config.DevContainerConfig) string {
 	return cfg.ContainerUser
 }
 
-// resolveRemoteUser determines the remote user for a container, using the
-// config's remoteUser/containerUser with fallback to detecting the container's
-// default user via whoami.
-func (e *Engine) resolveRemoteUser(ctx context.Context, cc containerContext, cfg *config.DevContainerConfig) string {
+// resolveRemoteUser determines the remote user for a container. Precedence:
+// config (remoteUser/containerUser) > imageUser (image Config.User) > whoami > "root".
+func (e *Engine) resolveRemoteUser(ctx context.Context, cc containerContext, cfg *config.DevContainerConfig, imageUser string) string {
 	remoteUser := configRemoteUser(cfg)
+	if remoteUser == "" && imageUser != "" {
+		remoteUser = imageUser
+	}
 	if remoteUser == "" {
 		remoteUser = e.detectContainerUser(ctx, cc)
 	}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -261,11 +261,12 @@ func (e *Engine) upExisting(ctx context.Context, ws *workspace.Workspace, cfg *c
 		storedHasEntrypoints = stored.HasFeatureEntrypoints
 	}
 
-	// Dispatch plugins. Use stored remoteUser as fallback so plugins
-	// target the correct home directory on resume (single backend returns "").
-	pluginUser := b.pluginUser(ctx)
-	if pluginUser == "" && storedResult != nil {
-		pluginUser = storedResult.RemoteUser
+	// Dispatch plugins. Backend handles config-vs-fallback precedence.
+	var pluginUser string
+	if storedResult != nil {
+		pluginUser = b.pluginUser(ctx, storedResult.RemoteUser)
+	} else {
+		pluginUser = b.pluginUser(ctx)
 	}
 	pluginResp, err := e.dispatchPlugins(ctx, ws, cfg, storedImageName, workspaceFolder, pluginUser)
 	if err != nil {
@@ -278,11 +279,12 @@ func (e *Engine) upExisting(ctx context.Context, ws *workspace.Workspace, cfg *c
 		containerID:     container.ID,
 		workspaceFolder: workspaceFolder,
 	}
-	// Pre-set remoteUser from stored result so finalize skips re-resolution.
-	// Without this, metadata-only remoteUser (e.g. node image with
+	// Pre-set remoteUser from stored result only when config doesn't have
+	// an explicit user. This allows live config changes to take effect.
+	// Without this guard, metadata-only remoteUser (e.g. node image with
 	// devcontainer.metadata label) would be lost on resume because finalize
 	// falls through to whoami which returns the container process user (root).
-	if storedResult != nil && storedResult.RemoteUser != "" {
+	if storedResult != nil && storedResult.RemoteUser != "" && configRemoteUser(cfg) == "" {
 		cc.remoteUser = storedResult.RemoteUser
 	}
 
@@ -330,17 +332,10 @@ func (e *Engine) upCreate(ctx context.Context, ws *workspace.Workspace, cfg *con
 		return nil, err
 	}
 
-	// Dispatch plugins.
-	pluginUser := b.pluginUser(ctx)
-	if pluginUser == "" {
-		// When devcontainer.json omits remoteUser/containerUser, use the user
-		// inferred from image metadata or Config.User so plugins target the
-		// correct home directory (e.g. /home/node instead of /root).
-		pluginUser = remoteUserFromMetadata(buildRes.imageMetadata)
-	}
-	if pluginUser == "" {
-		pluginUser = buildRes.imageUser
-	}
+	// Dispatch plugins. Backend handles config-vs-fallback precedence.
+	pluginUser := b.pluginUser(ctx,
+		remoteUserFromMetadata(buildRes.imageMetadata),
+		buildRes.imageUser)
 	pluginResp, err := e.dispatchPlugins(ctx, ws, cfg, buildRes.imageName, workspaceFolder, pluginUser)
 	if err != nil {
 		return nil, err
@@ -387,12 +382,8 @@ func (e *Engine) upCreate(ctx context.Context, ws *workspace.Workspace, cfg *con
 func (e *Engine) upFromImage(ctx context.Context, ws *workspace.Workspace, cfg *config.DevContainerConfig, workspaceFolder string, b containerBackend, imageName string, storedResult *workspace.Result, isSnapshot bool) (*UpResult, error) {
 	e.logger.Debug("up from image", "image", imageName, "snapshot", isSnapshot)
 
-	// Dispatch plugins. Use stored remoteUser as fallback so plugins
-	// target the correct home directory on resume (single backend returns "").
-	pluginUser := b.pluginUser(ctx)
-	if pluginUser == "" {
-		pluginUser = storedResult.RemoteUser
-	}
+	// Dispatch plugins. Backend handles config-vs-fallback precedence.
+	pluginUser := b.pluginUser(ctx, storedResult.RemoteUser)
 	pluginResp, err := e.dispatchPlugins(ctx, ws, cfg, imageName, workspaceFolder, pluginUser)
 	if err != nil {
 		return nil, err
@@ -410,11 +401,17 @@ func (e *Engine) upFromImage(ctx context.Context, ws *workspace.Workspace, cfg *
 		return nil, err
 	}
 
+	// Pre-set remoteUser from stored result only when config doesn't have
+	// an explicit user. This allows live config changes to take effect.
+	remoteUser := ""
+	if configRemoteUser(cfg) == "" && storedResult.RemoteUser != "" {
+		remoteUser = storedResult.RemoteUser
+	}
 	cc := containerContext{
 		workspaceID:     ws.ID,
 		containerID:     containerID,
 		workspaceFolder: workspaceFolder,
-		remoteUser:      storedResult.RemoteUser, // pre-set to skip re-resolution in finalize
+		remoteUser:      remoteUser,
 	}
 
 	// Use the original image name (not snapshot) for the result.

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -356,6 +356,17 @@ func (e *Engine) upCreate(ctx context.Context, ws *workspace.Workspace, cfg *con
 		return nil, err
 	}
 
+	// Late inspect: if the initial inspect in buildFromImage failed (image
+	// wasn't pulled yet), the runtime pulled it during createContainer. Re-
+	// inspect to capture devcontainer.metadata and Config.User so finalize
+	// can infer remoteUser correctly on first run.
+	if buildRes.imageMetadata == nil && buildRes.imageUser == "" && buildRes.imageName != "" {
+		if details, inspErr := e.driver.InspectImage(ctx, buildRes.imageName); inspErr == nil && details != nil {
+			buildRes.imageUser = userFromConfigUser(details.Config.User)
+			buildRes.imageMetadata = parseImageMetadataLabel(details.Config.Labels)
+		}
+	}
+
 	cc := containerContext{
 		workspaceID:     ws.ID,
 		containerID:     containerID,

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -300,13 +300,13 @@ func (e *Engine) upExisting(ctx context.Context, ws *workspace.Workspace, cfg *c
 	}
 
 	return e.finalize(ctx, ws, cfg, finalizeOpts{
-		cc:             cc,
-		imageName:      storedImageName,
-		hasEntrypoints: storedHasEntrypoints,
-		pluginResp:     pluginResp,
-		storedResult:   storedResult,
-		fromSnapshot:   storedResult != nil,
-		fromBuild:      false,
+		cc:                      cc,
+		imageName:               storedImageName,
+		hasEntrypoints:          storedHasEntrypoints,
+		pluginResp:              pluginResp,
+		storedResult:            storedResult,
+		fromSnapshot:            storedResult != nil,
+		shouldMergeFeatureHooks: false,
 	})
 }
 
@@ -368,13 +368,13 @@ func (e *Engine) upCreate(ctx context.Context, ws *workspace.Workspace, cfg *con
 		workspaceFolder: workspaceFolder,
 	}
 	return e.finalize(ctx, ws, cfg, finalizeOpts{
-		cc:             cc,
-		imageName:      buildRes.imageName,
-		hasEntrypoints: buildRes.hasEntrypoints,
-		pluginResp:     pluginResp,
-		imageMetadata:  buildRes.imageMetadata,
-		imageUser:      buildRes.imageUser,
-		fromBuild:      true,
+		cc:                      cc,
+		imageName:               buildRes.imageName,
+		hasEntrypoints:          buildRes.hasEntrypoints,
+		pluginResp:              pluginResp,
+		imageMetadata:           buildRes.imageMetadata,
+		imageUser:               buildRes.imageUser,
+		shouldMergeFeatureHooks: true,
 	})
 }
 
@@ -418,13 +418,13 @@ func (e *Engine) upFromImage(ctx context.Context, ws *workspace.Workspace, cfg *
 	resultImageName := storedResult.ImageName
 
 	return e.finalize(ctx, ws, cfg, finalizeOpts{
-		cc:             cc,
-		imageName:      resultImageName,
-		hasEntrypoints: hasEntrypoints,
-		pluginResp:     pluginResp,
-		storedResult:   storedResult,
-		fromSnapshot:   isSnapshot,
-		fromBuild:      false,
+		cc:                      cc,
+		imageName:               resultImageName,
+		hasEntrypoints:          hasEntrypoints,
+		pluginResp:              pluginResp,
+		storedResult:            storedResult,
+		fromSnapshot:            isSnapshot,
+		shouldMergeFeatureHooks: false,
 	})
 }
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -261,8 +261,12 @@ func (e *Engine) upExisting(ctx context.Context, ws *workspace.Workspace, cfg *c
 		storedHasEntrypoints = stored.HasFeatureEntrypoints
 	}
 
-	// Dispatch plugins.
+	// Dispatch plugins. Use stored remoteUser as fallback so plugins
+	// target the correct home directory on resume (single backend returns "").
 	pluginUser := b.pluginUser(ctx)
+	if pluginUser == "" && storedResult != nil {
+		pluginUser = storedResult.RemoteUser
+	}
 	pluginResp, err := e.dispatchPlugins(ctx, ws, cfg, storedImageName, workspaceFolder, pluginUser)
 	if err != nil {
 		e.logger.Warn("plugin dispatch failed for existing container", "error", err)
@@ -273,6 +277,13 @@ func (e *Engine) upExisting(ctx context.Context, ws *workspace.Workspace, cfg *c
 		workspaceID:     ws.ID,
 		containerID:     container.ID,
 		workspaceFolder: workspaceFolder,
+	}
+	// Pre-set remoteUser from stored result so finalize skips re-resolution.
+	// Without this, metadata-only remoteUser (e.g. node image with
+	// devcontainer.metadata label) would be lost on resume because finalize
+	// falls through to whoami which returns the container process user (root).
+	if storedResult != nil && storedResult.RemoteUser != "" {
+		cc.remoteUser = storedResult.RemoteUser
 	}
 
 	if !container.State.IsRunning() {
@@ -365,8 +376,12 @@ func (e *Engine) upCreate(ctx context.Context, ws *workspace.Workspace, cfg *con
 func (e *Engine) upFromImage(ctx context.Context, ws *workspace.Workspace, cfg *config.DevContainerConfig, workspaceFolder string, b containerBackend, imageName string, storedResult *workspace.Result, isSnapshot bool) (*UpResult, error) {
 	e.logger.Debug("up from image", "image", imageName, "snapshot", isSnapshot)
 
-	// Dispatch plugins.
+	// Dispatch plugins. Use stored remoteUser as fallback so plugins
+	// target the correct home directory on resume (single backend returns "").
 	pluginUser := b.pluginUser(ctx)
+	if pluginUser == "" {
+		pluginUser = storedResult.RemoteUser
+	}
 	pluginResp, err := e.dispatchPlugins(ctx, ws, cfg, imageName, workspaceFolder, pluginUser)
 	if err != nil {
 		return nil, err
@@ -388,6 +403,7 @@ func (e *Engine) upFromImage(ctx context.Context, ws *workspace.Workspace, cfg *
 		workspaceID:     ws.ID,
 		containerID:     containerID,
 		workspaceFolder: workspaceFolder,
+		remoteUser:      storedResult.RemoteUser, // pre-set to skip re-resolution in finalize
 	}
 
 	// Use the original image name (not snapshot) for the result.

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -320,6 +320,15 @@ func (e *Engine) upCreate(ctx context.Context, ws *workspace.Workspace, cfg *con
 
 	// Dispatch plugins.
 	pluginUser := b.pluginUser(ctx)
+	if pluginUser == "" {
+		// When devcontainer.json omits remoteUser/containerUser, use the user
+		// inferred from image metadata or Config.User so plugins target the
+		// correct home directory (e.g. /home/node instead of /root).
+		pluginUser = remoteUserFromMetadata(buildRes.imageMetadata)
+	}
+	if pluginUser == "" {
+		pluginUser = buildRes.imageUser
+	}
 	pluginResp, err := e.dispatchPlugins(ctx, ws, cfg, buildRes.imageName, workspaceFolder, pluginUser)
 	if err != nil {
 		return nil, err

--- a/internal/engine/env.go
+++ b/internal/engine/env.go
@@ -2,8 +2,9 @@ package engine
 
 import (
 	"maps"
-	"os"
 	"strings"
+
+	"github.com/fgrehm/crib/internal/config"
 )
 
 // parseEnvLines parses the output of the `env` command into a map.
@@ -23,13 +24,7 @@ func parseEnvLines(output string) map[string]string {
 
 // envMap returns the current process environment as a map.
 func envMap() map[string]string {
-	env := make(map[string]string)
-	for _, e := range os.Environ() {
-		if k, v, ok := strings.Cut(e, "="); ok {
-			env[k] = v
-		}
-	}
-	return env
+	return config.EnvMap()
 }
 
 // probedEnvSkip lists probed environment variables to exclude from the

--- a/internal/engine/finalize.go
+++ b/internal/engine/finalize.go
@@ -11,16 +11,20 @@ import (
 
 // finalizeOpts configures the finalize method.
 type finalizeOpts struct {
-	cc              containerContext
-	imageName       string                          // original (not snapshot) for result
-	hasEntrypoints  bool                            // feature entrypoints baked into image
-	pluginResp      *plugin.PreContainerRunResponse // may be nil
-	storedResult    *workspace.Result               // non-nil for snapshot/stored resume
-	fromSnapshot    bool                            // true = restore env + resume hooks
-	skipVolumeChown bool                            // true for restart (volumes exist)
-	fromBuild       bool                            // true if imageMetadata came from a build (not just inspect)
-	imageMetadata   []*config.ImageMetadata         // metadata for user inference and hook merging
-	imageUser       string                          // Config.User from image inspect (Dockerfile USER fallback)
+	cc                      containerContext
+	imageName               string                          // original (not snapshot) for result
+	hasEntrypoints          bool                            // feature entrypoints baked into image
+	pluginResp              *plugin.PreContainerRunResponse // may be nil
+	storedResult            *workspace.Result               // non-nil for snapshot/stored resume
+	fromSnapshot            bool                            // true = restore env + resume hooks
+	skipVolumeChown         bool                            // true for restart (volumes exist)
+	shouldMergeFeatureHooks bool                            // true when imageMetadata carries fresh feature
+	// lifecycle hooks that must be merged and stored.
+	// Set on first creation (build or image inspection) so
+	// hooks are persisted for restart/resume. False on
+	// resume paths that restore stored hooks.
+	imageMetadata []*config.ImageMetadata // metadata for user inference and hook merging
+	imageUser     string                  // Config.User from image inspect (Dockerfile USER fallback)
 }
 
 // finalize runs post-creation/post-restart steps: plugin file copies, volume
@@ -123,12 +127,14 @@ func (e *Engine) finalizeFreshPath(ctx context.Context, ws *workspace.Workspace,
 	envb.AddPluginResponse(opts.pluginResp)
 
 	// Merge feature hooks with user hooks once (used for both storage and dispatch).
-	// Only merge from imageMetadata when we actually built with features (fromBuild=true).
-	// Otherwise, use stored feature hooks to avoid overwriting them with label metadata
+	// On first creation (shouldMergeFeatureHooks=true), merge from imageMetadata
+	// and store the result so the restart/resume path can dispatch stored hooks
+	// without re-resolving features. On resume (shouldMergeFeatureHooks=false),
+	// use stored feature hooks to avoid overwriting them with label-only metadata
 	// that lacks feature lifecycle hooks.
 	var hooks *hookSet
 	switch {
-	case opts.fromBuild && len(opts.imageMetadata) > 0:
+	case opts.shouldMergeFeatureHooks && len(opts.imageMetadata) > 0:
 		merged := config.MergeConfiguration(cfg, opts.imageMetadata)
 		hooks = hookSetFromMerged(merged)
 		// Store feature-only hooks so the resume/restart path can dispatch them

--- a/internal/engine/finalize.go
+++ b/internal/engine/finalize.go
@@ -18,7 +18,8 @@ type finalizeOpts struct {
 	storedResult    *workspace.Result               // non-nil for snapshot/stored resume
 	fromSnapshot    bool                            // true = restore env + resume hooks
 	skipVolumeChown bool                            // true for restart (volumes exist)
-	imageMetadata   []*config.ImageMetadata         // feature metadata for hook merging (nil = no features)
+	fromBuild       bool                            // true if imageMetadata came from a build (not just inspect)
+	imageMetadata   []*config.ImageMetadata         // metadata for user inference and hook merging
 	imageUser       string                          // Config.User from image inspect (Dockerfile USER fallback)
 }
 
@@ -122,9 +123,12 @@ func (e *Engine) finalizeFreshPath(ctx context.Context, ws *workspace.Workspace,
 	envb.AddPluginResponse(opts.pluginResp)
 
 	// Merge feature hooks with user hooks once (used for both storage and dispatch).
+	// Only merge from imageMetadata when we actually built with features (fromBuild=true).
+	// Otherwise, use stored feature hooks to avoid overwriting them with label metadata
+	// that lacks feature lifecycle hooks.
 	var hooks *hookSet
 	switch {
-	case len(opts.imageMetadata) > 0:
+	case opts.fromBuild && len(opts.imageMetadata) > 0:
 		merged := config.MergeConfiguration(cfg, opts.imageMetadata)
 		hooks = hookSetFromMerged(merged)
 		// Store feature-only hooks so the resume/restart path can dispatch them

--- a/internal/engine/finalize.go
+++ b/internal/engine/finalize.go
@@ -63,11 +63,11 @@ func (e *Engine) finalize(ctx context.Context, ws *workspace.Workspace, cfg *con
 		// declare their intended dev user (e.g. node image sets remoteUser=node
 		// even though Config.User may be root). Fall back to Config.User only
 		// when metadata doesn't specify a user.
-		imageUser := remoteUserFromMetadata(opts.imageMetadata)
-		if imageUser == "" {
-			imageUser = opts.imageUser
+		fallbackUser := remoteUserFromMetadata(opts.imageMetadata)
+		if fallbackUser == "" {
+			fallbackUser = opts.imageUser
 		}
-		cc.remoteUser = e.resolveRemoteUser(ctx, cc, cfg, imageUser)
+		cc.remoteUser = e.resolveRemoteUser(ctx, cc, cfg, fallbackUser)
 	}
 
 	// 3. Build result (shared across both paths).

--- a/internal/engine/finalize.go
+++ b/internal/engine/finalize.go
@@ -42,6 +42,9 @@ func (e *Engine) finalize(ctx context.Context, ws *workspace.Workspace, cfg *con
 			if remoteUser == "" {
 				remoteUser = opts.imageUser
 			}
+			if remoteUser == "" {
+				remoteUser = remoteUserFromMetadata(opts.imageMetadata)
+			}
 			if remoteUser != "" && remoteUser != "root" {
 				volCC := cc
 				volCC.remoteUser = remoteUser
@@ -52,7 +55,13 @@ func (e *Engine) finalize(ctx context.Context, ws *workspace.Workspace, cfg *con
 
 	// 2. Resolve remote user (skip if already set, e.g. from restartSimple).
 	if cc.remoteUser == "" {
-		cc.remoteUser = e.resolveRemoteUser(ctx, cc, cfg, opts.imageUser)
+		// Config.User from image inspect is the primary imageUser fallback.
+		// If not set, check devcontainer.metadata label entries for remoteUser.
+		imageUser := opts.imageUser
+		if imageUser == "" {
+			imageUser = remoteUserFromMetadata(opts.imageMetadata)
+		}
+		cc.remoteUser = e.resolveRemoteUser(ctx, cc, cfg, imageUser)
 	}
 
 	// 3. Build result (shared across both paths).

--- a/internal/engine/finalize.go
+++ b/internal/engine/finalize.go
@@ -40,10 +40,13 @@ func (e *Engine) finalize(ctx context.Context, ws *workspace.Workspace, cfg *con
 		if !opts.skipVolumeChown {
 			remoteUser := configRemoteUser(cfg)
 			if remoteUser == "" {
-				remoteUser = opts.imageUser
+				// devcontainer.metadata remoteUser/containerUser takes priority
+				// over raw image Config.User -- the label is the spec mechanism
+				// for images to declare their intended dev user.
+				remoteUser = remoteUserFromMetadata(opts.imageMetadata)
 			}
 			if remoteUser == "" {
-				remoteUser = remoteUserFromMetadata(opts.imageMetadata)
+				remoteUser = opts.imageUser
 			}
 			if remoteUser != "" && remoteUser != "root" {
 				volCC := cc
@@ -55,11 +58,14 @@ func (e *Engine) finalize(ctx context.Context, ws *workspace.Workspace, cfg *con
 
 	// 2. Resolve remote user (skip if already set, e.g. from restartSimple).
 	if cc.remoteUser == "" {
-		// Config.User from image inspect is the primary imageUser fallback.
-		// If not set, check devcontainer.metadata label entries for remoteUser.
-		imageUser := opts.imageUser
+		// devcontainer.metadata remoteUser/containerUser takes priority over
+		// raw image Config.User: the label is the spec mechanism for images to
+		// declare their intended dev user (e.g. node image sets remoteUser=node
+		// even though Config.User may be root). Fall back to Config.User only
+		// when metadata doesn't specify a user.
+		imageUser := remoteUserFromMetadata(opts.imageMetadata)
 		if imageUser == "" {
-			imageUser = remoteUserFromMetadata(opts.imageMetadata)
+			imageUser = opts.imageUser
 		}
 		cc.remoteUser = e.resolveRemoteUser(ctx, cc, cfg, imageUser)
 	}

--- a/internal/engine/finalize.go
+++ b/internal/engine/finalize.go
@@ -19,6 +19,7 @@ type finalizeOpts struct {
 	fromSnapshot    bool                            // true = restore env + resume hooks
 	skipVolumeChown bool                            // true for restart (volumes exist)
 	imageMetadata   []*config.ImageMetadata         // feature metadata for hook merging (nil = no features)
+	imageUser       string                          // Config.User from image inspect (Dockerfile USER fallback)
 }
 
 // finalize runs post-creation/post-restart steps: plugin file copies, volume
@@ -38,6 +39,9 @@ func (e *Engine) finalize(ctx context.Context, ws *workspace.Workspace, cfg *con
 
 		if !opts.skipVolumeChown {
 			remoteUser := configRemoteUser(cfg)
+			if remoteUser == "" {
+				remoteUser = opts.imageUser
+			}
 			if remoteUser != "" && remoteUser != "root" {
 				volCC := cc
 				volCC.remoteUser = remoteUser
@@ -48,7 +52,7 @@ func (e *Engine) finalize(ctx context.Context, ws *workspace.Workspace, cfg *con
 
 	// 2. Resolve remote user (skip if already set, e.g. from restartSimple).
 	if cc.remoteUser == "" {
-		cc.remoteUser = e.resolveRemoteUser(ctx, cc, cfg)
+		cc.remoteUser = e.resolveRemoteUser(ctx, cc, cfg, opts.imageUser)
 	}
 
 	// 3. Build result (shared across both paths).

--- a/internal/engine/integration_test.go
+++ b/internal/engine/integration_test.go
@@ -962,12 +962,12 @@ func TestIntegrationImageMetadataLabel(t *testing.T) {
 		t.Fatalf("Up: %v", err)
 	}
 
-	// Restore workspace ownership so t.TempDir cleanup can remove the dir.
-	// chownWorkspace transfers ownership to the non-root remoteUser; we must
-	// chown it back to root before the container is deleted.
+	// Make the workspace world-writable so t.TempDir cleanup can remove it.
+	// chownWorkspace transfers directory ownership to the non-root remoteUser;
+	// chmod a+rwX lets the test runner (a different UID) still unlink files.
 	t.Cleanup(func() {
 		_ = d.ExecContainer(ctx, wsID, result.ContainerID,
-			[]string{"chown", "-R", "root:root", result.WorkspaceFolder},
+			[]string{"chmod", "-R", "a+rwX", result.WorkspaceFolder},
 			nil, io.Discard, io.Discard, nil, "root")
 	})
 
@@ -1028,12 +1028,12 @@ USER nonroot
 		t.Fatalf("Up: %v", err)
 	}
 
-	// Restore workspace ownership so t.TempDir cleanup can remove the dir.
-	// chownWorkspace transfers ownership to the non-root remoteUser; we must
-	// chown it back to root before the container is deleted.
+	// Make the workspace world-writable so t.TempDir cleanup can remove it.
+	// chownWorkspace transfers directory ownership to the non-root remoteUser;
+	// chmod a+rwX lets the test runner (a different UID) still unlink files.
 	t.Cleanup(func() {
 		_ = d.ExecContainer(ctx, wsID, result.ContainerID,
-			[]string{"chown", "-R", "root:root", result.WorkspaceFolder},
+			[]string{"chmod", "-R", "a+rwX", result.WorkspaceFolder},
 			nil, io.Discard, io.Discard, nil, "root")
 	})
 

--- a/internal/engine/integration_test.go
+++ b/internal/engine/integration_test.go
@@ -1210,8 +1210,17 @@ func TestIntegrationResumePreservesMetadataUser(t *testing.T) {
 	})
 
 	// Step 3: Edit devcontainer.json to override remoteUser, then recreate.
-	// The explicit config value should take precedence over the metadata label.
+	// chownWorkspace in step 1 transferred ownership to metauser; restore
+	// write access so the test can modify devcontainer.json (Docker chown
+	// takes real effect, unlike rootless Podman where it silently fails).
 	t.Run("config override after recreate", func(t *testing.T) {
+		if latestResult != nil {
+			_ = d.ExecContainer(ctx, wsID, latestResult.ContainerID,
+				[]string{"chmod", "-R", "a+rwX", latestResult.WorkspaceFolder},
+				nil, io.Discard, io.Discard, nil, "root")
+		}
+
+		// The explicit config value should take precedence over the metadata label.
 		overrideConfig := fmt.Sprintf(`{
 			"image": %q,
 			"remoteUser": "root",

--- a/internal/engine/integration_test.go
+++ b/internal/engine/integration_test.go
@@ -1249,3 +1249,304 @@ func TestIntegrationResumePreservesMetadataUser(t *testing.T) {
 		}
 	})
 }
+
+// TestIntegrationRestartRecreatePreservesUser verifies that engine.Restart
+// preserves a metadata-inferred remoteUser through a safe-config-change
+// recreate (changeSafe path). Without the storedResult pre-set in
+// restartRecreate, user resolution could fall back to "root" if image
+// inspection yields no metadata.
+func TestIntegrationRestartRecreatePreservesUser(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	e, d, _ := newTestEngine(t)
+
+	// Pre-build an image with a devcontainer.metadata label.
+	prebuiltImage := "crib-test-restart-user:latest"
+	buildDir := t.TempDir()
+	dockerfileContent := "FROM alpine:3.20\n" +
+		"RUN adduser -D restartuser\n" +
+		`LABEL devcontainer.metadata='[{"remoteUser":"restartuser"}]'` + "\n"
+	if err := os.WriteFile(filepath.Join(buildDir, "Dockerfile"), []byte(dockerfileContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.BuildImage(ctx, "", &driver.BuildOptions{
+		Image:      prebuiltImage,
+		Dockerfile: filepath.Join(buildDir, "Dockerfile"),
+		Context:    buildDir,
+	}); err != nil {
+		t.Fatalf("pre-building image: %v", err)
+	}
+	t.Cleanup(func() { _ = d.RemoveImage(ctx, prebuiltImage) })
+
+	projectDir := t.TempDir()
+	devcontainerDir := filepath.Join(projectDir, ".devcontainer")
+	if err := os.MkdirAll(devcontainerDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(devcontainerDir, "devcontainer.json")
+
+	// Initial config: no remoteUser -- will be inferred from metadata.
+	writeConfig := func(extra string) {
+		content := fmt.Sprintf(`{"image":%q,"overrideCommand":true%s}`, prebuiltImage, extra)
+		if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeConfig("")
+
+	wsID := "test-engine-restart-user"
+	ws := &workspace.Workspace{
+		ID:               wsID,
+		Source:           projectDir,
+		DevContainerPath: ".devcontainer/devcontainer.json",
+		CreatedAt:        time.Now(),
+		LastUsedAt:       time.Now(),
+	}
+
+	_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
+	t.Cleanup(func() {
+		_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
+		cleanupWorkspaceImages(t, d, wsID)
+	})
+
+	// Step 1: initial Up -- infer remoteUser from metadata.
+	upResult, err := e.Up(ctx, ws, UpOptions{})
+	if err != nil {
+		t.Fatalf("Up: %v", err)
+	}
+	if upResult.RemoteUser != "restartuser" {
+		t.Fatalf("Up: RemoteUser = %q, want %q", upResult.RemoteUser, "restartuser")
+	}
+
+	// Restore workspace write permissions before touching devcontainer.json.
+	// chownWorkspace transferred ownership to restartuser; chmod lets the test
+	// runner (a different UID) write the config file (Docker chown is real).
+	_ = d.ExecContainer(ctx, wsID, upResult.ContainerID,
+		[]string{"chmod", "-R", "a+rwX", upResult.WorkspaceFolder},
+		nil, io.Discard, io.Discard, nil, "root")
+
+	// Step 2: safe config change (add a containerEnv entry) → changeSafe →
+	// restartRecreate path. remoteUser must be preserved from storedResult.
+	writeConfig(`,"containerEnv":{"CRIB_TEST":"1"}`)
+
+	restartResult, err := e.Restart(ctx, ws)
+	if err != nil {
+		t.Fatalf("Restart: %v", err)
+	}
+	if !restartResult.Recreated {
+		t.Errorf("Restart: Recreated = false, want true (config changed)")
+	}
+	if restartResult.RemoteUser != "restartuser" {
+		t.Errorf("Restart: RemoteUser = %q, want %q (preserved from stored result)", restartResult.RemoteUser, "restartuser")
+	}
+
+	t.Cleanup(func() {
+		_ = d.ExecContainer(ctx, wsID, restartResult.ContainerID,
+			[]string{"chmod", "-R", "a+rwX", restartResult.WorkspaceFolder},
+			nil, io.Discard, io.Discard, nil, "root")
+	})
+}
+
+// TestIntegrationFeaturesPreserveBaseImageMetadata verifies that building a
+// cfg.Image workspace with local features preserves the base image's
+// devcontainer.metadata label. Feature overlay Dockerfiles do not inherit
+// labels, so crib must carry the pre-build base metadata forward.
+// Without the fix (retaining pre-build labelMetadata when the built image
+// lacks the label), remoteUser inference would silently fall back to "root".
+func TestIntegrationFeaturesPreserveBaseImageMetadata(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	e, d, _ := newTestEngine(t)
+
+	// Pre-build a base image carrying a devcontainer.metadata label.
+	baseImage := "crib-test-feature-meta-base:latest"
+	buildDir := t.TempDir()
+	dockerfileContent := "FROM alpine:3.20\n" +
+		"RUN adduser -D featurebaseuser\n" +
+		`LABEL devcontainer.metadata='[{"remoteUser":"featurebaseuser"}]'` + "\n"
+	if err := os.WriteFile(filepath.Join(buildDir, "Dockerfile"), []byte(dockerfileContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.BuildImage(ctx, "", &driver.BuildOptions{
+		Image:      baseImage,
+		Dockerfile: filepath.Join(buildDir, "Dockerfile"),
+		Context:    buildDir,
+	}); err != nil {
+		t.Fatalf("pre-building base image: %v", err)
+	}
+	t.Cleanup(func() { _ = d.RemoveImage(ctx, baseImage) })
+
+	projectDir := t.TempDir()
+	devcontainerDir := filepath.Join(projectDir, ".devcontainer")
+	if err := os.MkdirAll(devcontainerDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Minimal no-op local feature required to trigger the image+features path
+	// (buildFromImage with features, where the built image lacks the metadata label).
+	featureDir := filepath.Join(devcontainerDir, "noop-feature")
+	if err := os.MkdirAll(featureDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	featureJSON := `{"id":"noop-feature","version":"1.0.0","name":"No-op Feature","description":"Used for testing metadata label retention"}`
+	if err := os.WriteFile(filepath.Join(featureDir, "devcontainer-feature.json"), []byte(featureJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(featureDir, "install.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// devcontainer.json uses cfg.Image + the local feature, no remoteUser.
+	// remoteUser must be inferred from the base image's metadata label.
+	configContent := fmt.Sprintf(`{
+		"image": %q,
+		"features": {"./noop-feature": {}},
+		"overrideCommand": true
+	}`, baseImage)
+	if err := os.WriteFile(filepath.Join(devcontainerDir, "devcontainer.json"), []byte(configContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	wsID := "test-engine-feature-meta"
+	ws := &workspace.Workspace{
+		ID:               wsID,
+		Source:           projectDir,
+		DevContainerPath: ".devcontainer/devcontainer.json",
+		CreatedAt:        time.Now(),
+		LastUsedAt:       time.Now(),
+	}
+
+	_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
+	t.Cleanup(func() {
+		_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
+		cleanupWorkspaceImages(t, d, wsID)
+	})
+
+	result, err := e.Up(ctx, ws, UpOptions{})
+	if err != nil {
+		t.Fatalf("Up: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = d.ExecContainer(ctx, wsID, result.ContainerID,
+			[]string{"chmod", "-R", "a+rwX", result.WorkspaceFolder},
+			nil, io.Discard, io.Discard, nil, "root")
+	})
+
+	if result.RemoteUser != "featurebaseuser" {
+		t.Errorf("RemoteUser = %q, want %q (from base image devcontainer.metadata, preserved through feature build)",
+			result.RemoteUser, "featurebaseuser")
+	}
+}
+
+// TestIntegrationCfgRemoteUserWinsOverImage verifies that an explicit
+// remoteUser in devcontainer.json takes precedence over image metadata and
+// Dockerfile USER for both the cfg.Image and cfg.build.dockerfile paths.
+func TestIntegrationCfgRemoteUserWinsOverImage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	e, d, _ := newTestEngine(t)
+
+	tests := []struct {
+		name             string
+		wsID             string
+		buildDockerfile  string // non-empty = cfg.build.dockerfile; empty = pre-built cfg.Image
+		configRemoteUser string
+		wantRemoteUser   string
+	}{
+		{
+			name:             "cfg.Image: config remoteUser wins over metadata",
+			wsID:             "test-engine-cfguser-image",
+			configRemoteUser: "root",
+			wantRemoteUser:   "root",
+		},
+		{
+			name:             "cfg.build.dockerfile: config remoteUser wins over Dockerfile USER",
+			wsID:             "test-engine-cfguser-dockerfile",
+			buildDockerfile:  "FROM alpine:3.20\nRUN adduser -D dfuser\nUSER dfuser\n",
+			configRemoteUser: "root",
+			wantRemoteUser:   "root",
+		},
+	}
+
+	// Pre-build a shared base image with a metadata label for the cfg.Image test case.
+	baseImage := "crib-test-cfguser-base:latest"
+	buildDir := t.TempDir()
+	dockerfileContent := "FROM alpine:3.20\n" +
+		"RUN adduser -D imguser\n" +
+		`LABEL devcontainer.metadata='[{"remoteUser":"imguser"}]'` + "\n"
+	if err := os.WriteFile(filepath.Join(buildDir, "Dockerfile"), []byte(dockerfileContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.BuildImage(ctx, "", &driver.BuildOptions{
+		Image:      baseImage,
+		Dockerfile: filepath.Join(buildDir, "Dockerfile"),
+		Context:    buildDir,
+	}); err != nil {
+		t.Fatalf("pre-building base image: %v", err)
+	}
+	t.Cleanup(func() { _ = d.RemoveImage(ctx, baseImage) })
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			projectDir := t.TempDir()
+			devcontainerDir := filepath.Join(projectDir, ".devcontainer")
+			if err := os.MkdirAll(devcontainerDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+
+			var configContent string
+			if tt.buildDockerfile != "" {
+				if err := os.WriteFile(filepath.Join(devcontainerDir, "Dockerfile"), []byte(tt.buildDockerfile), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				configContent = fmt.Sprintf(`{
+					"build": {"dockerfile": "Dockerfile"},
+					"remoteUser": %q,
+					"overrideCommand": true
+				}`, tt.configRemoteUser)
+			} else {
+				configContent = fmt.Sprintf(`{
+					"image": %q,
+					"remoteUser": %q,
+					"overrideCommand": true
+				}`, baseImage, tt.configRemoteUser)
+			}
+			if err := os.WriteFile(filepath.Join(devcontainerDir, "devcontainer.json"), []byte(configContent), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			ws := &workspace.Workspace{
+				ID:               tt.wsID,
+				Source:           projectDir,
+				DevContainerPath: ".devcontainer/devcontainer.json",
+				CreatedAt:        time.Now(),
+				LastUsedAt:       time.Now(),
+			}
+
+			_ = d.DeleteContainer(ctx, tt.wsID, oci.ContainerName(tt.wsID))
+			t.Cleanup(func() {
+				_ = d.DeleteContainer(ctx, tt.wsID, oci.ContainerName(tt.wsID))
+				cleanupWorkspaceImages(t, d, tt.wsID)
+			})
+
+			result, err := e.Up(ctx, ws, UpOptions{})
+			if err != nil {
+				t.Fatalf("Up: %v", err)
+			}
+
+			if result.RemoteUser != tt.wantRemoteUser {
+				t.Errorf("RemoteUser = %q, want %q", result.RemoteUser, tt.wantRemoteUser)
+			}
+		})
+	}
+}

--- a/internal/engine/integration_test.go
+++ b/internal/engine/integration_test.go
@@ -992,7 +992,8 @@ USER nonroot
 
 	configContent := `{
 		"build": {"dockerfile": "Dockerfile"},
-		"overrideCommand": true
+		"overrideCommand": true,
+		"updateRemoteUserUID": false
 	}`
 	if err := os.WriteFile(filepath.Join(devcontainerDir, "devcontainer.json"), []byte(configContent), 0o644); err != nil {
 		t.Fatal(err)

--- a/internal/engine/integration_test.go
+++ b/internal/engine/integration_test.go
@@ -1116,3 +1116,127 @@ func TestIntegrationImageBasedMetadataLabel(t *testing.T) {
 		t.Errorf("RemoteUser = %q, want %q (from devcontainer.metadata label on pre-built image)", result.RemoteUser, "imguser")
 	}
 }
+
+// TestIntegrationResumePreservesMetadataUser verifies the full lifecycle:
+//  1. Up infers remoteUser from devcontainer.metadata label
+//  2. Second Up (upExisting, container running) preserves the inferred user
+//  3. Editing devcontainer.json to set explicit remoteUser + recreate picks it up
+//
+// Subtests are sequential (shared container state); do not add t.Parallel.
+func TestIntegrationResumePreservesMetadataUser(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	e, d, _ := newTestEngine(t)
+
+	// Pre-build an image with a devcontainer.metadata label.
+	prebuiltImage := "crib-test-resume-metadata:latest"
+	buildDir := t.TempDir()
+	dockerfile := "FROM alpine:3.20\n" +
+		"RUN adduser -D metauser\n" +
+		`LABEL devcontainer.metadata='[{"remoteUser":"metauser"}]'` + "\n"
+	if err := os.WriteFile(filepath.Join(buildDir, "Dockerfile"), []byte(dockerfile), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.BuildImage(ctx, "", &driver.BuildOptions{
+		Image:      prebuiltImage,
+		Dockerfile: filepath.Join(buildDir, "Dockerfile"),
+		Context:    buildDir,
+	}); err != nil {
+		t.Fatalf("pre-building image: %v", err)
+	}
+	t.Cleanup(func() { _ = d.RemoveImage(ctx, prebuiltImage) })
+
+	projectDir := t.TempDir()
+	devcontainerDir := filepath.Join(projectDir, ".devcontainer")
+	if err := os.MkdirAll(devcontainerDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(devcontainerDir, "devcontainer.json")
+
+	// Initial config: no remoteUser, should be inferred from metadata.
+	initialConfig := fmt.Sprintf(`{
+		"image": %q,
+		"overrideCommand": true
+	}`, prebuiltImage)
+	if err := os.WriteFile(configPath, []byte(initialConfig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	wsID := "test-engine-resume-metadata"
+	ws := &workspace.Workspace{
+		ID:               wsID,
+		Source:           projectDir,
+		DevContainerPath: ".devcontainer/devcontainer.json",
+		CreatedAt:        time.Now(),
+		LastUsedAt:       time.Now(),
+	}
+
+	_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
+	t.Cleanup(func() {
+		_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
+		cleanupWorkspaceImages(t, d, wsID)
+	})
+
+	// Track the latest result so the chmod cleanup targets the right container.
+	var latestResult *UpResult
+
+	// Step 1: First Up infers remoteUser from metadata label.
+	t.Run("initial up infers metadata remoteUser", func(t *testing.T) {
+		result, err := e.Up(ctx, ws, UpOptions{})
+		if err != nil {
+			t.Fatalf("Up: %v", err)
+		}
+		if result.RemoteUser != "metauser" {
+			t.Errorf("RemoteUser = %q, want %q", result.RemoteUser, "metauser")
+		}
+		latestResult = result
+	})
+
+	// Step 2: Second Up finds existing container (upExisting path).
+	// Without the storedResult pre-set fix, this would regress to "root"
+	// because the metadata fallback isn't available in the resume path.
+	t.Run("second up preserves remoteUser", func(t *testing.T) {
+		result, err := e.Up(ctx, ws, UpOptions{})
+		if err != nil {
+			t.Fatalf("Up: %v", err)
+		}
+		if result.RemoteUser != "metauser" {
+			t.Errorf("RemoteUser = %q, want %q (preserved on resume)", result.RemoteUser, "metauser")
+		}
+		latestResult = result
+	})
+
+	// Step 3: Edit devcontainer.json to override remoteUser, then recreate.
+	// The explicit config value should take precedence over the metadata label.
+	t.Run("config override after recreate", func(t *testing.T) {
+		overrideConfig := fmt.Sprintf(`{
+			"image": %q,
+			"remoteUser": "root",
+			"overrideCommand": true
+		}`, prebuiltImage)
+		if err := os.WriteFile(configPath, []byte(overrideConfig), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := e.Up(ctx, ws, UpOptions{Recreate: true})
+		if err != nil {
+			t.Fatalf("Up (recreate): %v", err)
+		}
+		if result.RemoteUser != "root" {
+			t.Errorf("RemoteUser = %q, want %q (config override)", result.RemoteUser, "root")
+		}
+		latestResult = result
+	})
+
+	// Restore workspace permissions for TempDir cleanup (runs before container delete due to LIFO).
+	t.Cleanup(func() {
+		if latestResult != nil {
+			_ = d.ExecContainer(ctx, wsID, latestResult.ContainerID,
+				[]string{"chmod", "-R", "a+rwX", latestResult.WorkspaceFolder},
+				nil, io.Discard, io.Discard, nil, "root")
+		}
+	})
+}

--- a/internal/engine/integration_test.go
+++ b/internal/engine/integration_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -961,6 +962,15 @@ func TestIntegrationImageMetadataLabel(t *testing.T) {
 		t.Fatalf("Up: %v", err)
 	}
 
+	// Restore workspace ownership so t.TempDir cleanup can remove the dir.
+	// chownWorkspace transfers ownership to the non-root remoteUser; we must
+	// chown it back to root before the container is deleted.
+	t.Cleanup(func() {
+		_ = d.ExecContainer(ctx, wsID, result.ContainerID,
+			[]string{"chown", "-R", "root:root", result.WorkspaceFolder},
+			nil, io.Discard, io.Discard, nil, "root")
+	})
+
 	if result.RemoteUser != "testlabeluser" {
 		t.Errorf("RemoteUser = %q, want %q (from devcontainer.metadata label)", result.RemoteUser, "testlabeluser")
 	}
@@ -992,8 +1002,7 @@ USER nonroot
 
 	configContent := `{
 		"build": {"dockerfile": "Dockerfile"},
-		"overrideCommand": true,
-		"updateRemoteUserUID": false
+		"overrideCommand": true
 	}`
 	if err := os.WriteFile(filepath.Join(devcontainerDir, "devcontainer.json"), []byte(configContent), 0o644); err != nil {
 		t.Fatal(err)
@@ -1018,6 +1027,15 @@ USER nonroot
 	if err != nil {
 		t.Fatalf("Up: %v", err)
 	}
+
+	// Restore workspace ownership so t.TempDir cleanup can remove the dir.
+	// chownWorkspace transfers ownership to the non-root remoteUser; we must
+	// chown it back to root before the container is deleted.
+	t.Cleanup(func() {
+		_ = d.ExecContainer(ctx, wsID, result.ContainerID,
+			[]string{"chown", "-R", "root:root", result.WorkspaceFolder},
+			nil, io.Discard, io.Discard, nil, "root")
+	})
 
 	if result.RemoteUser != "nonroot" {
 		t.Errorf("RemoteUser = %q, want %q (from Dockerfile USER instruction)", result.RemoteUser, "nonroot")

--- a/internal/engine/integration_test.go
+++ b/internal/engine/integration_test.go
@@ -906,3 +906,119 @@ func TestIntegrationDoctor(t *testing.T) {
 	}
 	_ = d // keep linter happy
 }
+
+func TestIntegrationImageMetadataLabel(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	e, d, _ := newTestEngine(t)
+
+	projectDir := t.TempDir()
+	devcontainerDir := filepath.Join(projectDir, ".devcontainer")
+	if err := os.MkdirAll(devcontainerDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Dockerfile with a devcontainer.metadata label declaring remoteUser.
+	// The label is the spec mechanism for pre-built images to carry user config
+	// (e.g. mcr.microsoft.com/devcontainers/* images use this pattern).
+	dockerfile := "FROM alpine:3.20\n" +
+		"RUN adduser -D testlabeluser\n" +
+		`LABEL devcontainer.metadata='[{"remoteUser":"testlabeluser"}]'` + "\n"
+	if err := os.WriteFile(filepath.Join(devcontainerDir, "Dockerfile"), []byte(dockerfile), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// devcontainer.json intentionally omits remoteUser -- it should be inferred
+	// from the devcontainer.metadata label baked into the image.
+	configContent := `{
+		"build": {"dockerfile": "Dockerfile"},
+		"overrideCommand": true
+	}`
+	if err := os.WriteFile(filepath.Join(devcontainerDir, "devcontainer.json"), []byte(configContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	wsID := "test-engine-metadata-label"
+	ws := &workspace.Workspace{
+		ID:               wsID,
+		Source:           projectDir,
+		DevContainerPath: ".devcontainer/devcontainer.json",
+		CreatedAt:        time.Now(),
+		LastUsedAt:       time.Now(),
+	}
+
+	_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
+	t.Cleanup(func() {
+		_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
+		cleanupWorkspaceImages(t, d, wsID)
+	})
+
+	result, err := e.Up(ctx, ws, UpOptions{})
+	if err != nil {
+		t.Fatalf("Up: %v", err)
+	}
+
+	if result.RemoteUser != "testlabeluser" {
+		t.Errorf("RemoteUser = %q, want %q (from devcontainer.metadata label)", result.RemoteUser, "testlabeluser")
+	}
+}
+
+func TestIntegrationDockerfileUser(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	e, d, _ := newTestEngine(t)
+
+	projectDir := t.TempDir()
+	devcontainerDir := filepath.Join(projectDir, ".devcontainer")
+	if err := os.MkdirAll(devcontainerDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Dockerfile with a USER instruction but no remoteUser in devcontainer.json.
+	// crib should infer remoteUser from the image's Config.User after the build.
+	dockerfile := `FROM alpine:3.20
+RUN adduser -D nonroot
+USER nonroot
+`
+	if err := os.WriteFile(filepath.Join(devcontainerDir, "Dockerfile"), []byte(dockerfile), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	configContent := `{
+		"build": {"dockerfile": "Dockerfile"},
+		"overrideCommand": true
+	}`
+	if err := os.WriteFile(filepath.Join(devcontainerDir, "devcontainer.json"), []byte(configContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	wsID := "test-engine-dockerfile-user"
+	ws := &workspace.Workspace{
+		ID:               wsID,
+		Source:           projectDir,
+		DevContainerPath: ".devcontainer/devcontainer.json",
+		CreatedAt:        time.Now(),
+		LastUsedAt:       time.Now(),
+	}
+
+	_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
+	t.Cleanup(func() {
+		_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
+		cleanupWorkspaceImages(t, d, wsID)
+	})
+
+	result, err := e.Up(ctx, ws, UpOptions{})
+	if err != nil {
+		t.Fatalf("Up: %v", err)
+	}
+
+	if result.RemoteUser != "nonroot" {
+		t.Errorf("RemoteUser = %q, want %q (from Dockerfile USER instruction)", result.RemoteUser, "nonroot")
+	}
+}

--- a/internal/engine/integration_test.go
+++ b/internal/engine/integration_test.go
@@ -1041,3 +1041,78 @@ USER nonroot
 		t.Errorf("RemoteUser = %q, want %q (from Dockerfile USER instruction)", result.RemoteUser, "nonroot")
 	}
 }
+
+// TestIntegrationImageBasedMetadataLabel tests the cfg.Image path (no
+// Dockerfile, no features) where remoteUser is inferred from a pre-built
+// image's devcontainer.metadata label.
+func TestIntegrationImageBasedMetadataLabel(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	e, d, _ := newTestEngine(t)
+
+	// Pre-build an image with a devcontainer.metadata label.
+	prebuiltImage := "crib-test-prebuilt-metadata:latest"
+	buildDir := t.TempDir()
+	dockerfile := "FROM alpine:3.20\n" +
+		"RUN adduser -D imguser\n" +
+		`LABEL devcontainer.metadata='[{"remoteUser":"imguser"}]'` + "\n"
+	if err := os.WriteFile(filepath.Join(buildDir, "Dockerfile"), []byte(dockerfile), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.BuildImage(ctx, "", &driver.BuildOptions{
+		Image:      prebuiltImage,
+		Dockerfile: filepath.Join(buildDir, "Dockerfile"),
+		Context:    buildDir,
+	}); err != nil {
+		t.Fatalf("pre-building image: %v", err)
+	}
+	t.Cleanup(func() { _ = d.RemoveImage(ctx, prebuiltImage) })
+
+	projectDir := t.TempDir()
+	devcontainerDir := filepath.Join(projectDir, ".devcontainer")
+	if err := os.MkdirAll(devcontainerDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// devcontainer.json uses "image" (no build), omits remoteUser.
+	configContent := fmt.Sprintf(`{
+		"image": %q,
+		"overrideCommand": true
+	}`, prebuiltImage)
+	if err := os.WriteFile(filepath.Join(devcontainerDir, "devcontainer.json"), []byte(configContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	wsID := "test-engine-image-metadata"
+	ws := &workspace.Workspace{
+		ID:               wsID,
+		Source:           projectDir,
+		DevContainerPath: ".devcontainer/devcontainer.json",
+		CreatedAt:        time.Now(),
+		LastUsedAt:       time.Now(),
+	}
+
+	_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
+	t.Cleanup(func() {
+		_ = d.DeleteContainer(ctx, wsID, oci.ContainerName(wsID))
+		cleanupWorkspaceImages(t, d, wsID)
+	})
+
+	result, err := e.Up(ctx, ws, UpOptions{})
+	if err != nil {
+		t.Fatalf("Up: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = d.ExecContainer(ctx, wsID, result.ContainerID,
+			[]string{"chmod", "-R", "a+rwX", result.WorkspaceFolder},
+			nil, io.Discard, io.Discard, nil, "root")
+	})
+
+	if result.RemoteUser != "imguser" {
+		t.Errorf("RemoteUser = %q, want %q (from devcontainer.metadata label on pre-built image)", result.RemoteUser, "imguser")
+	}
+}

--- a/internal/engine/restart.go
+++ b/internal/engine/restart.go
@@ -206,8 +206,15 @@ func (e *Engine) restartRecreate(ctx context.Context, ws *workspace.Workspace, c
 		}
 	}
 
-	// Dispatch plugins.
+	// Dispatch plugins. Apply the same metadata/imageUser fallback as upCreate
+	// so plugins target the correct home directory when config omits user fields.
 	pluginUser := b.pluginUser(ctx)
+	if pluginUser == "" {
+		pluginUser = remoteUserFromMetadata(metadata)
+	}
+	if pluginUser == "" {
+		pluginUser = imageUser
+	}
 	pluginResp, err := e.dispatchPlugins(ctx, ws, cfg, imgResult.imageName, workspaceFolder, pluginUser)
 	if err != nil {
 		return nil, err

--- a/internal/engine/restart.go
+++ b/internal/engine/restart.go
@@ -183,6 +183,7 @@ func (e *Engine) restartRecreate(ctx context.Context, ws *workspace.Workspace, c
 	// Determine the image to use.
 	imgResult := resolveRestartImage(hasSnapshot, snapshotImage, *storedResult, cfg)
 	var metadata []*config.ImageMetadata
+	var imageUser string
 
 	if imgResult.needsBuild {
 		e.reportProgress(PhaseBuild, "No cached image found, rebuilding...")
@@ -193,6 +194,7 @@ func (e *Engine) restartRecreate(ctx context.Context, ws *workspace.Workspace, c
 		imgResult.imageName = buildRes.imageName
 		imgResult.hasEntrypoints = buildRes.hasEntrypoints
 		metadata = buildRes.imageMetadata
+		imageUser = buildRes.imageUser
 	}
 
 	// Dispatch plugins.
@@ -233,6 +235,7 @@ func (e *Engine) restartRecreate(ctx context.Context, ws *workspace.Workspace, c
 		storedResult:   storedResult,
 		fromSnapshot:   hasSnapshot,
 		imageMetadata:  metadata,
+		imageUser:      imageUser,
 	})
 	if err != nil {
 		if upResult != nil {

--- a/internal/engine/restart.go
+++ b/internal/engine/restart.go
@@ -159,6 +159,7 @@ func (e *Engine) restartSimple(ctx context.Context, ws *workspace.Workspace, cfg
 		storedResult:    storedResult,
 		fromSnapshot:    true,
 		skipVolumeChown: true,
+		fromBuild:       false,
 	})
 	if err != nil {
 		return nil, err
@@ -244,6 +245,7 @@ func (e *Engine) restartRecreate(ctx context.Context, ws *workspace.Workspace, c
 		fromSnapshot:   hasSnapshot,
 		imageMetadata:  metadata,
 		imageUser:      imageUser,
+		fromBuild:      imgResult.needsBuild,
 	})
 	if err != nil {
 		if upResult != nil {

--- a/internal/engine/restart.go
+++ b/internal/engine/restart.go
@@ -195,6 +195,14 @@ func (e *Engine) restartRecreate(ctx context.Context, ws *workspace.Workspace, c
 		imgResult.hasEntrypoints = buildRes.hasEntrypoints
 		metadata = buildRes.imageMetadata
 		imageUser = buildRes.imageUser
+	} else if imgResult.imageName != "" {
+		// Inspect the cached/snapshot image for metadata and Config.User
+		// so finalize can infer remoteUser from devcontainer.metadata or
+		// Dockerfile USER even when no rebuild is needed.
+		if details, inspErr := e.driver.InspectImage(ctx, imgResult.imageName); inspErr == nil && details != nil {
+			imageUser = userFromConfigUser(details.Config.User)
+			metadata = parseImageMetadataLabel(details.Config.Labels)
+		}
 	}
 
 	// Dispatch plugins.

--- a/internal/engine/restart.go
+++ b/internal/engine/restart.go
@@ -209,9 +209,11 @@ func (e *Engine) restartRecreate(ctx context.Context, ws *workspace.Workspace, c
 	}
 
 	// Dispatch plugins. Backend handles config-vs-fallback precedence.
+	// Fallback chain: metadata remoteUser → image Config.User → stored result.
 	pluginUser := b.pluginUser(ctx,
 		remoteUserFromMetadata(metadata),
-		imageUser)
+		imageUser,
+		storedResult.RemoteUser)
 	pluginResp, err := e.dispatchPlugins(ctx, ws, cfg, imgResult.imageName, workspaceFolder, pluginUser)
 	if err != nil {
 		return nil, err

--- a/internal/engine/restart.go
+++ b/internal/engine/restart.go
@@ -230,9 +230,19 @@ func (e *Engine) restartRecreate(ctx context.Context, ws *workspace.Workspace, c
 		return nil, err
 	}
 
+	// Pre-set remoteUser from stored result only when config doesn't have an
+	// explicit user. This guards against inspection failures (image pruned,
+	// transient runtime error) causing finalize to fall back to "root" and
+	// skip volume chown for a previously-inferred non-root user.
+	// Mirrors the same guard in restartSimple.
+	remoteUser := ""
+	if configRemoteUser(cfg) == "" && storedResult.RemoteUser != "" {
+		remoteUser = storedResult.RemoteUser
+	}
 	cc := containerContext{
 		workspaceID:     ws.ID,
 		containerID:     containerID,
+		remoteUser:      remoteUser,
 		workspaceFolder: workspaceFolder,
 	}
 

--- a/internal/engine/restart.go
+++ b/internal/engine/restart.go
@@ -126,12 +126,8 @@ func (e *Engine) restartSimple(ctx context.Context, ws *workspace.Workspace, cfg
 		return nil, &ErrNoContainer{WorkspaceID: ws.ID}
 	}
 
-	// Dispatch plugins.
-	pluginUser := b.pluginUser(ctx)
-	if pluginUser == "" {
-		// For non-compose, use stored remote user for plugin dispatch.
-		pluginUser = storedResult.RemoteUser
-	}
+	// Dispatch plugins. Backend handles config-vs-fallback precedence.
+	pluginUser := b.pluginUser(ctx, storedResult.RemoteUser)
 	pluginResp, err := e.dispatchPlugins(ctx, ws, cfg, storedResult.ImageName, workspaceFolder, pluginUser)
 	if err != nil {
 		e.logger.Warn("plugin dispatch failed, continuing without plugins", "error", err)
@@ -144,10 +140,16 @@ func (e *Engine) restartSimple(ctx context.Context, ws *workspace.Workspace, cfg
 		return nil, err
 	}
 
+	// Pre-set remoteUser from stored result only when config doesn't have
+	// an explicit user. This allows live config changes to take effect.
+	remoteUser := ""
+	if configRemoteUser(cfg) == "" && storedResult.RemoteUser != "" {
+		remoteUser = storedResult.RemoteUser
+	}
 	cc := containerContext{
 		workspaceID:     ws.ID,
 		containerID:     newID,
-		remoteUser:      storedResult.RemoteUser, // pre-set to skip whoami
+		remoteUser:      remoteUser,
 		workspaceFolder: workspaceFolder,
 	}
 
@@ -206,15 +208,10 @@ func (e *Engine) restartRecreate(ctx context.Context, ws *workspace.Workspace, c
 		}
 	}
 
-	// Dispatch plugins. Apply the same metadata/imageUser fallback as upCreate
-	// so plugins target the correct home directory when config omits user fields.
-	pluginUser := b.pluginUser(ctx)
-	if pluginUser == "" {
-		pluginUser = remoteUserFromMetadata(metadata)
-	}
-	if pluginUser == "" {
-		pluginUser = imageUser
-	}
+	// Dispatch plugins. Backend handles config-vs-fallback precedence.
+	pluginUser := b.pluginUser(ctx,
+		remoteUserFromMetadata(metadata),
+		imageUser)
 	pluginResp, err := e.dispatchPlugins(ctx, ws, cfg, imgResult.imageName, workspaceFolder, pluginUser)
 	if err != nil {
 		return nil, err

--- a/internal/engine/restart.go
+++ b/internal/engine/restart.go
@@ -154,14 +154,14 @@ func (e *Engine) restartSimple(ctx context.Context, ws *workspace.Workspace, cfg
 	}
 
 	result, err := e.finalize(ctx, ws, cfg, finalizeOpts{
-		cc:              cc,
-		imageName:       storedResult.ImageName,
-		hasEntrypoints:  storedResult.HasFeatureEntrypoints,
-		pluginResp:      pluginResp,
-		storedResult:    storedResult,
-		fromSnapshot:    true,
-		skipVolumeChown: true,
-		fromBuild:       false,
+		cc:                      cc,
+		imageName:               storedResult.ImageName,
+		hasEntrypoints:          storedResult.HasFeatureEntrypoints,
+		pluginResp:              pluginResp,
+		storedResult:            storedResult,
+		fromSnapshot:            true,
+		skipVolumeChown:         true,
+		shouldMergeFeatureHooks: false,
 	})
 	if err != nil {
 		return nil, err
@@ -243,15 +243,15 @@ func (e *Engine) restartRecreate(ctx context.Context, ws *workspace.Workspace, c
 	}
 
 	upResult, err := e.finalize(ctx, ws, cfg, finalizeOpts{
-		cc:             cc,
-		imageName:      resultImageName,
-		hasEntrypoints: imgResult.hasEntrypoints,
-		pluginResp:     pluginResp,
-		storedResult:   storedResult,
-		fromSnapshot:   hasSnapshot,
-		imageMetadata:  metadata,
-		imageUser:      imageUser,
-		fromBuild:      imgResult.needsBuild,
+		cc:                      cc,
+		imageName:               resultImageName,
+		hasEntrypoints:          imgResult.hasEntrypoints,
+		pluginResp:              pluginResp,
+		storedResult:            storedResult,
+		fromSnapshot:            hasSnapshot,
+		imageMetadata:           metadata,
+		imageUser:               imageUser,
+		shouldMergeFeatureHooks: imgResult.needsBuild,
 	})
 	if err != nil {
 		if upResult != nil {


### PR DESCRIPTION
## Summary

Two devcontainer spec compliance fixes for `remoteUser`/`containerUser` resolution:

**Bug 1: `crib shell`/`exec`/`run` ignored updated `remoteUser`**

Per the spec, `remoteUser` governs tool processes. These commands were reading it exclusively from `result.json` (written at `crib up` time), so edits to `devcontainer.json` were silently ignored until the next rebuild. Now re-parses the live config on each invocation and falls back to the stored value on parse failure.

**Bug 2: `remoteUser`/`containerUser` not inferred from image**

When `devcontainer.json` omits both fields, the spec says `containerUser` defaults to the last Dockerfile `USER` instruction and `remoteUser` defaults to `containerUser`. Pre-built images can also declare `remoteUser` via a `devcontainer.metadata` label (e.g. `mcr.microsoft.com/devcontainers/javascript-node` sets `remoteUser: "node"` this way).

Per the spec, `containerUser` and `remoteUser` are independent "last value wins" properties that merge separately. `containerUserFromMetadata` and `remoteUserFromMetadata` resolve them independently (each prefers its own field, falls back to the other). This matters for images where metadata has `containerUser: "root"` + `remoteUser: "node"` — both must be respected.

### Changes

- `liveRemoteUser()` in `cmd/user.go`: re-parses the live config on each `shell`/`exec`/`run` invocation
- `parseImageMetadataLabel`: parses the `devcontainer.metadata` label (JSON array or single-object)
- `containerUserFromMetadata` / `remoteUserFromMetadata`: resolve each property independently from metadata per spec merge semantics
- `buildFromImage`: inspects the base image to capture metadata label and `Config.User`; resolves `containerUser` and `remoteUser` separately before feature context generation
- `buildFromDockerfile`: inspects the built image after `doBuild` to capture `Config.User` and any metadata label
- `backend.pluginUser(ctx, fallbacks...)`: unified config-first interface for both single and compose backends. Single: config → fallbacks. Compose: config → compose-derived → fallbacks. The compose backend no longer ignores fallbacks.
- `restartRecreate`: threads `remoteUserFromMetadata(metadata)`, `imageUser`, and `storedResult.RemoteUser` as fallbacks for plugin dispatch, preserving prior resolution when image inspection yields nothing
- `finalizeOpts.shouldMergeFeatureHooks`: renamed from `fromBuild` — controls whether feature lifecycle hooks should be merged from `imageMetadata` and stored for restart/resume, not whether a build occurred

## Test plan

- [x] Unit tests for `parseImageMetadataLabel` (array, single-object, missing, empty, malformed JSON)
- [x] Unit tests for `resolveRemoteUser` with `imageUser` fallback
- [x] Unit tests for `liveRemoteUser` (override, fallback, missing config)
- [x] Unit tests for `containerUserFromMetadata` (containerUser wins, remoteUser as fallback, last entry wins)
- [x] Unit tests for `remoteUserFromMetadata` (remoteUser preferred, containerUser fallback, last entry wins)
- [x] Unit tests for `pluginUser` precedence and fallbacks (single + compose backends)
- [x] Integration: `TestIntegrationImageMetadataLabel` — Dockerfile with `devcontainer.metadata` label; verifies `result.RemoteUser` is inferred without explicit config
- [x] Integration: `TestIntegrationDockerfileUser` — Dockerfile with `USER nonroot`; verifies `result.RemoteUser == "nonroot"` without explicit config
- [x] E2E: `TestE2ELiveRemoteUserOverride` — edits `remoteUser` in `devcontainer.json` after `crib up` and verifies `crib shell` picks it up without rebuild