### PR TITLE
fix(ci): address OpenSSF Scorecard findings

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,8 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22
           cache: npm
@@ -31,7 +31,7 @@ jobs:
         working-directory: website
       - run: npm run build
         working-directory: website
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: website/dist
 
@@ -44,4 +44,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: true
@@ -39,7 +39,7 @@ jobs:
             exit 1
           fi
 
-      - uses: goreleaser/goreleaser-action@v7
+      - uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         with:
           version: "~> v2"
           args: release --clean --release-notes /tmp/release-notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - "v*"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   tests:
@@ -16,6 +16,8 @@ jobs:
     name: GoReleaser
     needs: tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -28,6 +29,8 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+
+      - uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.10.1
 
       - name: Extract release notes from CHANGELOG.md
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,14 @@ jobs:
         env:
           CRIB_RUNTIME: docker
           GO_TEST_FLAGS: -json
+      - name: Fuzz tests (30s budget)
+        run: |
+          for pkg in ./internal/config/ ./internal/dockerfile/; do
+            for fuzz in $(go test "$pkg" -list 'Fuzz.*' 2>/dev/null | grep '^Fuzz'); do
+              echo "==> $pkg $fuzz"
+              go test "$pkg" -run "^$fuzz\$" -fuzz "^$fuzz\$" -fuzztime 10s
+            done
+          done
       - name: Lint
         run: make lint
       - name: Check formatting

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,13 +11,13 @@ jobs:
     name: Tests & lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: true
       - name: Install gotestfmt
-        run: go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
+        run: go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@v2.5.0
       - name: Unit tests
         run: set -euo pipefail && make test | tee /tmp/gotest.log | gotestfmt
         env:
@@ -52,13 +52,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: true
       - name: Install gotestfmt
-        run: go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
+        run: go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@v2.5.0
       # Suppress "Executing external compose provider" warnings that make
       # CI output look like failures (containers/podman#23441).
       - name: Configure podman
@@ -81,13 +81,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: true
       - name: Install gotestfmt
-        run: go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
+        run: go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@v2.5.0
       - name: Verify Docker is available
         run: docker info
       - name: E2E tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,10 +27,10 @@ jobs:
         env:
           CRIB_RUNTIME: docker
           GO_TEST_FLAGS: -json
-      - name: Fuzz tests (30s budget)
+      - name: Fuzz tests (10s per target)
         run: |
           for pkg in ./internal/config/ ./internal/dockerfile/; do
-            for fuzz in $(go test "$pkg" -list 'Fuzz.*' 2>/dev/null | grep '^Fuzz'); do
+            for fuzz in $(go test "$pkg" -list 'Fuzz.*' | grep '^Fuzz'); do
               echo "==> $pkg $fuzz"
               go test "$pkg" -run "^$fuzz\$" -fuzz "^$fuzz\$" -fuzztime 10s
             done

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,6 +26,16 @@ archives:
 checksum:
   name_template: checksums.txt
 
+signs:
+  - cmd: cosign
+    signature: "${artifact}.sigstore.json"
+    args:
+      - sign-blob
+      - "--bundle=${signature}"
+      - "${artifact}"
+      - "--yes"
+    artifacts: checksum
+
 release:
   github:
     owner: fgrehm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Go fuzz tests for config parsing (`ParseBytes`, `ParseMount`,
+  `SubstituteString`) and Dockerfile handling (`Parse`, `RemoveSyntaxVersion`,
+  `EnsureFinalStageName`). Runs in CI with a 10s per-target budget.
+- Cosign keyless signing for release artifacts. `checksums.txt.sigstore.json`
+  is now attached to each GitHub release.
+- `SECURITY.md` with responsible disclosure instructions.
+
+### Security
+
+- GitHub Actions pinned to commit SHAs across all workflows.
+- `contents: write` permission scoped to the GoReleaser job in `release.yml`
+  (was workflow-level).
+
 ## [0.8.0] - 2026-04-07
 
 ### Added

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@ Please include:
 - Steps to reproduce
 - The potential impact
 
-You should receive an initial response within 7 days. Please do not open a
+You should receive an initial response within a few days. Please do not open a
 public issue for security vulnerabilities.
 
 ## Supported Versions

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in crib, please report it through
+[GitHub's private vulnerability reporting](https://github.com/fgrehm/crib/security/advisories/new).
+
+Please include:
+
+- A description of the vulnerability
+- Steps to reproduce
+- The potential impact
+
+You should receive an initial response within 7 days. Please do not open a
+public issue for security vulnerabilities.
+
+## Supported Versions
+
+Security fixes are applied to the latest release only.

--- a/internal/config/fuzz_test.go
+++ b/internal/config/fuzz_test.go
@@ -19,6 +19,32 @@ func FuzzParseBytes(f *testing.F) {
 	})
 }
 
+func FuzzSubstituteString(f *testing.F) {
+	f.Add("${localWorkspaceFolder}/src")
+	f.Add("${containerWorkspaceFolder}")
+	f.Add("${localEnv:HOME}")
+	f.Add("${localEnv:MISSING:default-value}")
+	f.Add("${containerEnv:PATH}")
+	f.Add("${devcontainerId}")
+	f.Add("${localWorkspaceFolderBasename}")
+	f.Add("no variables here")
+	f.Add("${unknown}")
+	f.Add("nested ${localEnv:${nope}}")
+	f.Add("")
+
+	ctx := &SubstitutionContext{
+		DevContainerID:           "test-id",
+		LocalWorkspaceFolder:     "/home/user/project",
+		ContainerWorkspaceFolder: "/workspaces/project",
+		Env:                      map[string]string{"HOME": "/home/user", "PATH": "/usr/bin"},
+	}
+
+	f.Fuzz(func(t *testing.T, s string) {
+		// SubstituteString must not panic on any input.
+		_ = SubstituteString(ctx, s)
+	})
+}
+
 func FuzzParseMount(f *testing.F) {
 	f.Add("type=bind,src=/tmp,dst=/tmp")
 	f.Add("type=volume,source=mydata,target=/data")

--- a/internal/config/fuzz_test.go
+++ b/internal/config/fuzz_test.go
@@ -1,0 +1,34 @@
+package config
+
+import "testing"
+
+func FuzzParseBytes(f *testing.F) {
+	f.Add([]byte(`{"image": "ubuntu:22.04"}`))
+	f.Add([]byte(`{"dockerFile": "Dockerfile", "context": "."}`))
+	f.Add([]byte(`{"dockerComposeFile": "docker-compose.yml", "service": "app"}`))
+	f.Add([]byte(`// comment
+{"image": "node:20", "remoteUser": "node"}`))
+	f.Add([]byte(`{"image": "alpine", "mounts": ["type=bind,src=/tmp,dst=/tmp"]}`))
+	f.Add([]byte(`{}`))
+	f.Add([]byte(`not json at all`))
+	f.Add([]byte{})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// ParseBytes must not panic on any input.
+		_, _ = ParseBytes(data)
+	})
+}
+
+func FuzzParseMount(f *testing.F) {
+	f.Add("type=bind,src=/tmp,dst=/tmp")
+	f.Add("type=volume,source=mydata,target=/data")
+	f.Add("type=bind,source=${localWorkspaceFolder},target=/workspace")
+	f.Add("")
+	f.Add("no-equals-here")
+	f.Add("dst=/only-target")
+
+	f.Fuzz(func(t *testing.T, s string) {
+		// ParseMount must not panic on any input.
+		_, _ = ParseMount(s)
+	})
+}

--- a/internal/dockerfile/fuzz_test.go
+++ b/internal/dockerfile/fuzz_test.go
@@ -24,6 +24,19 @@ func FuzzParse(f *testing.F) {
 	})
 }
 
+func FuzzRemoveSyntaxVersion(f *testing.F) {
+	f.Add("# syntax=docker/dockerfile:1\nFROM ubuntu:22.04")
+	f.Add("#syntax=docker/dockerfile:1.4\nFROM node:20")
+	f.Add("FROM alpine:3.20")
+	f.Add("# syntax=docker/dockerfile:1\n# syntax=docker/dockerfile:1.4\nFROM scratch")
+	f.Add("")
+
+	f.Fuzz(func(t *testing.T, content string) {
+		// RemoveSyntaxVersion must not panic on any input.
+		_ = RemoveSyntaxVersion(content)
+	})
+}
+
 func FuzzEnsureFinalStageName(f *testing.F) {
 	f.Add("FROM ubuntu:22.04", "dev_container")
 	f.Add("FROM golang:1.22 AS builder\nFROM alpine:3.20", "dev_container")

--- a/internal/dockerfile/fuzz_test.go
+++ b/internal/dockerfile/fuzz_test.go
@@ -1,0 +1,37 @@
+package dockerfile
+
+import "testing"
+
+func FuzzParse(f *testing.F) {
+	f.Add("FROM ubuntu:22.04")
+	f.Add("FROM golang:1.22 AS builder\nRUN go build .\nFROM alpine:3.20\nCOPY --from=builder /app /app")
+	f.Add("ARG BASE=ubuntu:22.04\nFROM ${BASE}\nUSER node")
+	f.Add("FROM scratch")
+	f.Add("# syntax=docker/dockerfile:1\nFROM node:20")
+	f.Add("")
+	f.Add("not a dockerfile")
+
+	f.Fuzz(func(t *testing.T, content string) {
+		// Parse must not panic on any input.
+		df, err := Parse(content)
+		if err != nil {
+			return
+		}
+
+		// Exercise methods that process parsed output.
+		df.FindBaseImage(nil, "")
+		df.FindUserStatement(nil, nil, "")
+	})
+}
+
+func FuzzEnsureFinalStageName(f *testing.F) {
+	f.Add("FROM ubuntu:22.04", "dev_container")
+	f.Add("FROM golang:1.22 AS builder\nFROM alpine:3.20", "dev_container")
+	f.Add("FROM node:20 AS app", "dev_container")
+	f.Add("", "dev_container")
+
+	f.Fuzz(func(t *testing.T, content, name string) {
+		// EnsureFinalStageName must not panic on any input.
+		_, _, _ = EnsureFinalStageName(content, name)
+	})
+}


### PR DESCRIPTION
## Summary

Addresses several OpenSSF Scorecard findings (baseline score: 4.8/10 on commit ee09a9b).

- Pin all GitHub Actions to commit SHAs across `docs.yml`, `release.yml`, and
  `test.yml`. Also pins `gotestfmt@v2.5.0`. Dependabot will keep these current.
- Scope `contents: write` to the GoReleaser job in `release.yml` (was workflow-level).
- Add `SECURITY.md` pointing to GitHub private vulnerability reporting.
- Add cosign keyless signing to releases. GoReleaser signs `checksums.txt` via
  Sigstore OIDC, producing `checksums.txt.sigstore.json` as a release asset.
- Add 6 Go fuzz tests covering config parsing (`ParseBytes`, `ParseMount`,
  `SubstituteString`) and Dockerfile handling (`Parse`, `RemoveSyntaxVersion`,
  `EnsureFinalStageName`). Each target runs for 10s in CI.

Not addressed: Branch-Protection (GitHub settings, handled separately),
Code-Review (solo maintainer), CII-Best-Practices (external questionnaire).