### PR TITLE
fix: stop stripping terminal display preferences from container env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Terminal display preferences now propagate to containers. `LS_COLORS`,
+  `LSCOLORS`, `LESSCLOSE`, `LESSOPEN`, `COLORTERM`, `VTE_VERSION`,
+  `TERM_PROGRAM`, and `TERM_PROGRAM_VERSION` were incorrectly stripped
+  from probed container environment, causing tools like `ls --color`,
+  `bat`, `delta`, and `less` to render without the user's preferred
+  styling during `crib shell`/`crib exec`.
+
 ## [0.9.0] - 2026-04-28
 
 ### Added

--- a/internal/engine/env.go
+++ b/internal/engine/env.go
@@ -39,18 +39,6 @@ var probedEnvSkip = map[string]bool{
 	"_":          true,
 	"MISE_SHELL": true,
 
-	// Terminal colors and pager helpers.
-	"LS_COLORS": true,
-	"LSCOLORS":  true,
-	"LESSCLOSE": true,
-	"LESSOPEN":  true,
-
-	// Terminal identity.
-	"TERM_PROGRAM":         true,
-	"TERM_PROGRAM_VERSION": true,
-	"COLORTERM":            true,
-	"VTE_VERSION":          true,
-
 	// X11/Wayland display.
 	"WINDOWID":        true,
 	"DISPLAY":         true,

--- a/internal/engine/env_test.go
+++ b/internal/engine/env_test.go
@@ -72,14 +72,6 @@ func TestFilterProbedEnv_SkipsNoisyHostVars(t *testing.T) {
 	probed := map[string]string{
 		"PATH":                     "/usr/bin",
 		"HOME":                     "/home/user",
-		"LS_COLORS":                "rs=0:di=01;34:...",
-		"LSCOLORS":                 "Gxfxcxdxbxegedabagacad",
-		"LESSCLOSE":                "/usr/bin/lesspipe %s %s",
-		"LESSOPEN":                 "| /usr/bin/lesspipe %s",
-		"TERM_PROGRAM":             "tmux",
-		"TERM_PROGRAM_VERSION":     "3.4",
-		"COLORTERM":                "truecolor",
-		"VTE_VERSION":              "7200",
 		"WINDOWID":                 "12345",
 		"DISPLAY":                  ":0",
 		"WAYLAND_DISPLAY":          "wayland-0",
@@ -95,8 +87,6 @@ func TestFilterProbedEnv_SkipsNoisyHostVars(t *testing.T) {
 	result := filterProbedEnv(probed)
 
 	noisyVars := []string{
-		"LS_COLORS", "LSCOLORS", "LESSCLOSE", "LESSOPEN",
-		"TERM_PROGRAM", "TERM_PROGRAM_VERSION", "COLORTERM", "VTE_VERSION",
 		"WINDOWID", "DISPLAY", "WAYLAND_DISPLAY",
 		"DESKTOP_SESSION", "SESSION_MANAGER",
 		"XDG_SESSION_TYPE", "XDG_SESSION_CLASS", "XDG_SESSION_ID",


### PR DESCRIPTION
Remove `LS_COLORS`, `LSCOLORS`, `LESSCLOSE`, `LESSOPEN`, `COLORTERM`, `VTE_VERSION`, `TERM_PROGRAM`, and `TERM_PROGRAM_VERSION` from the `probedEnvSkip` list in `internal/engine/env.go`.

These vars carry terminal display preferences (color schemes, truecolor detection, terminal identity) that should propagate into containers so tools like `ls --color`, `bat`, `delta`, and `less` render with the user's preferred styling during `crib shell`/`crib exec`.

They were incorrectly treated as session noise alongside `SHLVL` and `_`.