### PR TITLE
feat(coding-agents): add pi credential support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cosign keyless signing for release artifacts. `checksums.txt.sigstore.json`
   is now attached to each GitHub release.
 - `SECURITY.md` with responsible disclosure instructions.
+- pi support in the coding-agents plugin. Enablement is auto-detected from the
+  presence of `~/.pi/agent/auth.json` on the host, and pi follows the same
+  `credentials` mode as Claude Code. In host mode, the auth file is copied
+  into the container. In workspace mode, a persistent state directory is
+  bind-mounted so credentials created inside the container survive rebuilds.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cosign keyless signing for release artifacts. `checksums.txt.sigstore.json`
   is now attached to each GitHub release.
 - `SECURITY.md` with responsible disclosure instructions.
-- pi support in the coding-agents plugin. Enablement is auto-detected from the
-  presence of `~/.pi/agent/auth.json` on the host, and pi follows the same
-  `credentials` mode as Claude Code. In host mode, the auth file is copied
-  into the container. In workspace mode, a persistent state directory is
-  bind-mounted so credentials created inside the container survive rebuilds.
+- pi support in the coding-agents plugin. pi behaves identically to Claude
+  Code under the shared `credentials` mode: in host mode,
+  `~/.pi/agent/auth.json` is copied into the container when it exists on the
+  host; in workspace mode, a persistent state directory is bind-mounted so
+  credentials created inside the container survive rebuilds.
 
 ### Fixed
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -131,6 +131,28 @@ After switching to workspace mode, run `claude` inside the container and authent
 | Claude not installed on host | Workspace |
 | Credentials should stay per-project | Workspace |
 
+### pi support
+
+In addition to Claude Code, crib also supports [pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) credentials. Both agents can run side-by-side in the same container and share the same `credentials` mode.
+
+**Enablement is auto-detected.** pi is only active when `~/.pi/agent/auth.json` exists on the host. If the file is missing, crib produces no pi artifacts regardless of mode. Once enabled, pi follows whichever `credentials` mode you pick for Claude:
+
+| Mode | `~/.pi/agent/auth.json` on host? | Behavior |
+|---|---|---|
+| `host` (default) | yes | `auth.json` is copied into the container on each `crib up`. |
+| `workspace` | yes | `~/.crib/workspaces/{id}/plugins/coding-agents/pi-state/` is bind-mounted over `~/.pi/agent/`. The mount shadows the host file; authenticate inside the container and the credentials persist across rebuilds. |
+| either | no | Nothing. |
+
+:::note[Enabling pi without installing it on the host]
+If you want per-workspace pi credentials but don't have pi installed on the host, `touch` the auth file to signal intent, then use workspace mode:
+
+```sh
+mkdir -p ~/.pi/agent && touch ~/.pi/agent/auth.json
+```
+
+Then set `credentials: "workspace"` and authenticate inside the container on first use. (Don't use this with host mode — an empty auth file would get copied into the container.)
+:::
+
 ### Credential cleanup
 
 In both modes, plugin data (including credentials) is stored on the host under `~/.crib/workspaces/{id}/plugins/coding-agents/`. Running `crib remove` deletes the workspace and all plugin data with it.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -133,25 +133,12 @@ After switching to workspace mode, run `claude` inside the container and authent
 
 ### pi support
 
-In addition to Claude Code, crib also supports [pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) credentials. Both agents can run side-by-side in the same container and share the same `credentials` mode.
+In addition to Claude Code, crib also supports [pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) credentials. Both agents can run side-by-side in the same container and behave identically under the shared `credentials` mode:
 
-**Enablement is auto-detected.** pi is only active when `~/.pi/agent/auth.json` exists on the host. If the file is missing, crib produces no pi artifacts regardless of mode. Once enabled, pi follows whichever `credentials` mode you pick for Claude:
-
-| Mode | `~/.pi/agent/auth.json` on host? | Behavior |
-|---|---|---|
-| `host` (default) | yes | `auth.json` is copied into the container on each `crib up`. |
-| `workspace` | yes | `~/.crib/workspaces/{id}/plugins/coding-agents/pi-state/` is bind-mounted over `~/.pi/agent/`. The mount shadows the host file; authenticate inside the container and the credentials persist across rebuilds. |
-| either | no | Nothing. |
-
-:::note[Enabling pi without installing it on the host]
-If you want per-workspace pi credentials but don't have pi installed on the host, `touch` the auth file to signal intent, then use workspace mode:
-
-```sh
-mkdir -p ~/.pi/agent && touch ~/.pi/agent/auth.json
-```
-
-Then set `credentials: "workspace"` and authenticate inside the container on first use. (Don't use this with host mode — an empty auth file would get copied into the container.)
-:::
+| Mode | Behavior |
+|---|---|
+| `host` (default) | If `~/.pi/agent/auth.json` exists on the host, it's copied into the container on each `crib up`. Otherwise no-op. |
+| `workspace` | `~/.crib/workspaces/{id}/plugins/coding-agents/pi-state/` is bind-mounted over `~/.pi/agent/` so credentials created inside the container survive rebuilds. No host prerequisites. |
 
 ### Credential cleanup
 

--- a/internal/plugin/codingagents/claude.go
+++ b/internal/plugin/codingagents/claude.go
@@ -1,0 +1,119 @@
+package codingagents
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/fgrehm/crib/internal/config"
+	"github.com/fgrehm/crib/internal/plugin"
+)
+
+// handleClaude dispatches Claude Code credential handling based on the
+// configured mode.
+func (p *Plugin) handleClaude(req *plugin.PreContainerRunRequest, mode string) (*plugin.PreContainerRunResponse, error) {
+	if mode == "workspace" {
+		return p.claudeWorkspaceMode(req)
+	}
+	return p.claudeHostMode(req)
+}
+
+// claudeHostMode is the default behavior: copy host ~/.claude/.credentials.json
+// and a minimal ~/.claude.json into the container.
+func (p *Plugin) claudeHostMode(req *plugin.PreContainerRunRequest) (*plugin.PreContainerRunResponse, error) {
+	home := p.homeDir
+	if home == "" {
+		var err error
+		home, err = os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("getting home directory: %w", err)
+		}
+	}
+
+	credsSrc := filepath.Join(home, ".claude", ".credentials.json")
+	if _, err := os.Stat(credsSrc); os.IsNotExist(err) {
+		return nil, nil
+	} else if err != nil {
+		return nil, fmt.Errorf("checking credentials: %w", err)
+	}
+
+	pluginDir := filepath.Join(req.WorkspaceDir, "plugins", "coding-agents", "claude-code")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		return nil, fmt.Errorf("creating plugin dir: %w", err)
+	}
+
+	// Stage credentials file.
+	credsDst := filepath.Join(pluginDir, "credentials.json")
+	if err := plugin.CopyFile(credsSrc, credsDst, 0o600); err != nil {
+		return nil, fmt.Errorf("staging credentials: %w", err)
+	}
+
+	// Generate minimal config so Claude Code skips onboarding.
+	configDst := filepath.Join(pluginDir, "claude.json")
+	if err := os.WriteFile(configDst, []byte(`{"hasCompletedOnboarding":true}`), 0o644); err != nil {
+		return nil, fmt.Errorf("writing config: %w", err)
+	}
+
+	remoteHome := plugin.InferRemoteHome(req.RemoteUser)
+	owner := plugin.InferOwner(req.RemoteUser)
+
+	return &plugin.PreContainerRunResponse{
+		Copies: []plugin.FileCopy{
+			{
+				Source: credsDst,
+				Target: filepath.Join(remoteHome, ".claude", ".credentials.json"),
+				Mode:   "0600",
+				User:   owner,
+			},
+			{
+				Source:      configDst,
+				Target:      filepath.Join(remoteHome, ".claude.json"),
+				User:        owner,
+				IfNotExists: true,
+			},
+		},
+	}, nil
+}
+
+// claudeWorkspaceMode bind-mounts a persistent directory for ~/.claude/ so
+// credentials created inside the container survive rebuilds. A minimal
+// ~/.claude.json is injected via FileCopy (not bind-mount) because
+// Claude Code does atomic renames on that file.
+func (p *Plugin) claudeWorkspaceMode(req *plugin.PreContainerRunRequest) (*plugin.PreContainerRunResponse, error) {
+	stateDir := filepath.Join(req.WorkspaceDir, "plugins", "coding-agents", "claude-state")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		return nil, fmt.Errorf("creating state dir: %w", err)
+	}
+
+	// Generate minimal config so Claude Code skips onboarding on first run.
+	// This is re-injected on each rebuild via FileCopy.
+	configDir := filepath.Join(req.WorkspaceDir, "plugins", "coding-agents", "claude-code")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		return nil, fmt.Errorf("creating plugin dir: %w", err)
+	}
+	configDst := filepath.Join(configDir, "claude.json")
+	if err := os.WriteFile(configDst, []byte(`{"hasCompletedOnboarding":true}`), 0o644); err != nil {
+		return nil, fmt.Errorf("writing config: %w", err)
+	}
+
+	remoteHome := plugin.InferRemoteHome(req.RemoteUser)
+	owner := plugin.InferOwner(req.RemoteUser)
+
+	return &plugin.PreContainerRunResponse{
+		Mounts: []config.Mount{
+			{
+				Type:   "bind",
+				Source: stateDir,
+				Target: filepath.Join(remoteHome, ".claude"),
+			},
+		},
+		Copies: []plugin.FileCopy{
+			{
+				Source:      configDst,
+				Target:      filepath.Join(remoteHome, ".claude.json"),
+				User:        owner,
+				IfNotExists: true,
+			},
+		},
+	}, nil
+}

--- a/internal/plugin/codingagents/pi.go
+++ b/internal/plugin/codingagents/pi.go
@@ -1,0 +1,94 @@
+package codingagents
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/fgrehm/crib/internal/config"
+	"github.com/fgrehm/crib/internal/plugin"
+)
+
+// handlePi mirrors Claude's behavior for pi. Workspace mode always creates
+// a persistent state directory and bind-mounts it over `~/.pi/agent/`. Host
+// mode copies `~/.pi/agent/auth.json` into the container only if the file
+// exists on the host.
+func (p *Plugin) handlePi(req *plugin.PreContainerRunRequest, mode string) (*plugin.PreContainerRunResponse, error) {
+	if mode == "workspace" {
+		return p.piWorkspaceMode(req)
+	}
+
+	home := p.homeDir
+	if home == "" {
+		var err error
+		home, err = os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("getting home directory: %w", err)
+		}
+	}
+
+	authSrc := filepath.Join(home, ".pi", "agent", "auth.json")
+	info, err := os.Stat(authSrc)
+	if os.IsNotExist(err) {
+		return nil, nil
+	} else if err != nil {
+		return nil, fmt.Errorf("checking pi auth: %w", err)
+	}
+	// Treat anything other than a regular file (directory, socket, etc.) as
+	// "not enabled" so we never try to CopyFile something we can't read.
+	if !info.Mode().IsRegular() {
+		slog.Warn("coding-agents: pi auth path is not a regular file, skipping pi injection", "path", authSrc)
+		return nil, nil
+	}
+	return p.piHostMode(req, authSrc)
+}
+
+// piHostMode stages pi credentials from authSrc and copies them into the container.
+func (p *Plugin) piHostMode(req *plugin.PreContainerRunRequest, authSrc string) (*plugin.PreContainerRunResponse, error) {
+	pluginDir := filepath.Join(req.WorkspaceDir, "plugins", "coding-agents", "pi")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		return nil, fmt.Errorf("creating plugin dir: %w", err)
+	}
+
+	// Stage auth file.
+	authDst := filepath.Join(pluginDir, "auth.json")
+	if err := plugin.CopyFile(authSrc, authDst, 0o600); err != nil {
+		return nil, fmt.Errorf("staging pi auth: %w", err)
+	}
+
+	remoteHome := plugin.InferRemoteHome(req.RemoteUser)
+	owner := plugin.InferOwner(req.RemoteUser)
+
+	return &plugin.PreContainerRunResponse{
+		Copies: []plugin.FileCopy{
+			{
+				Source: authDst,
+				Target: filepath.Join(remoteHome, ".pi", "agent", "auth.json"),
+				Mode:   "0600",
+				User:   owner,
+			},
+		},
+	}, nil
+}
+
+// piWorkspaceMode bind-mounts a persistent directory for pi so credentials
+// created inside the container survive rebuilds.
+func (p *Plugin) piWorkspaceMode(req *plugin.PreContainerRunRequest) (*plugin.PreContainerRunResponse, error) {
+	stateDir := filepath.Join(req.WorkspaceDir, "plugins", "coding-agents", "pi-state")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		return nil, fmt.Errorf("creating pi state dir: %w", err)
+	}
+
+	remoteHome := plugin.InferRemoteHome(req.RemoteUser)
+
+	return &plugin.PreContainerRunResponse{
+		Mounts: []config.Mount{
+			{
+				Type:   "bind",
+				Source: stateDir,
+				Target: filepath.Join(remoteHome, ".pi", "agent"),
+			},
+		},
+	}, nil
+}

--- a/internal/plugin/codingagents/plugin.go
+++ b/internal/plugin/codingagents/plugin.go
@@ -2,25 +2,15 @@ package codingagents
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
-	"os"
-	"path/filepath"
 
-	"github.com/fgrehm/crib/internal/config"
 	"github.com/fgrehm/crib/internal/plugin"
 )
 
-// Plugin provides coding-agent credential sharing. Currently supports
-// Claude Code and pi by staging credentials and injecting them into the
-// container.
-//
-// Claude Code: ~/.claude/.credentials.json and ~/.claude.json
-// pi: ~/.pi/agent/auth.json
-//
-// When configured with "credentials": "workspace" in devcontainer.json
-// customizations, the plugin instead bind-mounts persistent directories
-// so credentials created inside the container survive rebuilds.
+// Plugin provides coding-agent credential sharing for Claude Code and pi.
+// Both agents behave identically under the shared `credentials` customization
+// ("host" default, or "workspace") and can run side-by-side in the same
+// container. Per-agent handling lives in claude.go and pi.go.
 type Plugin struct {
 	plugin.BasePlugin
 	homeDir string // overridable for testing; defaults to os.UserHomeDir()
@@ -34,22 +24,13 @@ func New() *Plugin {
 // Name returns the plugin identifier.
 func (p *Plugin) Name() string { return "coding-agents" }
 
-// PreContainerRun dispatches credential handling for Claude Code and pi
-// identically. Both share the single `credentials` customization ("host"
-// default, or "workspace"). In host mode each agent's host credentials are
-// copied into the container when present. In workspace mode each agent gets
-// a persistent bind-mounted state directory so credentials created inside
-// the container survive rebuilds.
+// PreContainerRun dispatches credential handling for Claude Code and pi.
+// Claude is primary; a pi failure is logged at Warn and skipped so it can
+// never block Claude credential injection.
 func (p *Plugin) PreContainerRun(_ context.Context, req *plugin.PreContainerRunRequest) (*plugin.PreContainerRunResponse, error) {
 	mode := getCredentialsMode(req.Customizations)
 
-	var resp *plugin.PreContainerRunResponse
-	var err error
-	if mode == "workspace" {
-		resp, err = p.workspaceMode(req)
-	} else {
-		resp, err = p.hostMode(req)
-	}
+	resp, err := p.handleClaude(req, mode)
 	if err != nil {
 		return nil, err
 	}
@@ -70,106 +51,6 @@ func (p *Plugin) PreContainerRun(_ context.Context, req *plugin.PreContainerRunR
 	return resp, nil
 }
 
-// hostMode is the default behavior: copy host ~/.claude/.credentials.json
-// and a minimal ~/.claude.json into the container.
-func (p *Plugin) hostMode(req *plugin.PreContainerRunRequest) (*plugin.PreContainerRunResponse, error) {
-	home := p.homeDir
-	if home == "" {
-		var err error
-		home, err = os.UserHomeDir()
-		if err != nil {
-			return nil, fmt.Errorf("getting home directory: %w", err)
-		}
-	}
-
-	credsSrc := filepath.Join(home, ".claude", ".credentials.json")
-	if _, err := os.Stat(credsSrc); os.IsNotExist(err) {
-		return nil, nil
-	} else if err != nil {
-		return nil, fmt.Errorf("checking credentials: %w", err)
-	}
-
-	pluginDir := filepath.Join(req.WorkspaceDir, "plugins", "coding-agents", "claude-code")
-	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
-		return nil, fmt.Errorf("creating plugin dir: %w", err)
-	}
-
-	// Stage credentials file.
-	credsDst := filepath.Join(pluginDir, "credentials.json")
-	if err := plugin.CopyFile(credsSrc, credsDst, 0o600); err != nil {
-		return nil, fmt.Errorf("staging credentials: %w", err)
-	}
-
-	// Generate minimal config so Claude Code skips onboarding.
-	configDst := filepath.Join(pluginDir, "claude.json")
-	if err := os.WriteFile(configDst, []byte(`{"hasCompletedOnboarding":true}`), 0o644); err != nil {
-		return nil, fmt.Errorf("writing config: %w", err)
-	}
-
-	remoteHome := plugin.InferRemoteHome(req.RemoteUser)
-	owner := plugin.InferOwner(req.RemoteUser)
-
-	return &plugin.PreContainerRunResponse{
-		Copies: []plugin.FileCopy{
-			{
-				Source: credsDst,
-				Target: filepath.Join(remoteHome, ".claude", ".credentials.json"),
-				Mode:   "0600",
-				User:   owner,
-			},
-			{
-				Source:      configDst,
-				Target:      filepath.Join(remoteHome, ".claude.json"),
-				User:        owner,
-				IfNotExists: true,
-			},
-		},
-	}, nil
-}
-
-// workspaceMode bind-mounts a persistent directory for ~/.claude/ so
-// credentials created inside the container survive rebuilds. A minimal
-// ~/.claude.json is injected via FileCopy (not bind-mount) because
-// Claude Code does atomic renames on that file.
-func (p *Plugin) workspaceMode(req *plugin.PreContainerRunRequest) (*plugin.PreContainerRunResponse, error) {
-	stateDir := filepath.Join(req.WorkspaceDir, "plugins", "coding-agents", "claude-state")
-	if err := os.MkdirAll(stateDir, 0o755); err != nil {
-		return nil, fmt.Errorf("creating state dir: %w", err)
-	}
-
-	// Generate minimal config so Claude Code skips onboarding on first run.
-	// This is re-injected on each rebuild via FileCopy.
-	configDir := filepath.Join(req.WorkspaceDir, "plugins", "coding-agents", "claude-code")
-	if err := os.MkdirAll(configDir, 0o755); err != nil {
-		return nil, fmt.Errorf("creating plugin dir: %w", err)
-	}
-	configDst := filepath.Join(configDir, "claude.json")
-	if err := os.WriteFile(configDst, []byte(`{"hasCompletedOnboarding":true}`), 0o644); err != nil {
-		return nil, fmt.Errorf("writing config: %w", err)
-	}
-
-	remoteHome := plugin.InferRemoteHome(req.RemoteUser)
-	owner := plugin.InferOwner(req.RemoteUser)
-
-	return &plugin.PreContainerRunResponse{
-		Mounts: []config.Mount{
-			{
-				Type:   "bind",
-				Source: stateDir,
-				Target: filepath.Join(remoteHome, ".claude"),
-			},
-		},
-		Copies: []plugin.FileCopy{
-			{
-				Source:      configDst,
-				Target:      filepath.Join(remoteHome, ".claude.json"),
-				User:        owner,
-				IfNotExists: true,
-			},
-		},
-	}, nil
-}
-
 // getCredentialsMode reads the credentials mode from customizations.crib.coding-agents.
 // Returns "host" (default) or "workspace".
 func getCredentialsMode(customizations map[string]any) string {
@@ -188,88 +69,4 @@ func getCredentialsMode(customizations map[string]any) string {
 		return "workspace"
 	}
 	return "host"
-}
-
-// handlePi mirrors Claude's behavior for pi. Workspace mode always creates
-// a persistent state directory and bind-mounts it over `~/.pi/agent/`. Host
-// mode copies `~/.pi/agent/auth.json` into the container only if the file
-// exists on the host.
-func (p *Plugin) handlePi(req *plugin.PreContainerRunRequest, mode string) (*plugin.PreContainerRunResponse, error) {
-	if mode == "workspace" {
-		return p.piWorkspaceMode(req)
-	}
-
-	home := p.homeDir
-	if home == "" {
-		var err error
-		home, err = os.UserHomeDir()
-		if err != nil {
-			return nil, fmt.Errorf("getting home directory: %w", err)
-		}
-	}
-
-	authSrc := filepath.Join(home, ".pi", "agent", "auth.json")
-	info, err := os.Stat(authSrc)
-	if os.IsNotExist(err) {
-		return nil, nil
-	} else if err != nil {
-		return nil, fmt.Errorf("checking pi auth: %w", err)
-	}
-	// Treat anything other than a regular file (directory, socket, etc.) as
-	// "not enabled" so we never try to CopyFile something we can't read.
-	if !info.Mode().IsRegular() {
-		slog.Warn("coding-agents: pi auth path is not a regular file, skipping pi injection", "path", authSrc)
-		return nil, nil
-	}
-	return p.piHostMode(req, authSrc)
-}
-
-// piHostMode stages pi credentials from authSrc and copies them into the container.
-func (p *Plugin) piHostMode(req *plugin.PreContainerRunRequest, authSrc string) (*plugin.PreContainerRunResponse, error) {
-	pluginDir := filepath.Join(req.WorkspaceDir, "plugins", "coding-agents", "pi")
-	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
-		return nil, fmt.Errorf("creating plugin dir: %w", err)
-	}
-
-	// Stage auth file.
-	authDst := filepath.Join(pluginDir, "auth.json")
-	if err := plugin.CopyFile(authSrc, authDst, 0o600); err != nil {
-		return nil, fmt.Errorf("staging pi auth: %w", err)
-	}
-
-	remoteHome := plugin.InferRemoteHome(req.RemoteUser)
-	owner := plugin.InferOwner(req.RemoteUser)
-
-	return &plugin.PreContainerRunResponse{
-		Copies: []plugin.FileCopy{
-			{
-				Source: authDst,
-				Target: filepath.Join(remoteHome, ".pi", "agent", "auth.json"),
-				Mode:   "0600",
-				User:   owner,
-			},
-		},
-	}, nil
-}
-
-// piWorkspaceMode bind-mounts a persistent directory for pi so credentials
-// created inside the container survive rebuilds. User can authenticate inside
-// the container and credentials persist across rebuilds.
-func (p *Plugin) piWorkspaceMode(req *plugin.PreContainerRunRequest) (*plugin.PreContainerRunResponse, error) {
-	stateDir := filepath.Join(req.WorkspaceDir, "plugins", "coding-agents", "pi-state")
-	if err := os.MkdirAll(stateDir, 0o755); err != nil {
-		return nil, fmt.Errorf("creating pi state dir: %w", err)
-	}
-
-	remoteHome := plugin.InferRemoteHome(req.RemoteUser)
-
-	return &plugin.PreContainerRunResponse{
-		Mounts: []config.Mount{
-			{
-				Type:   "bind",
-				Source: stateDir,
-				Target: filepath.Join(remoteHome, ".pi", "agent"),
-			},
-		},
-	}, nil
 }

--- a/internal/plugin/codingagents/plugin.go
+++ b/internal/plugin/codingagents/plugin.go
@@ -203,10 +203,16 @@ func (p *Plugin) handlePi(req *plugin.PreContainerRunRequest, mode string) (*plu
 	}
 
 	authSrc := filepath.Join(home, ".pi", "agent", "auth.json")
-	if _, err := os.Stat(authSrc); os.IsNotExist(err) {
+	info, err := os.Stat(authSrc)
+	if os.IsNotExist(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, fmt.Errorf("checking pi auth: %w", err)
+	}
+	// Treat anything other than a regular file (directory, socket, etc.) as
+	// "not enabled" so we never try to CopyFile something we can't read.
+	if !info.Mode().IsRegular() {
+		return nil, nil
 	}
 
 	if mode == "workspace" {

--- a/internal/plugin/codingagents/plugin.go
+++ b/internal/plugin/codingagents/plugin.go
@@ -3,6 +3,7 @@ package codingagents
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 
@@ -51,11 +52,12 @@ func (p *Plugin) PreContainerRun(_ context.Context, req *plugin.PreContainerRunR
 		return nil, err
 	}
 
+	// pi handling is best-effort: a pi-specific failure must not break Claude
+	// credential injection. Log at Warn and continue rather than bubbling up.
 	piResp, err := p.handlePi(req, mode)
 	if err != nil {
-		return nil, err
-	}
-	if piResp != nil {
+		slog.Warn("coding-agents: pi credential handling failed, skipping pi injection", "error", err)
+	} else if piResp != nil {
 		if resp == nil {
 			resp = &plugin.PreContainerRunResponse{}
 		}

--- a/internal/plugin/codingagents/plugin.go
+++ b/internal/plugin/codingagents/plugin.go
@@ -34,10 +34,12 @@ func New() *Plugin {
 // Name returns the plugin identifier.
 func (p *Plugin) Name() string { return "coding-agents" }
 
-// PreContainerRun dispatches credential handling for Claude Code and pi.
-// Both agents share the single `credentials` customization ("host" default,
-// or "workspace"). pi is only active when `~/.pi/agent/auth.json` exists on
-// the host; otherwise crib produces no pi artifacts regardless of mode.
+// PreContainerRun dispatches credential handling for Claude Code and pi
+// identically. Both share the single `credentials` customization ("host"
+// default, or "workspace"). In host mode each agent's host credentials are
+// copied into the container when present. In workspace mode each agent gets
+// a persistent bind-mounted state directory so credentials created inside
+// the container survive rebuilds.
 func (p *Plugin) PreContainerRun(_ context.Context, req *plugin.PreContainerRunRequest) (*plugin.PreContainerRunResponse, error) {
 	mode := getCredentialsMode(req.Customizations)
 
@@ -188,13 +190,15 @@ func getCredentialsMode(customizations map[string]any) string {
 	return "host"
 }
 
-// handlePi routes pi credential handling based on the shared credentials mode.
-// pi is only active when `~/.pi/agent/auth.json` exists on the host, which is
-// the user-visible opt-in gesture. In host mode the auth file is copied into
-// the container; in workspace mode a persistent state directory is
-// bind-mounted over `~/.pi/agent/` so credentials created inside the
-// container survive rebuilds.
+// handlePi mirrors Claude's behavior for pi. Workspace mode always creates
+// a persistent state directory and bind-mounts it over `~/.pi/agent/`. Host
+// mode copies `~/.pi/agent/auth.json` into the container only if the file
+// exists on the host.
 func (p *Plugin) handlePi(req *plugin.PreContainerRunRequest, mode string) (*plugin.PreContainerRunResponse, error) {
+	if mode == "workspace" {
+		return p.piWorkspaceMode(req)
+	}
+
 	home := p.homeDir
 	if home == "" {
 		var err error
@@ -215,10 +219,6 @@ func (p *Plugin) handlePi(req *plugin.PreContainerRunRequest, mode string) (*plu
 	// "not enabled" so we never try to CopyFile something we can't read.
 	if !info.Mode().IsRegular() {
 		return nil, nil
-	}
-
-	if mode == "workspace" {
-		return p.piWorkspaceMode(req)
 	}
 	return p.piHostMode(req, authSrc)
 }

--- a/internal/plugin/codingagents/plugin.go
+++ b/internal/plugin/codingagents/plugin.go
@@ -11,13 +11,15 @@ import (
 )
 
 // Plugin provides coding-agent credential sharing. Currently supports
-// Claude Code by staging ~/.claude/.credentials.json and a minimal
-// ~/.claude.json, then requesting they be copied into the container.
+// Claude Code and pi by staging credentials and injecting them into the
+// container.
+//
+// Claude Code: ~/.claude/.credentials.json and ~/.claude.json
+// pi: ~/.pi/agent/auth.json
 //
 // When configured with "credentials": "workspace" in devcontainer.json
-// customizations, the plugin instead bind-mounts a persistent directory
-// for ~/.claude/ so credentials created inside the container survive
-// rebuilds. The user authenticates inside the container on first use.
+// customizations, the plugin instead bind-mounts persistent directories
+// so credentials created inside the container survive rebuilds.
 type Plugin struct {
 	plugin.BasePlugin
 	homeDir string // overridable for testing; defaults to os.UserHomeDir()
@@ -31,16 +33,37 @@ func New() *Plugin {
 // Name returns the plugin identifier.
 func (p *Plugin) Name() string { return "coding-agents" }
 
-// PreContainerRun checks the credentials mode from devcontainer.json
-// customizations and either copies host credentials into the container
-// ("host" mode, default) or bind-mounts a persistent directory for
-// in-container authentication ("workspace" mode).
+// PreContainerRun dispatches credential handling for Claude Code and pi.
+// Both agents share the single `credentials` customization ("host" default,
+// or "workspace"). pi is only active when `~/.pi/agent/auth.json` exists on
+// the host; otherwise crib produces no pi artifacts regardless of mode.
 func (p *Plugin) PreContainerRun(_ context.Context, req *plugin.PreContainerRunRequest) (*plugin.PreContainerRunResponse, error) {
 	mode := getCredentialsMode(req.Customizations)
+
+	var resp *plugin.PreContainerRunResponse
+	var err error
 	if mode == "workspace" {
-		return p.workspaceMode(req)
+		resp, err = p.workspaceMode(req)
+	} else {
+		resp, err = p.hostMode(req)
 	}
-	return p.hostMode(req)
+	if err != nil {
+		return nil, err
+	}
+
+	piResp, err := p.handlePi(req, mode)
+	if err != nil {
+		return nil, err
+	}
+	if piResp != nil {
+		if resp == nil {
+			resp = &plugin.PreContainerRunResponse{}
+		}
+		resp.Mounts = append(resp.Mounts, piResp.Mounts...)
+		resp.Copies = append(resp.Copies, piResp.Copies...)
+	}
+
+	return resp, nil
 }
 
 // hostMode is the default behavior: copy host ~/.claude/.credentials.json
@@ -161,4 +184,83 @@ func getCredentialsMode(customizations map[string]any) string {
 		return "workspace"
 	}
 	return "host"
+}
+
+// handlePi routes pi credential handling based on the shared credentials mode.
+// pi is only active when `~/.pi/agent/auth.json` exists on the host, which is
+// the user-visible opt-in gesture. In host mode the auth file is copied into
+// the container; in workspace mode a persistent state directory is
+// bind-mounted over `~/.pi/agent/` so credentials created inside the
+// container survive rebuilds.
+func (p *Plugin) handlePi(req *plugin.PreContainerRunRequest, mode string) (*plugin.PreContainerRunResponse, error) {
+	home := p.homeDir
+	if home == "" {
+		var err error
+		home, err = os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("getting home directory: %w", err)
+		}
+	}
+
+	authSrc := filepath.Join(home, ".pi", "agent", "auth.json")
+	if _, err := os.Stat(authSrc); os.IsNotExist(err) {
+		return nil, nil
+	} else if err != nil {
+		return nil, fmt.Errorf("checking pi auth: %w", err)
+	}
+
+	if mode == "workspace" {
+		return p.piWorkspaceMode(req)
+	}
+	return p.piHostMode(req, authSrc)
+}
+
+// piHostMode stages pi credentials from authSrc and copies them into the container.
+func (p *Plugin) piHostMode(req *plugin.PreContainerRunRequest, authSrc string) (*plugin.PreContainerRunResponse, error) {
+	pluginDir := filepath.Join(req.WorkspaceDir, "plugins", "coding-agents", "pi")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		return nil, fmt.Errorf("creating plugin dir: %w", err)
+	}
+
+	// Stage auth file.
+	authDst := filepath.Join(pluginDir, "auth.json")
+	if err := plugin.CopyFile(authSrc, authDst, 0o600); err != nil {
+		return nil, fmt.Errorf("staging pi auth: %w", err)
+	}
+
+	remoteHome := plugin.InferRemoteHome(req.RemoteUser)
+	owner := plugin.InferOwner(req.RemoteUser)
+
+	return &plugin.PreContainerRunResponse{
+		Copies: []plugin.FileCopy{
+			{
+				Source: authDst,
+				Target: filepath.Join(remoteHome, ".pi", "agent", "auth.json"),
+				Mode:   "0600",
+				User:   owner,
+			},
+		},
+	}, nil
+}
+
+// piWorkspaceMode bind-mounts a persistent directory for pi so credentials
+// created inside the container survive rebuilds. User can authenticate inside
+// the container and credentials persist across rebuilds.
+func (p *Plugin) piWorkspaceMode(req *plugin.PreContainerRunRequest) (*plugin.PreContainerRunResponse, error) {
+	stateDir := filepath.Join(req.WorkspaceDir, "plugins", "coding-agents", "pi-state")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		return nil, fmt.Errorf("creating pi state dir: %w", err)
+	}
+
+	remoteHome := plugin.InferRemoteHome(req.RemoteUser)
+
+	return &plugin.PreContainerRunResponse{
+		Mounts: []config.Mount{
+			{
+				Type:   "bind",
+				Source: stateDir,
+				Target: filepath.Join(remoteHome, ".pi", "agent"),
+			},
+		},
+	}, nil
 }

--- a/internal/plugin/codingagents/plugin.go
+++ b/internal/plugin/codingagents/plugin.go
@@ -218,6 +218,7 @@ func (p *Plugin) handlePi(req *plugin.PreContainerRunRequest, mode string) (*plu
 	// Treat anything other than a regular file (directory, socket, etc.) as
 	// "not enabled" so we never try to CopyFile something we can't read.
 	if !info.Mode().IsRegular() {
+		slog.Warn("coding-agents: pi auth path is not a regular file, skipping pi injection", "path", authSrc)
 		return nil, nil
 	}
 	return p.piHostMode(req, authSrc)

--- a/internal/plugin/codingagents/plugin_test.go
+++ b/internal/plugin/codingagents/plugin_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/fgrehm/crib/internal/plugin"
@@ -277,9 +278,11 @@ func TestPreContainerRun_WorkspaceMode(t *testing.T) {
 		t.Fatal("expected non-nil response")
 	}
 
-	// Should produce one mount (persistent ~/.claude/) and one copy (onboarding config).
+	// Claude workspace mode alone produces one mount (persistent ~/.claude/)
+	// and one onboarding config copy. pi is untouched unless the pi key
+	// explicitly opts in.
 	if len(resp.Mounts) != 1 {
-		t.Fatalf("expected 1 mount, got %d", len(resp.Mounts))
+		t.Fatalf("expected 1 mount (claude only), got %d", len(resp.Mounts))
 	}
 	mount := resp.Mounts[0]
 	expectedSource := filepath.Join(wsDir, "plugins", "coding-agents", "claude-state")
@@ -296,14 +299,14 @@ func TestPreContainerRun_WorkspaceMode(t *testing.T) {
 	if len(resp.Copies) != 1 {
 		t.Fatalf("expected 1 copy (onboarding config only), got %d", len(resp.Copies))
 	}
-	copy := resp.Copies[0]
-	if copy.Target != "/home/vscode/.claude.json" {
-		t.Errorf("config target: expected /home/vscode/.claude.json, got %s", copy.Target)
+	cfg := resp.Copies[0]
+	if cfg.Target != "/home/vscode/.claude.json" {
+		t.Errorf("config target: expected /home/vscode/.claude.json, got %s", cfg.Target)
 	}
-	if copy.User != "vscode" {
-		t.Errorf("config user: expected vscode, got %s", copy.User)
+	if cfg.User != "vscode" {
+		t.Errorf("config user: expected vscode, got %s", cfg.User)
 	}
-	if !copy.IfNotExists {
+	if !cfg.IfNotExists {
 		t.Errorf("config IfNotExists: expected true (don't overwrite user's ~/.claude.json)")
 	}
 }
@@ -428,5 +431,191 @@ func TestGetCredentialsMode(t *testing.T) {
 				t.Errorf("getCredentialsMode() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+// --- pi tests ---
+
+// setupPiAuth creates a minimal ~/.pi/agent/auth.json file.
+func setupPiAuth(t *testing.T, home string) {
+	t.Helper()
+	piAgentDir := filepath.Join(home, ".pi", "agent")
+	if err := os.MkdirAll(piAgentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	auth := `{"anthropic":{"type":"api_key","key":"sk-ant-test"}}`
+	if err := os.WriteFile(filepath.Join(piAgentDir, "auth.json"), []byte(auth), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPreContainerRun_PiHostMode_CredentialsExist(t *testing.T) {
+	home := t.TempDir()
+	setupPiAuth(t, home)
+
+	wsDir := t.TempDir()
+	p := &Plugin{homeDir: home}
+	req := testReqWithCustomizations(wsDir, "vscode", nil)
+	resp, err := p.PreContainerRun(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response")
+	}
+
+	// Should have one copy for pi auth.json (no Claude creds on host).
+	if len(resp.Copies) != 1 {
+		t.Fatalf("expected 1 copy, got %d", len(resp.Copies))
+	}
+
+	piCopy := resp.Copies[0]
+	expectedSource := filepath.Join(wsDir, "plugins", "coding-agents", "pi", "auth.json")
+	if piCopy.Source != expectedSource {
+		t.Errorf("auth source: expected %s, got %s", expectedSource, piCopy.Source)
+	}
+	if piCopy.Target != "/home/vscode/.pi/agent/auth.json" {
+		t.Errorf("auth target: expected /home/vscode/.pi/agent/auth.json, got %s", piCopy.Target)
+	}
+	if piCopy.Mode != "0600" {
+		t.Errorf("auth mode: expected 0600, got %s", piCopy.Mode)
+	}
+	if piCopy.User != "vscode" {
+		t.Errorf("auth user: expected vscode, got %s", piCopy.User)
+	}
+}
+
+func TestPreContainerRun_PiHostMode_NoAuthFile(t *testing.T) {
+	home := t.TempDir() // no ~/.pi/agent/auth.json, no Claude creds
+
+	wsDir := t.TempDir()
+	p := &Plugin{homeDir: home}
+	req := testReqWithCustomizations(wsDir, "vscode", nil)
+	resp, err := p.PreContainerRun(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp != nil {
+		t.Errorf("expected nil response when no creds exist, got %+v", resp)
+	}
+}
+
+func TestPreContainerRun_PiHostMode_WithClaudeCredentials(t *testing.T) {
+	// Both Claude and pi credentials exist - both should be injected
+	home := t.TempDir()
+	setupCredentials(t, home)
+	setupPiAuth(t, home)
+
+	wsDir := t.TempDir()
+	p := &Plugin{homeDir: home}
+	req := testReqWithCustomizations(wsDir, "vscode", nil)
+	resp, err := p.PreContainerRun(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should have 3 copies: 2 Claude + 1 pi
+	if len(resp.Copies) != 3 {
+		t.Fatalf("expected 3 copies (2 claude + 1 pi), got %d", len(resp.Copies))
+	}
+
+	// Locate pi copy by target suffix rather than index.
+	var piCopy *plugin.FileCopy
+	for i := range resp.Copies {
+		if strings.HasSuffix(resp.Copies[i].Target, ".pi/agent/auth.json") {
+			piCopy = &resp.Copies[i]
+			break
+		}
+	}
+	if piCopy == nil {
+		t.Fatal("expected a pi auth copy among responses")
+	}
+	if piCopy.User != "vscode" {
+		t.Errorf("pi auth user: expected vscode, got %s", piCopy.User)
+	}
+}
+
+func TestPreContainerRun_PiWorkspaceMode(t *testing.T) {
+	home := t.TempDir()
+	setupPiAuth(t, home)
+
+	wsDir := t.TempDir()
+	p := &Plugin{homeDir: home}
+	req := testReqWithCustomizations(wsDir, "vscode", map[string]any{
+		"coding-agents": map[string]any{
+			"credentials": "workspace",
+		},
+	})
+	resp, err := p.PreContainerRun(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response")
+	}
+
+	// Claude workspace mount + pi workspace mount = 2 mounts.
+	if len(resp.Mounts) != 2 {
+		t.Fatalf("expected 2 mounts, got %d", len(resp.Mounts))
+	}
+
+	piMount := resp.Mounts[1]
+	expectedSource := filepath.Join(wsDir, "plugins", "coding-agents", "pi-state")
+	if piMount.Source != expectedSource {
+		t.Errorf("pi mount source: expected %s, got %s", expectedSource, piMount.Source)
+	}
+	if piMount.Target != "/home/vscode/.pi/agent" {
+		t.Errorf("pi mount target: expected /home/vscode/.pi/agent, got %s", piMount.Target)
+	}
+	if piMount.Type != "bind" {
+		t.Errorf("pi mount type: expected bind, got %s", piMount.Type)
+	}
+}
+
+// TestPreContainerRun_ClaudeWorkspaceMode_NoPiArtifacts verifies that a user
+// who only opts Claude into workspace mode does not get a stray pi-state
+// directory or bind mount. This regression would otherwise let processes in
+// the container write files into the workspace state dir.
+func TestPreContainerRun_ClaudeWorkspaceMode_NoPiArtifacts(t *testing.T) {
+	wsDir := t.TempDir()
+	p := &Plugin{homeDir: t.TempDir()} // no host pi auth
+	req := testReqWithCustomizations(wsDir, "vscode", map[string]any{
+		"coding-agents": map[string]any{
+			"credentials": "workspace",
+		},
+	})
+
+	if _, err := p.PreContainerRun(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(filepath.Join(wsDir, "plugins", "coding-agents", "pi-state")); !os.IsNotExist(err) {
+		t.Errorf("expected pi-state dir to NOT exist, stat err: %v", err)
+	}
+}
+
+func TestPreContainerRun_PiWorkspaceMode_CreatesStateDir(t *testing.T) {
+	home := t.TempDir()
+	setupPiAuth(t, home)
+
+	wsDir := t.TempDir()
+	p := &Plugin{homeDir: home}
+	req := testReqWithCustomizations(wsDir, "vscode", map[string]any{
+		"coding-agents": map[string]any{
+			"credentials": "workspace",
+		},
+	})
+
+	if _, err := p.PreContainerRun(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+
+	stateDir := filepath.Join(wsDir, "plugins", "coding-agents", "pi-state")
+	info, err := os.Stat(stateDir)
+	if err != nil {
+		t.Fatalf("expected pi state dir to exist: %v", err)
+	}
+	if !info.IsDir() {
+		t.Errorf("expected pi state dir to be a directory")
 	}
 }

--- a/internal/plugin/codingagents/plugin_test.go
+++ b/internal/plugin/codingagents/plugin_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -483,6 +484,49 @@ func TestPreContainerRun_PiHostMode_CredentialsExist(t *testing.T) {
 	}
 	if piCopy.User != "vscode" {
 		t.Errorf("auth user: expected vscode, got %s", piCopy.User)
+	}
+}
+
+// TestPreContainerRun_PiFailure_DoesNotBreakClaude verifies that pi is
+// best-effort: a pi-specific error must not discard Claude's response.
+// Trigger: valid Claude creds + a pi auth.json that passes stat but cannot be
+// read (mode 0000), forcing piHostMode's CopyFile to fail.
+func TestPreContainerRun_PiFailure_DoesNotBreakClaude(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file permission semantics differ on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses file permissions")
+	}
+
+	home := t.TempDir()
+	setupCredentials(t, home)
+	setupPiAuth(t, home)
+
+	authPath := filepath.Join(home, ".pi", "agent", "auth.json")
+	if err := os.Chmod(authPath, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(authPath, 0o600) })
+
+	wsDir := t.TempDir()
+	p := &Plugin{homeDir: home}
+	req := testReqWithCustomizations(wsDir, "vscode", nil)
+
+	resp, err := p.PreContainerRun(context.Background(), req)
+	if err != nil {
+		t.Fatalf("expected no error (pi failure should be logged, not returned), got %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected Claude response despite pi failure")
+	}
+	if len(resp.Copies) != 2 {
+		t.Fatalf("expected 2 Claude copies, got %d: %+v", len(resp.Copies), resp.Copies)
+	}
+	for _, c := range resp.Copies {
+		if strings.Contains(c.Target, "/.pi/") {
+			t.Errorf("expected no pi copies after pi failure, got %+v", c)
+		}
 	}
 }
 

--- a/internal/plugin/codingagents/plugin_test.go
+++ b/internal/plugin/codingagents/plugin_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/fgrehm/crib/internal/config"
 	"github.com/fgrehm/crib/internal/plugin"
 	"github.com/fgrehm/crib/internal/plugin/plugintest"
 )
@@ -579,7 +580,17 @@ func TestPreContainerRun_PiWorkspaceMode(t *testing.T) {
 		t.Fatalf("expected 2 mounts, got %d", len(resp.Mounts))
 	}
 
-	piMount := resp.Mounts[1]
+	// Locate the pi mount by target suffix rather than relying on ordering.
+	var piMount *config.Mount
+	for i := range resp.Mounts {
+		if strings.HasSuffix(resp.Mounts[i].Target, "/.pi/agent") {
+			piMount = &resp.Mounts[i]
+			break
+		}
+	}
+	if piMount == nil {
+		t.Fatal("expected a pi mount among responses")
+	}
 	expectedSource := filepath.Join(wsDir, "plugins", "coding-agents", "pi-state")
 	if piMount.Source != expectedSource {
 		t.Errorf("pi mount source: expected %s, got %s", expectedSource, piMount.Source)

--- a/internal/plugin/codingagents/plugin_test.go
+++ b/internal/plugin/codingagents/plugin_test.go
@@ -279,8 +279,8 @@ func TestPreContainerRun_WorkspaceMode(t *testing.T) {
 	}
 
 	// Claude workspace mode alone produces one mount (persistent ~/.claude/)
-	// and one onboarding config copy. pi is untouched unless the pi key
-	// explicitly opts in.
+	// and one onboarding config copy. pi stays dormant because there is no
+	// ~/.pi/agent/auth.json on the host.
 	if len(resp.Mounts) != 1 {
 		t.Fatalf("expected 1 mount (claude only), got %d", len(resp.Mounts))
 	}
@@ -482,6 +482,26 @@ func TestPreContainerRun_PiHostMode_CredentialsExist(t *testing.T) {
 	}
 	if piCopy.User != "vscode" {
 		t.Errorf("auth user: expected vscode, got %s", piCopy.User)
+	}
+}
+
+func TestPreContainerRun_PiHostMode_AuthPathIsDirectory(t *testing.T) {
+	// Guard: a directory (or other non-regular file) at the auth.json path
+	// should be treated as "not enabled" rather than triggering a copy error.
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, ".pi", "agent", "auth.json"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	wsDir := t.TempDir()
+	p := &Plugin{homeDir: home}
+	req := testReqWithCustomizations(wsDir, "vscode", nil)
+	resp, err := p.PreContainerRun(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp != nil {
+		t.Errorf("expected nil response when auth path is a directory, got %+v", resp)
 	}
 }
 

--- a/internal/plugin/codingagents/plugin_test.go
+++ b/internal/plugin/codingagents/plugin_test.go
@@ -280,22 +280,31 @@ func TestPreContainerRun_WorkspaceMode(t *testing.T) {
 		t.Fatal("expected non-nil response")
 	}
 
-	// Claude workspace mode alone produces one mount (persistent ~/.claude/)
-	// and one onboarding config copy. pi stays dormant because there is no
-	// ~/.pi/agent/auth.json on the host.
-	if len(resp.Mounts) != 1 {
-		t.Fatalf("expected 1 mount (claude only), got %d", len(resp.Mounts))
+	// Workspace mode produces two mounts (Claude state + pi state) plus one
+	// Claude onboarding config copy. Both agents are always mounted in
+	// workspace mode regardless of host state, matching Claude's semantics.
+	if len(resp.Mounts) != 2 {
+		t.Fatalf("expected 2 mounts (claude + pi), got %d", len(resp.Mounts))
 	}
-	mount := resp.Mounts[0]
+	var claudeMount *config.Mount
+	for i := range resp.Mounts {
+		if strings.HasSuffix(resp.Mounts[i].Target, "/.claude") {
+			claudeMount = &resp.Mounts[i]
+			break
+		}
+	}
+	if claudeMount == nil {
+		t.Fatal("expected a claude mount among responses")
+	}
 	expectedSource := filepath.Join(wsDir, "plugins", "coding-agents", "claude-state")
-	if mount.Source != expectedSource {
-		t.Errorf("mount source: expected %s, got %s", expectedSource, mount.Source)
+	if claudeMount.Source != expectedSource {
+		t.Errorf("claude mount source: expected %s, got %s", expectedSource, claudeMount.Source)
 	}
-	if mount.Target != "/home/vscode/.claude" {
-		t.Errorf("mount target: expected /home/vscode/.claude, got %s", mount.Target)
+	if claudeMount.Target != "/home/vscode/.claude" {
+		t.Errorf("claude mount target: expected /home/vscode/.claude, got %s", claudeMount.Target)
 	}
-	if mount.Type != "bind" {
-		t.Errorf("mount type: expected bind, got %s", mount.Type)
+	if claudeMount.Type != "bind" {
+		t.Errorf("claude mount type: expected bind, got %s", claudeMount.Type)
 	}
 
 	if len(resp.Copies) != 1 {
@@ -601,11 +610,10 @@ func TestPreContainerRun_PiHostMode_WithClaudeCredentials(t *testing.T) {
 }
 
 func TestPreContainerRun_PiWorkspaceMode(t *testing.T) {
-	home := t.TempDir()
-	setupPiAuth(t, home)
-
+	// Workspace mode is unconditional for pi, matching Claude. No host
+	// ~/.pi/ dir is required.
 	wsDir := t.TempDir()
-	p := &Plugin{homeDir: home}
+	p := &Plugin{homeDir: t.TempDir()}
 	req := testReqWithCustomizations(wsDir, "vscode", map[string]any{
 		"coding-agents": map[string]any{
 			"credentials": "workspace",
@@ -647,34 +655,9 @@ func TestPreContainerRun_PiWorkspaceMode(t *testing.T) {
 	}
 }
 
-// TestPreContainerRun_ClaudeWorkspaceMode_NoPiArtifacts verifies that a user
-// who only opts Claude into workspace mode does not get a stray pi-state
-// directory or bind mount. This regression would otherwise let processes in
-// the container write files into the workspace state dir.
-func TestPreContainerRun_ClaudeWorkspaceMode_NoPiArtifacts(t *testing.T) {
-	wsDir := t.TempDir()
-	p := &Plugin{homeDir: t.TempDir()} // no host pi auth
-	req := testReqWithCustomizations(wsDir, "vscode", map[string]any{
-		"coding-agents": map[string]any{
-			"credentials": "workspace",
-		},
-	})
-
-	if _, err := p.PreContainerRun(context.Background(), req); err != nil {
-		t.Fatal(err)
-	}
-
-	if _, err := os.Stat(filepath.Join(wsDir, "plugins", "coding-agents", "pi-state")); !os.IsNotExist(err) {
-		t.Errorf("expected pi-state dir to NOT exist, stat err: %v", err)
-	}
-}
-
 func TestPreContainerRun_PiWorkspaceMode_CreatesStateDir(t *testing.T) {
-	home := t.TempDir()
-	setupPiAuth(t, home)
-
 	wsDir := t.TempDir()
-	p := &Plugin{homeDir: home}
+	p := &Plugin{homeDir: t.TempDir()}
 	req := testReqWithCustomizations(wsDir, "vscode", map[string]any{
 		"coding-agents": map[string]any{
 			"credentials": "workspace",


### PR DESCRIPTION
## Summary

- Adds [pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) credential support to the `coding-agents` plugin alongside Claude Code. Both agents behave identically under the shared `credentials` customization (`host` default, or `workspace`) and can run side-by-side in the same container.
- **`host` mode**: each agent's host credentials are copied into the container when they exist (`~/.claude/.credentials.json` for Claude, `~/.pi/agent/auth.json` for pi). No-op for any agent whose auth file is absent.
- **`workspace` mode**: each agent gets a persistent bind-mounted state directory (`claude-state/`, `pi-state/`) so credentials created inside the container survive rebuilds. No host prerequisites.
- pi handling is best-effort: any pi-specific failure (unreadable auth file, copy error, non-regular path) is logged at `slog.Warn` and skipped rather than propagated, so an issue with the newer optional agent never blocks Claude credential injection.

## Test plan

- [x] `make test` (race + shuffle, unit suite) passes
- [x] `make lint` clean
- [ ] Manual: `crib up` in `host` mode with `~/.pi/agent/auth.json` present → pi auth copied into container, pi runs
- [ ] Manual: `crib up` in `host` mode with no pi auth on host → Claude unchanged, no pi artifacts
- [ ] Manual: `crib up` in `workspace` mode → both `claude-state/` and `pi-state/` bind-mounted; authenticate each inside the container; credentials persist across rebuild
- [ ] Manual: verify Claude Code behavior is unchanged in both modes