### PR TITLE
feat(plugins): add disable mechanism and ssh socket-type check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Plugin configurability. Bundled plugins can now be disabled globally
+  (`~/.config/crib/config.toml` under `[plugins]` with `disable = ["ssh",
+  ...]` or `disable_all = true`), per-project (`.cribrc` with
+  `plugins.disable = ssh, dotfiles` or `plugins = false`), or per-command
+  (`--disable-plugin ssh` on `crib up`, `crib rebuild`, `crib restart`).
+  Unknown names in the disable list log a warning. Closes
+  [#37](https://github.com/fgrehm/crib/issues/37) (users can now skip the
+  SSH plugin on macOS + Colima where virtiofs breaks agent socket bind
+  mounts).
 - Go fuzz tests for config parsing (`ParseBytes`, `ParseMount`,
   `SubstituteString`) and Dockerfile handling (`Parse`, `RemoveSyntaxVersion`,
   `EnsureFinalStageName`). Runs in CI with a 10s per-target budget.
@@ -35,6 +44,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   compose workspaces set container runtime options in the compose YAML.
 
 ### Fixed
+
+- SSH plugin now verifies that `SSH_AUTH_SOCK` points at an actual Unix
+  socket before bind-mounting it. Defense-in-depth for environments like
+  macOS + Colima, where virtiofs exposes the socket as a regular file that
+  crashes the container runtime when bind-mounted. When the path is not a
+  socket the plugin logs a warning and skips agent forwarding.
 
 #### Spec-compliant `remoteUser` / `containerUser` resolution
 

--- a/cmd/cribrc.go
+++ b/cmd/cribrc.go
@@ -17,9 +17,11 @@ type dotfilesRC struct {
 
 // cribRC holds values loaded from a .cribrc file.
 type cribRC struct {
-	Config   string   // devcontainer config directory (same as --config / -C)
-	Cache    []string // package cache providers (e.g. "npm", "pip", "go")
-	Dotfiles dotfilesRC
+	Config            string     // devcontainer config directory (same as --config / -C)
+	Cache             []string   // package cache providers (e.g. "npm", "pip", "go")
+	Dotfiles          dotfilesRC // dotfiles plugin overrides (dotfiles.* keys + kill switch)
+	PluginsDisable    []string   // plugin names to skip (e.g. "ssh", "dotfiles")
+	PluginsDisableAll bool       // kill switch: "plugins = false" disables every plugin
 }
 
 // loadCribRC reads a .cribrc file from cwd. Returns nil, nil if not found.
@@ -71,6 +73,17 @@ func loadCribRC() (*cribRC, error) {
 			rc.Dotfiles.TargetPath = val
 		case "dotfiles.installCommand":
 			rc.Dotfiles.InstallCommand = val
+		case "plugins":
+			if val == "false" {
+				rc.PluginsDisableAll = true
+			}
+		case "plugins.disable":
+			for p := range strings.SplitSeq(val, ",") {
+				p = strings.TrimSpace(p)
+				if p != "" {
+					rc.PluginsDisable = append(rc.PluginsDisable, p)
+				}
+			}
 		}
 	}
 	return rc, scanner.Err()

--- a/cmd/cribrc_test.go
+++ b/cmd/cribrc_test.go
@@ -91,3 +91,41 @@ func TestLoadCribRC_DotfilesDisableWithRepository(t *testing.T) {
 		t.Errorf("Repository = %q, want git@github.com:user/dots", rc.Dotfiles.Repository)
 	}
 }
+
+func TestLoadCribRC_PluginsDisable(t *testing.T) {
+	rc := setupCribRC(t, "plugins.disable = ssh, dotfiles\n")
+	if len(rc.PluginsDisable) != 2 {
+		t.Fatalf("expected 2 plugins, got %v", rc.PluginsDisable)
+	}
+	if rc.PluginsDisable[0] != "ssh" || rc.PluginsDisable[1] != "dotfiles" {
+		t.Errorf("PluginsDisable = %v, want [ssh dotfiles]", rc.PluginsDisable)
+	}
+}
+
+func TestLoadCribRC_PluginsDisableSingle(t *testing.T) {
+	rc := setupCribRC(t, "plugins.disable = ssh\n")
+	if len(rc.PluginsDisable) != 1 || rc.PluginsDisable[0] != "ssh" {
+		t.Errorf("PluginsDisable = %v, want [ssh]", rc.PluginsDisable)
+	}
+}
+
+func TestLoadCribRC_PluginsDisableEmpty(t *testing.T) {
+	rc := setupCribRC(t, "plugins.disable =\n")
+	if len(rc.PluginsDisable) != 0 {
+		t.Errorf("PluginsDisable = %v, want empty", rc.PluginsDisable)
+	}
+}
+
+func TestLoadCribRC_PluginsKillSwitch(t *testing.T) {
+	rc := setupCribRC(t, "plugins = false\n")
+	if !rc.PluginsDisableAll {
+		t.Error("expected PluginsDisableAll = true")
+	}
+}
+
+func TestLoadCribRC_PluginsKillSwitchUnknownValue_Ignored(t *testing.T) {
+	rc := setupCribRC(t, "plugins = maybe\n")
+	if rc.PluginsDisableAll {
+		t.Error("expected PluginsDisableAll = false for unknown value")
+	}
+}

--- a/cmd/plugins.go
+++ b/cmd/plugins.go
@@ -16,15 +16,26 @@ var knownPlugins = []string{
 	"package-cache",
 }
 
-// disablePluginsFlag collects --disable-plugin values for up/rebuild/restart.
-var disablePluginsFlag []string
-
 // addPluginFlags registers the --disable-plugin flag on commands that create
 // or recreate containers. The flag accepts repeated values or a
-// comma-separated list.
+// comma-separated list. Values are read per-invocation via
+// disabledPluginsForCommand so state does not leak across cobra executions.
 func addPluginFlags(cmd *cobra.Command) {
-	cmd.Flags().StringSliceVar(&disablePluginsFlag, "disable-plugin",
+	cmd.Flags().StringSlice("disable-plugin",
 		nil, "disable a bundled plugin by name (repeatable or comma-separated)")
+}
+
+// disabledPluginsForCommand returns the parsed --disable-plugin values for cmd.
+// Returns nil if the flag is unset or not registered on the command.
+func disabledPluginsForCommand(cmd *cobra.Command) []string {
+	if cmd == nil {
+		return nil
+	}
+	vals, err := cmd.Flags().GetStringSlice("disable-plugin")
+	if err != nil {
+		return nil
+	}
+	return vals
 }
 
 // isKnownPlugin reports whether name matches a bundled plugin.

--- a/cmd/plugins.go
+++ b/cmd/plugins.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"slices"
+
+	"github.com/spf13/cobra"
+)
+
+// knownPlugins is the canonical set of bundled plugin names. Used for
+// warning on unrecognized disable entries.
+var knownPlugins = []string{
+	"coding-agents",
+	"shell-history",
+	"ssh",
+	"dotfiles",
+	"package-cache",
+}
+
+// disablePluginsFlag collects --disable-plugin values for up/rebuild/restart.
+var disablePluginsFlag []string
+
+// addPluginFlags registers the --disable-plugin flag on commands that create
+// or recreate containers. The flag accepts repeated values or a
+// comma-separated list.
+func addPluginFlags(cmd *cobra.Command) {
+	cmd.Flags().StringSliceVar(&disablePluginsFlag, "disable-plugin",
+		nil, "disable a bundled plugin by name (repeatable or comma-separated)")
+}
+
+// isKnownPlugin reports whether name matches a bundled plugin.
+func isKnownPlugin(name string) bool {
+	return slices.Contains(knownPlugins, name)
+}

--- a/cmd/plugins.go
+++ b/cmd/plugins.go
@@ -4,6 +4,7 @@ import (
 	"slices"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 // knownPlugins is the canonical set of bundled plugin names. Used for
@@ -41,4 +42,21 @@ func disabledPluginsForCommand(cmd *cobra.Command) []string {
 // isKnownPlugin reports whether name matches a bundled plugin.
 func isKnownPlugin(name string) bool {
 	return slices.Contains(knownPlugins, name)
+}
+
+// resetPerExecutionFlags clears parsed state for flags that must not leak
+// across Execute() calls in the same process. pflag retains the slice value
+// and the Changed bit between invocations of cobra's parser, so a stray
+// --disable-plugin from a previous run would otherwise affect a later run
+// where the flag is absent.
+func resetPerExecutionFlags(cmd *cobra.Command) {
+	for _, c := range cmd.Commands() {
+		if f := c.Flags().Lookup("disable-plugin"); f != nil {
+			if sv, ok := f.Value.(pflag.SliceValue); ok {
+				_ = sv.Replace(nil)
+			}
+			f.Changed = false
+		}
+		resetPerExecutionFlags(c)
+	}
 }

--- a/cmd/rebuild.go
+++ b/cmd/rebuild.go
@@ -21,7 +21,7 @@ var rebuildCmd = &cobra.Command{
 		eng.SetOutput(os.Stdout, os.Stderr)
 		eng.SetVerbose(verboseFlag || debugFlag)
 		eng.SetProgress(func(ev engine.ProgressEvent) { u.Dim("  " + ev.Message) })
-		setupPlugins(eng, d)
+		setupPlugins(cmd, eng, d)
 
 		ws, err := currentWorkspace(store, true)
 		if err != nil {

--- a/cmd/rebuild.go
+++ b/cmd/rebuild.go
@@ -63,3 +63,7 @@ var rebuildCmd = &cobra.Command{
 		return nil
 	},
 }
+
+func init() {
+	addPluginFlags(rebuildCmd)
+}

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -31,7 +31,7 @@ args), restart will ask you to run 'crib rebuild' instead.`,
 		eng.SetOutput(os.Stdout, os.Stderr)
 		eng.SetVerbose(verboseFlag || debugFlag)
 		eng.SetProgress(func(ev engine.ProgressEvent) { u.Dim("  " + ev.Message) })
-		setupPlugins(eng, d)
+		setupPlugins(cmd, eng, d)
 
 		ws, err := currentWorkspace(store, false)
 		if err != nil {

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -73,3 +73,7 @@ args), restart will ask you to run 'crib rebuild' instead.`,
 		return nil
 	},
 }
+
+func init() {
+	addPluginFlags(restartCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -179,6 +179,7 @@ func Execute() int {
 			return a
 		},
 	}))
+	resetPerExecutionFlags(rootCmd)
 	if err := rootCmd.ExecuteContext(ctx); err != nil {
 		u := newUI()
 		u.Error(err.Error())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,13 +49,15 @@ func displayContainerName(recorded, wsID string) string {
 }
 
 var (
-	debugFlag       bool
-	verboseFlag     bool
-	configDirFlag   string
-	dirFlag         string
-	logger          *slog.Logger
-	cacheProviders  []string   // loaded from .cribrc cache key
-	projectDotfiles dotfilesRC // loaded from .cribrc dotfiles keys
+	debugFlag             bool
+	verboseFlag           bool
+	configDirFlag         string
+	dirFlag               string
+	logger                *slog.Logger
+	cacheProviders        []string   // loaded from .cribrc cache key
+	projectDotfiles       dotfilesRC // loaded from .cribrc dotfiles keys
+	projectPluginsDisable []string   // loaded from .cribrc plugins.disable
+	projectPluginsOff     bool       // loaded from .cribrc plugins = false
 )
 
 // version variables injected at build time via ldflags.
@@ -101,6 +103,8 @@ var rootCmd = &cobra.Command{
 				logger.Debug("loaded cache providers from .cribrc", "providers", rc.Cache)
 			}
 			projectDotfiles = rc.Dotfiles
+			projectPluginsDisable = rc.PluginsDisable
+			projectPluginsOff = rc.PluginsDisableAll
 		}
 
 		return nil
@@ -289,22 +293,46 @@ func resolveDotfilesPlugin(gcfg globalconfig.DotfilesConfig, rc dotfilesRC) (glo
 
 // setupPlugins creates a plugin manager with bundled plugins and attaches it
 // to the engine. Called from commands that create containers (up, rebuild, restart).
+//
+// Plugins can be disabled via the global config (`[plugins]` with
+// `disable = [...]` or `disable_all = true`), `.cribrc`
+// (`plugins.disable = ssh, ...` or `plugins = false`), or the
+// `--disable-plugin` flag on the current command.
 func setupPlugins(eng *engine.Engine, d *oci.OCIDriver) {
 	eng.SetRuntime(d.Runtime().String())
 	mgr := plugin.NewManager(logger)
-	mgr.Register(codingagents.New())
-	mgr.Register(shellhistory.New())
-	mgr.Register(pluginssh.New())
-	var globalDotfiles globalconfig.DotfilesConfig
+
+	var globalCfg globalconfig.Config
 	if gcfg, err := globalconfig.Load(); err != nil {
 		logger.Warn("failed to load global config", "error", err)
-	} else {
-		globalDotfiles = gcfg.Dotfiles
+	} else if gcfg != nil {
+		globalCfg = *gcfg
 	}
-	if cfg, ok := resolveDotfilesPlugin(globalDotfiles, projectDotfiles); ok {
-		mgr.Register(dotfiles.New(cfg))
+
+	// Kill switch: skip every plugin when any layer asks for it.
+	if globalCfg.Plugins.DisableAll || projectPluginsOff {
+		eng.SetPlugins(mgr)
+		return
 	}
-	if len(cacheProviders) > 0 {
+
+	disabled := collectDisabledPlugins(globalCfg.Plugins.Disable, projectPluginsDisable, disablePluginsFlag)
+	warnUnknownDisabledPlugins(disabled)
+
+	if !disabled["coding-agents"] {
+		mgr.Register(codingagents.New())
+	}
+	if !disabled["shell-history"] {
+		mgr.Register(shellhistory.New())
+	}
+	if !disabled["ssh"] {
+		mgr.Register(pluginssh.New())
+	}
+	if !disabled["dotfiles"] {
+		if cfg, ok := resolveDotfilesPlugin(globalCfg.Dotfiles, projectDotfiles); ok {
+			mgr.Register(dotfiles.New(cfg))
+		}
+	}
+	if !disabled["package-cache"] && len(cacheProviders) > 0 {
 		if unknown := packagecache.ValidateProviders(cacheProviders); len(unknown) > 0 {
 			logger.Warn("unknown cache providers in .cribrc", "unknown", unknown, "supported", packagecache.SupportedProviders())
 		}
@@ -312,6 +340,31 @@ func setupPlugins(eng *engine.Engine, d *oci.OCIDriver) {
 		eng.SetBuildCacheMounts(packagecache.BuildCacheMounts(cacheProviders))
 	}
 	eng.SetPlugins(mgr)
+}
+
+// collectDisabledPlugins merges disable entries from every layer into a set.
+// Trimmed, empty-filtered.
+func collectDisabledPlugins(layers ...[]string) map[string]bool {
+	out := map[string]bool{}
+	for _, layer := range layers {
+		for _, name := range layer {
+			name = strings.TrimSpace(name)
+			if name != "" {
+				out[name] = true
+			}
+		}
+	}
+	return out
+}
+
+// warnUnknownDisabledPlugins logs a warning for names that do not match any
+// bundled plugin. Typos shouldn't silently disable nothing.
+func warnUnknownDisabledPlugins(disabled map[string]bool) {
+	for name := range disabled {
+		if !isKnownPlugin(name) {
+			logger.Warn("unknown plugin in disable list", "name", name, "known", knownPlugins)
+		}
+	}
 }
 
 // appendRemoteEnv appends -e KEY=VALUE flags for each entry in result.RemoteEnv.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -88,6 +88,14 @@ var rootCmd = &cobra.Command{
 			},
 		}))
 
+		// Reset .cribrc-derived globals so stale values from a previous
+		// rootCmd execution in the same process do not leak into this run
+		// (matters for tests that reuse the command tree).
+		cacheProviders = nil
+		projectDotfiles = dotfilesRC{}
+		projectPluginsDisable = nil
+		projectPluginsOff = false
+
 		// Apply .cribrc defaults for flags not explicitly set by the user.
 		rc, rcErr := loadCribRC()
 		if rcErr != nil {
@@ -298,7 +306,7 @@ func resolveDotfilesPlugin(gcfg globalconfig.DotfilesConfig, rc dotfilesRC) (glo
 // `disable = [...]` or `disable_all = true`), `.cribrc`
 // (`plugins.disable = ssh, ...` or `plugins = false`), or the
 // `--disable-plugin` flag on the current command.
-func setupPlugins(eng *engine.Engine, d *oci.OCIDriver) {
+func setupPlugins(cmd *cobra.Command, eng *engine.Engine, d *oci.OCIDriver) {
 	eng.SetRuntime(d.Runtime().String())
 	mgr := plugin.NewManager(logger)
 
@@ -311,7 +319,7 @@ func setupPlugins(eng *engine.Engine, d *oci.OCIDriver) {
 
 	// Warn about unknown names in any disable layer before honoring the kill
 	// switch — a typo is a config mistake whether or not plugins are all off.
-	disabled := collectDisabledPlugins(globalCfg.Plugins.Disable, projectPluginsDisable, disablePluginsFlag)
+	disabled := collectDisabledPlugins(globalCfg.Plugins.Disable, projectPluginsDisable, disabledPluginsForCommand(cmd))
 	warnUnknownDisabledPlugins(disabled)
 
 	// Kill switch: skip every plugin when any layer asks for it.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"slices"
 	"strings"
 	"syscall"
 	"time"
@@ -369,12 +370,18 @@ func collectDisabledPlugins(layers ...[]string) map[string]bool {
 }
 
 // warnUnknownDisabledPlugins logs a warning for names that do not match any
-// bundled plugin. Typos shouldn't silently disable nothing.
+// bundled plugin. Typos shouldn't silently disable nothing. Names are sorted
+// so log output is stable across runs.
 func warnUnknownDisabledPlugins(disabled map[string]bool) {
+	unknown := make([]string, 0, len(disabled))
 	for name := range disabled {
 		if !isKnownPlugin(name) {
-			logger.Warn("unknown plugin in disable list", "name", name, "known", knownPlugins)
+			unknown = append(unknown, name)
 		}
+	}
+	slices.Sort(unknown)
+	for _, name := range unknown {
+		logger.Warn("unknown plugin in disable list", "name", name, "known", knownPlugins)
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -309,14 +309,16 @@ func setupPlugins(eng *engine.Engine, d *oci.OCIDriver) {
 		globalCfg = *gcfg
 	}
 
+	// Warn about unknown names in any disable layer before honoring the kill
+	// switch — a typo is a config mistake whether or not plugins are all off.
+	disabled := collectDisabledPlugins(globalCfg.Plugins.Disable, projectPluginsDisable, disablePluginsFlag)
+	warnUnknownDisabledPlugins(disabled)
+
 	// Kill switch: skip every plugin when any layer asks for it.
 	if globalCfg.Plugins.DisableAll || projectPluginsOff {
 		eng.SetPlugins(mgr)
 		return
 	}
-
-	disabled := collectDisabledPlugins(globalCfg.Plugins.Disable, projectPluginsDisable, disablePluginsFlag)
-	warnUnknownDisabledPlugins(disabled)
 
 	if !disabled["coding-agents"] {
 		mgr.Register(codingagents.New())

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/fgrehm/crib/internal/globalconfig"
+	"github.com/spf13/cobra"
 )
 
 func TestVersionString_Dev(t *testing.T) {
@@ -232,6 +233,47 @@ func TestCollectDisabledPlugins(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestResetPerExecutionFlags(t *testing.T) {
+	root := &cobra.Command{Use: "test"}
+	sub := &cobra.Command{Use: "up", RunE: func(*cobra.Command, []string) error { return nil }}
+	addPluginFlags(sub)
+	root.AddCommand(sub)
+
+	// First "run": --disable-plugin ssh provided.
+	root.SetArgs([]string{"up", "--disable-plugin", "ssh"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("first execute: %v", err)
+	}
+	got := disabledPluginsForCommand(sub)
+	if len(got) != 1 || got[0] != "ssh" {
+		t.Fatalf("first run: got %v, want [ssh]", got)
+	}
+
+	// Reset before the next parse, then "run" without the flag.
+	resetPerExecutionFlags(root)
+	root.SetArgs([]string{"up"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("second execute: %v", err)
+	}
+	if got := disabledPluginsForCommand(sub); len(got) != 0 {
+		t.Errorf("second run: got %v, want empty (stale value leaked)", got)
+	}
+	if f := sub.Flags().Lookup("disable-plugin"); f.Changed {
+		t.Errorf("second run: flag Changed=true after reset")
+	}
+
+	// Third "run": flag provided again, should not accumulate with the first run.
+	resetPerExecutionFlags(root)
+	root.SetArgs([]string{"up", "--disable-plugin", "dotfiles"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("third execute: %v", err)
+	}
+	got = disabledPluginsForCommand(sub)
+	if len(got) != 1 || got[0] != "dotfiles" {
+		t.Errorf("third run: got %v, want [dotfiles] only", got)
 	}
 }
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -327,6 +327,11 @@ func TestWarnUnknownDisabledPlugins(t *testing.T) {
 			name:     "empty set never warns",
 			disabled: map[string]bool{},
 		},
+		{
+			name:      "multiple unknowns log in sorted order",
+			disabled:  map[string]bool{"zebra": true, "alpha": true, "mike": true},
+			wantNames: []string{"alpha", "mike", "zebra"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -337,13 +342,20 @@ func TestWarnUnknownDisabledPlugins(t *testing.T) {
 			warnUnknownDisabledPlugins(tt.disabled)
 
 			out := buf.String()
+			prevIdx := -1
 			for _, n := range tt.wantNames {
 				if !strings.Contains(out, "unknown plugin in disable list") {
 					t.Errorf("expected warning message, got %q", out)
 				}
-				if !strings.Contains(out, "name="+n) {
+				idx := strings.Index(out, "name="+n)
+				if idx == -1 {
 					t.Errorf("expected warning to include name=%s, got %q", n, out)
+					continue
 				}
+				if idx < prevIdx {
+					t.Errorf("expected names in sorted order; %q appeared before expected predecessor in %q", n, out)
+				}
+				prevIdx = idx
 			}
 			for _, n := range tt.wantSilent {
 				if strings.Contains(out, "name="+n+" ") || strings.HasSuffix(strings.TrimRight(out, "\n"), "name="+n) {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"bytes"
+	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/fgrehm/crib/internal/globalconfig"
@@ -170,6 +173,143 @@ func TestResolveDotfilesPlugin(t *testing.T) {
 			}
 			if tt.wantInstall != "" && cfg.InstallCommand != tt.wantInstall {
 				t.Errorf("InstallCommand = %q, want %q", cfg.InstallCommand, tt.wantInstall)
+			}
+		})
+	}
+}
+
+func TestCollectDisabledPlugins(t *testing.T) {
+	tests := []struct {
+		name   string
+		layers [][]string
+		want   map[string]bool
+	}{
+		{
+			name:   "no layers",
+			layers: nil,
+			want:   map[string]bool{},
+		},
+		{
+			name:   "single layer",
+			layers: [][]string{{"ssh"}},
+			want:   map[string]bool{"ssh": true},
+		},
+		{
+			name: "merges across global, cribrc, and flag",
+			layers: [][]string{
+				{"ssh"},           // global
+				{"dotfiles"},      // .cribrc
+				{"package-cache"}, // --disable-plugin
+			},
+			want: map[string]bool{"ssh": true, "dotfiles": true, "package-cache": true},
+		},
+		{
+			name:   "dedupes across layers",
+			layers: [][]string{{"ssh", "dotfiles"}, {"ssh"}},
+			want:   map[string]bool{"ssh": true, "dotfiles": true},
+		},
+		{
+			name:   "trims whitespace and filters empty entries",
+			layers: [][]string{{"  ssh  ", "", "  "}, {"dotfiles"}},
+			want:   map[string]bool{"ssh": true, "dotfiles": true},
+		},
+		{
+			name:   "nil layer entries are tolerated",
+			layers: [][]string{nil, {"ssh"}, nil},
+			want:   map[string]bool{"ssh": true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := collectDisabledPlugins(tt.layers...)
+			if len(got) != len(tt.want) {
+				t.Fatalf("len = %d, want %d (got %v)", len(got), len(tt.want), got)
+			}
+			for k, v := range tt.want {
+				if got[k] != v {
+					t.Errorf("key %q = %v, want %v", k, got[k], v)
+				}
+			}
+		})
+	}
+}
+
+func TestIsKnownPlugin(t *testing.T) {
+	for _, name := range []string{"coding-agents", "shell-history", "ssh", "dotfiles", "package-cache"} {
+		if !isKnownPlugin(name) {
+			t.Errorf("isKnownPlugin(%q) = false, want true", name)
+		}
+	}
+	for _, name := range []string{"", "sssh", "unknown", "SSH"} {
+		if isKnownPlugin(name) {
+			t.Errorf("isKnownPlugin(%q) = true, want false", name)
+		}
+	}
+}
+
+// captureLogger installs a slog logger that writes to buf and returns a
+// restore func. Tests patch the package-level logger so warn calls in
+// cmd/root.go are observable.
+func captureLogger(t *testing.T, buf *bytes.Buffer) func() {
+	t.Helper()
+	orig := logger
+	logger = slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	return func() { logger = orig }
+}
+
+func TestWarnUnknownDisabledPlugins(t *testing.T) {
+	tests := []struct {
+		name       string
+		disabled   map[string]bool
+		wantNames  []string // names that should appear in a warning line
+		wantSilent []string // names that should NOT produce warnings
+	}{
+		{
+			name:       "all known names",
+			disabled:   map[string]bool{"ssh": true, "dotfiles": true},
+			wantSilent: []string{"ssh", "dotfiles"},
+		},
+		{
+			name:      "unknown name warns",
+			disabled:  map[string]bool{"sssh": true},
+			wantNames: []string{"sssh"},
+		},
+		{
+			name:       "mixed: only unknowns warn",
+			disabled:   map[string]bool{"ssh": true, "typo": true, "dotfiles": true},
+			wantNames:  []string{"typo"},
+			wantSilent: []string{"ssh", "dotfiles"},
+		},
+		{
+			name:     "empty set never warns",
+			disabled: map[string]bool{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			defer captureLogger(t, &buf)()
+
+			warnUnknownDisabledPlugins(tt.disabled)
+
+			out := buf.String()
+			for _, n := range tt.wantNames {
+				if !strings.Contains(out, "unknown plugin in disable list") {
+					t.Errorf("expected warning message, got %q", out)
+				}
+				if !strings.Contains(out, "name="+n) {
+					t.Errorf("expected warning to include name=%s, got %q", n, out)
+				}
+			}
+			for _, n := range tt.wantSilent {
+				if strings.Contains(out, "name="+n+" ") || strings.HasSuffix(strings.TrimRight(out, "\n"), "name="+n) {
+					t.Errorf("did not expect warning for known name %q, got %q", n, out)
+				}
+			}
+			if len(tt.wantNames) == 0 && strings.Contains(out, "unknown plugin in disable list") {
+				t.Errorf("did not expect any warning, got %q", out)
 			}
 		})
 	}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -23,7 +23,7 @@ var upCmd = &cobra.Command{
 		eng.SetOutput(os.Stdout, os.Stderr)
 		eng.SetVerbose(verboseFlag || debugFlag)
 		eng.SetProgress(func(ev engine.ProgressEvent) { u.Dim("  " + ev.Message) })
-		setupPlugins(eng, d)
+		setupPlugins(cmd, eng, d)
 
 		ws, err := currentWorkspace(store, true)
 		if err != nil {

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -59,4 +59,5 @@ var upCmd = &cobra.Command{
 
 func init() {
 	upCmd.Flags().BoolVar(&recreateFlag, "recreate", false, "recreate container even if one already exists")
+	addPluginFlags(upCmd)
 }

--- a/docs/commands-reference.md
+++ b/docs/commands-reference.md
@@ -7,6 +7,14 @@ description: Detailed usage, flags, and examples for every crib command.
 
 Build the container image (if needed) and start the workspace. On first run, this builds the image, creates the container, syncs UID/GID, probes the user environment, and runs all [lifecycle hooks](/crib/guides/lifecycle-hooks/). On subsequent runs, it starts the existing container and runs only the resume hooks (`postStartCommand`, `postAttachCommand`).
 
+```bash
+crib up                                    # standard run
+crib up --disable-plugin ssh               # skip a bundled plugin for this run
+crib up --disable-plugin ssh,dotfiles      # repeatable or comma-separated
+```
+
+See [Disabling plugins](/crib/guides/plugins/#disabling-plugins) for per-project and global alternatives.
+
 ## `crib down`
 
 Stop and remove the workspace container. This clears lifecycle hook markers, so the next `crib up` runs all hooks from scratch. Use this when you want a clean restart.
@@ -48,11 +56,11 @@ Both `run` and `exec` inherit the probed environment (`remoteEnv`) from `crib up
 
 ## `crib restart`
 
-Restart the workspace, detecting what changed since the last `crib up`. See [Smart Restart](/crib/guides/smart-restart/) for details on how change detection works.
+Restart the workspace, detecting what changed since the last `crib up`. See [Smart Restart](/crib/guides/smart-restart/) for details on how change detection works. Accepts `--disable-plugin` like `crib up`.
 
 ## `crib rebuild`
 
-Full rebuild: runs `down` followed by `up`. Use this when the image needs to be rebuilt (changed Dockerfile, base image, or features). Clears any snapshot image so the build starts from scratch.
+Full rebuild: runs `down` followed by `up`. Use this when the image needs to be rebuilt (changed Dockerfile, base image, or features). Clears any snapshot image so the build starts from scratch. Accepts `--disable-plugin` like `crib up`.
 
 ## `crib logs`
 

--- a/docs/custom-config.md
+++ b/docs/custom-config.md
@@ -18,3 +18,29 @@ config = .devcontainer-custom
 ```
 
 An explicit `--config` on the command line takes precedence over `.cribrc`.
+
+## Other `.cribrc` keys
+
+`.cribrc` also carries per-project settings for bundled plugins:
+
+```ini
+# Devcontainer config location (same as --config / -C).
+config = .devcontainer-custom
+
+# Package cache providers (see guides/plugins).
+cache = npm, pip, go
+
+# Dotfiles overrides (see guides/plugins).
+dotfiles.repository = https://github.com/user/work-dotfiles
+dotfiles.targetPath = ~/work-dotfiles
+dotfiles.installCommand = make install
+# Or disable dotfiles for this project:
+# dotfiles = false
+
+# Skip specific bundled plugins for this project.
+plugins.disable = ssh, dotfiles
+# Or disable every bundled plugin:
+# plugins = false
+```
+
+Format is one `key = value` per line. Lines starting with `#` are comments. See [Built-in Plugins](/crib/guides/plugins/) for what each plugin does and the full list of names you can pass to `plugins.disable`.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -7,6 +7,47 @@ description: What crib's built-in plugins do and how to configure them.
 
 Plugins run during `crib up` and `crib rebuild`. They are fail-open: if a plugin can't find something it needs (no SSH agent running, no Claude credentials on disk), it skips silently and doesn't block container creation.
 
+Bundled plugin names (used when disabling): `coding-agents`, `shell-history`, `ssh`, `dotfiles`, `package-cache`.
+
+---
+
+## Disabling plugins
+
+Plugins can be skipped at three levels. Any layer asking for a plugin to be disabled wins, they combine additively.
+
+**Per-command** (one-off, `crib up`, `crib rebuild`, `crib restart`):
+
+```bash
+crib up --disable-plugin ssh
+crib up --disable-plugin ssh --disable-plugin dotfiles
+crib up --disable-plugin ssh,dotfiles     # comma-separated also works
+```
+
+**Per-project** (`.cribrc` in the project root):
+
+```ini
+# Skip specific plugins for this project:
+plugins.disable = ssh, dotfiles
+
+# Or disable every bundled plugin:
+plugins = false
+```
+
+**Globally** (`~/.config/crib/config.toml`, or `$XDG_CONFIG_HOME/crib/config.toml`):
+
+```toml
+[plugins]
+disable = ["ssh", "dotfiles"]
+# Or kill switch:
+# disable_all = true
+```
+
+Unknown plugin names in any disable list produce a warning at startup and are otherwise ignored, so typos don't silently do nothing.
+
+:::tip[When to disable the SSH plugin]
+On macOS with Colima, virtiofs exposes the SSH agent socket as a regular file. The plugin detects this and logs a warning instead of bind-mounting it (the runtime would crash). If you don't need agent forwarding at all on that setup, disable the plugin with `--disable-plugin ssh` or the equivalent `.cribrc` / global config entry.
+:::
+
 ---
 
 ## Shell history

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -5,7 +5,7 @@ description: What crib's built-in plugins do and how to configure them.
 
 `crib` ships five built-in plugins that hook into the dev container lifecycle. They inject credentials, SSH config, shell history persistence, dotfiles, and shared package caches into a workspace without extra devcontainer.json boilerplate for the ones that need no configuration.
 
-Plugins run during `crib up` and `crib rebuild`. They are fail-open: if a plugin can't find something it needs (no SSH agent running, no Claude credentials on disk), it skips silently and doesn't block container creation.
+Plugins run during `crib up`, `crib rebuild`, and `crib restart`. They are fail-open: if a plugin can't find something it needs (no SSH agent running, no Claude credentials on disk), it skips that piece of setup without blocking container creation. Some cases log a warning (e.g. `SSH_AUTH_SOCK` pointing at a regular file instead of a socket) so the skip is visible.
 
 Bundled plugin names (used when disabling): `coding-agents`, `shell-history`, `ssh`, `dotfiles`, `package-cache`.
 

--- a/internal/globalconfig/config.go
+++ b/internal/globalconfig/config.go
@@ -11,6 +11,7 @@ import (
 // Config holds user-level crib settings from ~/.config/crib/config.toml.
 type Config struct {
 	Dotfiles DotfilesConfig `toml:"dotfiles"`
+	Plugins  PluginsConfig  `toml:"plugins"`
 }
 
 // DotfilesConfig configures dotfiles repository cloning and installation.
@@ -18,6 +19,14 @@ type DotfilesConfig struct {
 	Repository     string `toml:"repository"`
 	TargetPath     string `toml:"targetPath"`
 	InstallCommand string `toml:"installCommand"`
+}
+
+// PluginsConfig disables bundled plugins globally. Disable lists specific
+// plugins by name; DisableAll is a kill switch that skips plugin registration
+// entirely.
+type PluginsConfig struct {
+	Disable    []string `toml:"disable"`
+	DisableAll bool     `toml:"disable_all"`
 }
 
 // Load reads the global config from the default path.

--- a/internal/globalconfig/config_test.go
+++ b/internal/globalconfig/config_test.go
@@ -120,3 +120,74 @@ func TestLoadFrom_EmptyFile(t *testing.T) {
 		t.Errorf("expected empty config from empty file")
 	}
 }
+
+func TestLoadFrom_PluginsDisableList(t *testing.T) {
+	path := writeTOMLConfig(t, `
+[plugins]
+disable = ["ssh", "dotfiles"]
+`)
+
+	cfg, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	want := []string{"ssh", "dotfiles"}
+	if len(cfg.Plugins.Disable) != len(want) {
+		t.Fatalf("Disable len = %d, want %d (%v)", len(cfg.Plugins.Disable), len(want), cfg.Plugins.Disable)
+	}
+	for i, v := range want {
+		if cfg.Plugins.Disable[i] != v {
+			t.Errorf("Disable[%d] = %q, want %q", i, cfg.Plugins.Disable[i], v)
+		}
+	}
+	if cfg.Plugins.DisableAll {
+		t.Error("DisableAll = true, want false")
+	}
+}
+
+func TestLoadFrom_PluginsDisableAll(t *testing.T) {
+	path := writeTOMLConfig(t, `
+[plugins]
+disable_all = true
+`)
+
+	cfg, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	if !cfg.Plugins.DisableAll {
+		t.Error("expected DisableAll = true")
+	}
+}
+
+func TestLoadFrom_PluginsEmptySection(t *testing.T) {
+	path := writeTOMLConfig(t, `
+[plugins]
+`)
+
+	cfg, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	if len(cfg.Plugins.Disable) != 0 {
+		t.Errorf("expected empty Disable list, got %v", cfg.Plugins.Disable)
+	}
+	if cfg.Plugins.DisableAll {
+		t.Error("expected DisableAll = false")
+	}
+}
+
+func TestLoadFrom_PluginsMissingSection(t *testing.T) {
+	path := writeTOMLConfig(t, `
+[dotfiles]
+repository = "x"
+`)
+
+	cfg, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	if len(cfg.Plugins.Disable) != 0 || cfg.Plugins.DisableAll {
+		t.Errorf("expected zero-value Plugins, got %+v", cfg.Plugins)
+	}
+}

--- a/internal/plugin/ssh/plugin.go
+++ b/internal/plugin/ssh/plugin.go
@@ -133,7 +133,7 @@ func (p *Plugin) agentForwarding() (*config.Mount, map[string]string) {
 		return nil, nil
 	}
 	if fi.Mode().Type()&os.ModeSocket == 0 {
-		slog.Warn("ssh: SSH_AUTH_SOCK is not a socket, skipping agent forwarding",
+		slog.Warn("ssh plugin: SSH_AUTH_SOCK is not a socket, skipping agent forwarding",
 			"path", sock, "mode", fi.Mode().String())
 		return nil, nil
 	}

--- a/internal/plugin/ssh/plugin.go
+++ b/internal/plugin/ssh/plugin.go
@@ -117,15 +117,24 @@ func (p *Plugin) PreContainerRun(_ context.Context, req *plugin.PreContainerRunR
 }
 
 // agentForwarding binds the host's SSH agent socket into the container.
-// Returns nil if SSH_AUTH_SOCK is unset or the socket doesn't exist.
+// Returns nil if SSH_AUTH_SOCK is unset, the path doesn't exist, or the
+// path points to something other than a Unix socket. The socket-type
+// check is defense-in-depth: some filesystems (e.g. virtiofs on macOS +
+// Colima) expose the socket as a regular file that cannot be bind-mounted
+// as one, and attempting to mount it crashes the container runtime.
 func (p *Plugin) agentForwarding() (*config.Mount, map[string]string) {
 	sock := p.getenv("SSH_AUTH_SOCK")
 	if sock == "" {
 		return nil, nil
 	}
 
-	// Verify socket exists.
-	if _, err := os.Stat(sock); err != nil {
+	fi, err := os.Stat(sock)
+	if err != nil {
+		return nil, nil
+	}
+	if fi.Mode().Type()&os.ModeSocket == 0 {
+		slog.Warn("ssh: SSH_AUTH_SOCK is not a socket, skipping agent forwarding",
+			"path", sock, "mode", fi.Mode().String())
 		return nil, nil
 	}
 

--- a/internal/plugin/ssh/plugin_test.go
+++ b/internal/plugin/ssh/plugin_test.go
@@ -107,6 +107,37 @@ func TestPreContainerRun_AgentForwarding_NoSocket(t *testing.T) {
 	}
 }
 
+// TestPreContainerRun_AgentForwarding_NotASocket covers the macOS + Colima
+// case where SSH_AUTH_SOCK points at a regular file (virtiofs materialises
+// the socket as a file we cannot bind-mount as a socket). The plugin should
+// skip agent forwarding instead of wiring in a mount that breaks the runtime.
+func TestPreContainerRun_AgentForwarding_NotASocket(t *testing.T) {
+	fakeSock := filepath.Join(t.TempDir(), "agent.sock")
+	if err := os.WriteFile(fakeSock, []byte("not a socket"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	home := t.TempDir()
+	p := &Plugin{
+		homeDir: home,
+		getenvFunc: func(key string) string {
+			if key == "SSH_AUTH_SOCK" {
+				return fakeSock
+			}
+			return ""
+		},
+		gitConfigCmd: func(string) string { return "" },
+	}
+
+	resp, err := p.PreContainerRun(context.Background(), plugintest.TestReq(t.TempDir(), "vscode"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp != nil {
+		t.Errorf("expected nil response when SSH_AUTH_SOCK is a regular file, got %+v", resp)
+	}
+}
+
 // --- SSH config tests ---
 
 func TestPreContainerRun_SSHConfig(t *testing.T) {


### PR DESCRIPTION
## Summary

- Bundled plugins can be disabled at three layers:
  - **Global** (`~/.config/crib/config.toml`): `[plugins]` section with `disable = ["ssh", ...]` or `disable_all = true`.
  - **Per-project** (`.cribrc`): `plugins.disable = ssh, dotfiles` or `plugins = false` kill switch (mirrors the existing `dotfiles = false` pattern).
  - **Per-command**: `--disable-plugin` flag on `crib up`, `crib rebuild`, and `crib restart` (repeatable or comma-separated).
- Unknown names in the disable list log a warning, not an error. Canonical plugin list lives in `cmd/plugins.go`: `coding-agents`, `shell-history`, `ssh`, `dotfiles`, `package-cache`.
- SSH plugin now checks `SSH_AUTH_SOCK` file mode before bind-mounting. Paths that exist but are not Unix sockets (e.g. virtiofs regular-file surrogates on macOS + Colima) log a warning and skip agent forwarding instead of crashing the container runtime. Defense-in-depth for #37.

Closes #37.

## Test plan

- [x] `go test -short -race -shuffle=on ./...` passes (including e2e)
- [x] `make lint` clean, `make fmt` clean, gocyclo pre-commit hook clean
- [x] New unit tests: `TestLoadFrom_Plugins*` (4), `TestLoadCribRC_Plugins*` (5), `TestPreContainerRun_AgentForwarding_NotASocket` (1)
- [ ] Manual smoke on a real workspace: `crib up --disable-plugin ssh` registers no SSH mounts
- [ ] Manual smoke with `~/.config/crib/config.toml` `[plugins] disable_all = true` skips all plugins
- [ ] Manual smoke with `.cribrc` `plugins = false` skips all plugins